### PR TITLE
Initial working session creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ Note: this is an experimental work in progress and is not ready for use.
 
 ## Developers
 
+### Building Espresso Server
+
+```
+cd espresso-server
+./gradlew clean assembleDebug assembleAndroidTest
+```
+
 ### Layout
 
 * `espresso-server`: Java code that gets built into a test apk, which contains the WebDriver-based server to be run in the Espresso context.

--- a/espresso-server/AndroidManifest-test.xml
+++ b/espresso-server/AndroidManifest-test.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="io.appium.espressoserver.test" platformBuildVersionCode="25" platformBuildVersionName="7.1.1">
+    <instrumentation android:functionalTest="false" android:handleProfiling="false" android:label="Tests for io.appium.espressoserver" android:name="android.support.test.runner.AndroidJUnitRunner" android:targetPackage="io.appium.espressoserver"/>
+    <application>
+        <uses-library android:name="android.test.runner"/>
+    </application>
+</manifest>

--- a/espresso-server/app/build.gradle
+++ b/espresso-server/app/build.gradle
@@ -27,8 +27,9 @@ dependencies {
     compile 'com.android.support:appcompat-v7:25.0.0'
     testCompile 'junit:junit:4.12'
     compile 'com.android.support.constraint:constraint-layout:1.0.2'
-    compile 'org.nanohttpd:nanohttpd-webserver:2.3.1'
-    compile 'com.google.code.gson:gson:2.2.4'
+
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
     androidTestCompile 'com.android.support.test:runner:0.5'
+    androidTestCompile 'org.nanohttpd:nanohttpd-webserver:2.3.1'
+    androidTestCompile 'com.google.code.gson:gson:2.2.4'
 }

--- a/espresso-server/app/proguard-rules.pro
+++ b/espresso-server/app/proguard-rules.pro
@@ -1,6 +1,6 @@
 # Add project specific ProGuard rules here.
 # By default, the flags in this file are appended to flags specified
-# in /Users/danielgraham/Library/Android/sdk/tools/proguard/proguard-android.txt
+# in ~/Library/Android/sdk/tools/proguard/proguard-android.txt
 # You can edit the include path and order by changing the proguardFiles
 # directive in build.gradle.
 #

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/EspressoServerRunnerTest.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/EspressoServerRunnerTest.java
@@ -22,22 +22,6 @@ import io.appium.espressoserver.Http.Server;
 @RunWith(AndroidJUnit4.class)
 @LargeTest
 public class EspressoServerRunnerTest {
-
-    /**
-     * A JUnit {@link Rule @Rule} to launch your activity under test. This is a replacement
-     * for {@link ActivityInstrumentationTestCase2}.
-     * <p>
-     * Rules are interceptors which are executed for each test method and will run before
-     * any of your setup code in the {@link Before @Before} method.
-     * <p>
-     * {@link ActivityTestRule} will create and launch of the activity for you and also expose
-     * the activity under test. To get a reference to the activity you can use
-     * the {@link ActivityTestRule#getActivity()} method.
-     */
-    @Rule
-    public ActivityTestRule<MainActivity> mActivityRule = new ActivityTestRule<>(
-            MainActivity.class);
-
     @Test
     public void startEspressoServer() throws InterruptedException, IOException {
         new Server();

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/Http/AppiumResponse.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/Http/AppiumResponse.java
@@ -2,21 +2,36 @@ package io.appium.espressoserver.Http;
 
 public class AppiumResponse {
     private boolean success;
-    private String message;
+    private String value;
+    private int status;
 
-    public boolean isSuccess() {
+    public AppiumResponse (int status, boolean success, String value) {
+        this.status = status;
+        this.success = success;
+        this.value = value;
+    }
+
+    public boolean isSuccess () {
         return success;
     }
 
-    public void setSuccess(boolean success) {
+    public void setSuccess (boolean success) {
         this.success = success;
     }
 
-    public String getMessage() {
-        return message;
+    public void setStatus (int status) {
+      this.status = status;
     }
 
-    public void setMessage(String message) {
-        this.message = message;
+    public int getStatus () {
+      return this.status;
+    }
+
+    public String getValue () {
+        return value;
+    }
+
+    public void setValue (String value) {
+        this.value = value;
     }
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/Http/Server.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/Http/Server.java
@@ -13,7 +13,13 @@ import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
+import android.app.Instrumentation;
+import android.app.Instrumentation.ActivityMonitor;
+import android.content.Intent;
+import android.support.test.InstrumentationRegistry;
+
 public class Server extends NanoHTTPD {
+    private boolean opened = false;
 
     public Server() throws IOException {
         super(8080);
@@ -23,10 +29,21 @@ public class Server extends NanoHTTPD {
 
     @Override
     public Response serve(IHTTPSession session) {
-        AppiumResponse response = new AppiumResponse();
+        if (!opened) {
+            final String CLASS_NAME = "io.appium.android.apis.ApiDemos";
+
+            Instrumentation mInstrumentation = InstrumentationRegistry.getInstrumentation();
+            ActivityMonitor mSessionMonitor = mInstrumentation.addMonitor(CLASS_NAME, null, false);
+            Intent intent = new Intent(Intent.ACTION_MAIN);
+            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            intent.setClassName(mInstrumentation.getTargetContext(), CLASS_NAME);
+            mInstrumentation.startActivitySync(intent);
+
+            opened = true;
+        } 
+
+        AppiumResponse response = new AppiumResponse(0, true, "Hello world!");
         Gson gson = new Gson();
-        response.setSuccess(true);
-        response.setMessage("Hello World!");
         return newFixedLengthResponse(gson.toJson(response));
     }
 }

--- a/espresso-server/app/src/main/java/io/appium/espressoserver/MainActivity.java
+++ b/espresso-server/app/src/main/java/io/appium/espressoserver/MainActivity.java
@@ -7,8 +7,6 @@ import android.os.Bundle;
 
 import java.io.IOException;
 
-import fi.iki.elonen.NanoHTTPD;
-
 import static android.content.Context.WIFI_SERVICE;
 
 public class MainActivity extends AppCompatActivity {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -90,6 +90,8 @@ class EspressoDriver extends BaseDriver {
     this.jwpProxyActive = false;
     this.defaultIME = null;
     this.jwpProxyAvoid = NO_PROXY;
+
+    this.apkStrings = {}; // map of language -> strings obj
   }
 
   async createSession (caps) {
@@ -116,7 +118,8 @@ class EspressoDriver extends BaseDriver {
         fullReset: false,
         autoLaunch: true,
         adbPort: DEFAULT_ADB_PORT,
-        androidInstallTimeout: 90000
+        androidInstallTimeout: 90000,
+        systemPort: 8080,
       };
       _.defaults(this.opts, defaultOpts);
 
@@ -268,8 +271,8 @@ class EspressoDriver extends BaseDriver {
     // set the localized strings for the current language from the apk
     // TODO: incorporate changes from appium#5308 which fix a race cond-
     // ition bug in old appium and need to be replicated here
-    this.apkStrings[this.opts.language] = await androidHelpers.pushStrings(
-        this.opts.language, this.adb, this.opts);
+    // this.apkStrings[this.opts.language] = await androidHelpers.pushStrings(
+    //     this.opts.language, this.adb, this.opts);
 
     if (!this.opts.app) {
       if (this.opts.fullReset) {
@@ -381,15 +384,15 @@ class EspressoDriver extends BaseDriver {
 }
 
 // first add the android-driver commands which we will fall back to
-for (let [cmd, fn] of _.pairs(androidCommands)) {
+for (let [cmd, fn] of _.toPairs(androidCommands)) {
   // we do some different/special things with these methods
-  if (!_.contains(['defaultWebviewName'], cmd)) {
+  if (!_.includes(['defaultWebviewName'], cmd)) {
     EspressoDriver.prototype[cmd] = fn;
   }
 }
 
 // then overwrite with any espresso-specific commands
-for (let [cmd, fn] of _.pairs(commands)) {
+for (let [cmd, fn] of _.toPairs(commands)) {
   EspressoDriver.prototype[cmd] = fn;
 }
 

--- a/lib/espresso-runner.js
+++ b/lib/espresso-runner.js
@@ -7,15 +7,13 @@ import { fs } from 'appium-support';
 
 
 const TEST_APK_PATH = path.resolve(__dirname, '..', '..', 'espresso-server', 'app', 'build', 'outputs', 'apk', 'androidTest', 'debug', 'app-debug-androidTest.apk');
-const APP_APK_PATH = path.resolve(__dirname, '..', '..', 'espresso-server', 'app', 'build', 'outputs', 'apk', 'debug', 'app-debug.apk');
 const TEST_MANIFEST_PATH = path.resolve(__dirname, '..', '..', 'espresso-server', 'AndroidManifest-test.xml');
 const TEST_APK_PKG = "io.appium.espressoserver.test";
-const APP_APK_PKG = "io.appium.espressoserver";
-const REQD_PARAMS = ['adb', 'tmpDir', 'host', 'systemPort', 'devicePort', 'appPackage'];
+const REQUIRED_PARAMS = ['adb', 'tmpDir', 'host', 'systemPort', 'devicePort', 'appPackage'];
 
 class EspressoRunner {
   constructor (opts = {}) {
-    for (let req of REQD_PARAMS) {
+    for (let req of REQUIRED_PARAMS) {
       if (!opts || !opts[req]) {
         throw new Error(`Option '${req}' is required!`);
       }
@@ -29,18 +27,14 @@ class EspressoRunner {
 
   // TODO mostly duplicated from uiautomator2's installServerApk
   async installTestApk () {
-    for (let pkg of [TEST_APK_PKG, APP_APK_PKG]) {
-      if (await this.adb.isAppInstalled(pkg)) {
-        // for now, uninstall always
-        // TODO: figure out how to know if the server is able to instrument the AUT
-        await this.adb.uninstallApk(pkg);
-      }
+    if (await this.adb.isAppInstalled(TEST_APK_PKG)) {
+      // for now, uninstall always
+      // TODO: figure out how to know if the server is able to instrument the AUT
+      await this.adb.uninstallApk(TEST_APK_PKG);
     }
 
     let tmpTestApkPath = await this.buildNewModServer();
     await this.signAndInstall(this.modServerPath, TEST_APK_PKG);
-
-    await this.signAndInstall(APP_APK_PATH, APP_APK_PKG);
   }
 
   async buildNewModServer () {

--- a/lib/espresso-runner.js
+++ b/lib/espresso-runner.js
@@ -2,10 +2,16 @@ import { exec } from 'teen_process';
 import { JWProxy } from 'appium-base-driver';
 import { retryInterval } from 'asyncbox';
 import logger from './logger';
+import path from 'path';
+import { fs } from 'appium-support';
 
-const TEST_APK_PATH = ""; // TODO figure out where this will be built
+
+const TEST_APK_PATH = path.resolve(__dirname, '..', '..', 'espresso-server', 'app', 'build', 'outputs', 'apk', 'androidTest', 'debug', 'app-debug-androidTest.apk');
+const APP_APK_PATH = path.resolve(__dirname, '..', '..', 'espresso-server', 'app', 'build', 'outputs', 'apk', 'debug', 'app-debug.apk');
+const TEST_MANIFEST_PATH = path.resolve(__dirname, '..', '..', 'espresso-server', 'AndroidManifest-test.xml');
 const TEST_APK_PKG = "io.appium.espressoserver.test";
-const REQD_PARAMS = ['adb', 'tmpDir', 'host', 'systemPort', 'devicePort'];
+const APP_APK_PKG = "io.appium.espressoserver";
+const REQD_PARAMS = ['adb', 'tmpDir', 'host', 'systemPort', 'devicePort', 'appPackage'];
 
 class EspressoRunner {
   constructor (opts = {}) {
@@ -17,31 +23,56 @@ class EspressoRunner {
     }
     this.jwproxy = new JWProxy({host: this.host, port: this.systemPort});
     this.proxyReqRes = this.jwproxy.proxyReqRes.bind(this.jwproxy);
+
+    this.modServerPath = path.resolve(this.tmpDir, `${TEST_APK_PKG}.apk`);
   }
 
   // TODO mostly duplicated from uiautomator2's installServerApk
   async installTestApk () {
-    // Installs the apks on to the device or emulator
-    let isApkInstalled = await this.adb.isAppInstalled(TEST_APK_PKG);
-    if (isApkInstalled) {
-      //check server apk versionName
-      let apkVersion = await this.getAPKVersion(TEST_APK_PATH);
-      let pkgVersion = await this.getInstalledPackageVersion(TEST_APK_PKG);
-      if (apkVersion !== pkgVersion) {
-        isApkInstalled = false;
-        await this.adb.uninstallApk(TEST_APK_PKG);
+    for (let pkg of [TEST_APK_PKG, APP_APK_PKG]) {
+      if (await this.adb.isAppInstalled(pkg)) {
+        // for now, uninstall always
+        // TODO: figure out how to know if the server is able to instrument the AUT
+        await this.adb.uninstallApk(pkg);
       }
     }
-    if (!isApkInstalled) {
-      await this.signAndInstall(TEST_APK_PATH, TEST_APK_PKG);
+
+    let tmpTestApkPath = await this.buildNewModServer();
+    await this.signAndInstall(this.modServerPath, TEST_APK_PKG);
+
+    await this.signAndInstall(APP_APK_PATH, APP_APK_PKG);
+  }
+
+  async buildNewModServer () {
+    logger.info(`Repackaging espresso server for: '${this.appPackage}'`);
+    let packageTmpDir = path.resolve(this.tmpDir, this.appPackage);
+    let newManifestPath = path.resolve(this.tmpDir, 'AndroidManifest.xml');
+    logger.info(`Creating new manifest: '${newManifestPath}'`);
+    await fs.mkdir(packageTmpDir);
+    await fs.copyFile(TEST_MANIFEST_PATH, newManifestPath);
+    if (await fs.exists(this.modServerPath)) {
+      await fs.unlink(this.modServerPath);
     }
+    await this.adb.initAapt(); // TODO this should be internal to adb
+    await this.adb.compileManifest(newManifestPath, TEST_APK_PKG, this.appPackage); // creates a file `${newManifestPath}.apk`
+    await this.adb.insertManifest(newManifestPath, TEST_APK_PATH, this.modServerPath); // copies from second are to third and add manifest
+    logger.info(`Repackaged espresso server ready: '${this.modServerPath}'`);
   }
 
   // TODO duplicated from uiautomator2
   async signAndInstall (apk, apkPackage) {
     await this.checkAndSignCert(apk, apkPackage);
     await this.adb.install(apk);
-    logger.info("Installed Espresso Test Server apk");
+    logger.info(`Installed Espresso Test Server apk '${apk}' (pkg: '${apkPackage}')`);
+  }
+
+  // TODO duplicated from uiautomator2, should be a lib method
+  async checkAndSignCert (apk, apkPackage) {
+    let signed = await this.adb.checkApkCert(apk, apkPackage);
+    if (!signed) {
+      await this.adb.sign(apk);
+    }
+    return !signed;
   }
 
   // TODO duplicated from uiautomator2, should be a lib method
@@ -70,26 +101,16 @@ class EspressoRunner {
     return pkgVersion.toString();
   }
 
-  // TODO duplicated from uiautomator2, should be a lib method
-  async checkAndSignCert (apk, apkPackage) {
-    let signed = await this.adb.checkApkCert(apk, apkPackage);
-    if (!signed) {
-      await this.adb.sign(apk);
-    }
-    return !signed;
-  }
-
   async startSession (caps) {
-    let cmd = ['am', 'instrument', '-w', '-e', 'debug',
+    let cmd = ['am', 'instrument', '-w', '-e', 'debug', 'false',
       `${TEST_APK_PKG}/android.support.test.runner.AndroidJUnitRunner`];
 
-    logger.info(`Starting Espresso Server /*TODO VERSION*/ with cmd: ` +
-        `${cmd}`);
+    logger.info(`Starting Espresso Server /*TODO VERSION*/ with cmd: ${cmd.join(' ')}`);
 
     await this.adb.shell(cmd);
 
     logger.info('Waiting for Espresso to be online...');
-    // wait 20s for UiAutomator2 to be online
+    // wait 20s for espresso to be online
     await retryInterval(20, 1000, async () => {
       await this.jwproxy.command('/status', 'GET');
     });

--- a/test/functional/driver-e2e-specs.js
+++ b/test/functional/driver-e2e-specs.js
@@ -1,0 +1,42 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import _ from 'lodash';
+import ADB from 'appium-adb';
+import wd from 'wd';
+import sampleApps from 'sample-apps'
+import { startServer } from '../../..';
+
+
+chai.should();
+chai.use(chaiAsPromised);
+let expect = chai.expect;
+
+const HOST = '0.0.0.0',
+      PORT = 4994;
+const MOCHA_TIMEOUT = 60 * 1000 * (process.env.TRAVIS ? 8 : 4);
+
+let defaultCaps = {
+  androidInstallTimeout: 90000,
+  app: sampleApps('ApiDemos-debug'),
+  deviceName: 'Android',
+  platformName: 'Android',
+};
+
+describe('createSession', function () {
+  let driver;
+  let server;
+  before(async () => {
+    server = await startServer(PORT, HOST);
+    driver = wd.promiseChainRemote(HOST, PORT);
+  });
+  afterEach(async () => {
+    try {
+      await driver.quit();
+    } catch (ign) {}
+  });
+  it('should start android session focusing on default pkg and act', async () => {
+    let status = await driver.init(defaultCaps);
+
+    status[1].app.should.eql(defaultCaps.app);
+  });
+});


### PR DESCRIPTION
Wire in the espresso server and add the first functional test. Everything is hardcoded right now, but this gives a starting place to begin working on the espress-server handlers without needing to do a bunch of manual work.

Run a test like `gulp transpile && mocha -t 60000 build/test/functional/driver-e2e-specs.js`