### PR TITLE
Only rebuild server if necessary

### DIFF
--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -14,9 +14,12 @@ let espressoCapConstraints = {
   launchTimeout: {
     isNumber:true
   },
-  skipUnlock : {
-    isBoolean : true
-  }
+  skipUnlock: {
+    isBoolean: true
+  },
+  forceEspressoRebuild: {
+    isBoolean: true
+  },
 };
 
 let desiredCapConstraints = {};

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -262,6 +262,7 @@ class EspressoDriver extends BaseDriver {
       tmpDir: this.opts.tmpDir,
       appPackage: this.opts.appPackage,
       appActivity: this.opts.appActivity,
+      forceEspressoRebuild: !!this.opts.forceEspressoRebuild,
     });
     this.proxyReqRes = this.espresso.proxyReqRes.bind(this.espresso);
   }

--- a/lib/espresso-runner.js
+++ b/lib/espresso-runner.js
@@ -32,13 +32,10 @@ class EspressoRunner {
       await fs.unlink(this.modServerPath);
     }
 
-    let needsUninstall = false;
     if (!(await fs.exists(this.modServerPath))) {
       await this.buildNewModServer();
-      needsUninstall = true;
     }
-    needsUninstall = await this.checkAndSignCert(this.modServerPath) || needsUninstall;
-    if (needsUninstall) {
+    if (await this.checkAndSignCert(this.modServerPath)) {
       logger.info("New server was built, uninstalling any instances of it");
       await this.adb.uninstallApk(TEST_APK_PKG);
     }

--- a/lib/espresso-runner.js
+++ b/lib/espresso-runner.js
@@ -3,18 +3,19 @@ import { JWProxy } from 'appium-base-driver';
 import { retryInterval } from 'asyncbox';
 import logger from './logger';
 import path from 'path';
-import { fs } from 'appium-support';
+import { fs, util } from 'appium-support';
+import { version } from '../../package.json'; // eslint-disable-line import/no-unresolved
 
 
 const TEST_APK_PATH = path.resolve(__dirname, '..', '..', 'espresso-server', 'app', 'build', 'outputs', 'apk', 'androidTest', 'debug', 'app-debug-androidTest.apk');
 const TEST_MANIFEST_PATH = path.resolve(__dirname, '..', '..', 'espresso-server', 'AndroidManifest-test.xml');
 const TEST_APK_PKG = "io.appium.espressoserver.test";
-const REQUIRED_PARAMS = ['adb', 'tmpDir', 'host', 'systemPort', 'devicePort', 'appPackage'];
+const REQUIRED_PARAMS = ['adb', 'tmpDir', 'host', 'systemPort', 'devicePort', 'appPackage', 'forceEspressoRebuild'];
 
 class EspressoRunner {
   constructor (opts = {}) {
     for (let req of REQUIRED_PARAMS) {
-      if (!opts || !opts[req]) {
+      if (!opts || !util.hasValue(opts[req])) {
         throw new Error(`Option '${req}' is required!`);
       }
       this[req] = opts[req];
@@ -22,19 +23,27 @@ class EspressoRunner {
     this.jwproxy = new JWProxy({host: this.host, port: this.systemPort});
     this.proxyReqRes = this.jwproxy.proxyReqRes.bind(this.jwproxy);
 
-    this.modServerPath = path.resolve(this.tmpDir, `${TEST_APK_PKG}.apk`);
+    this.modServerPath = path.resolve(this.tmpDir, `${TEST_APK_PKG}_${version}_${this.appPackage}.apk`);
   }
 
-  // TODO mostly duplicated from uiautomator2's installServerApk
   async installTestApk () {
-    if (await this.adb.isAppInstalled(TEST_APK_PKG)) {
-      // for now, uninstall always
-      // TODO: figure out how to know if the server is able to instrument the AUT
-      await this.adb.uninstallApk(TEST_APK_PKG);
+    if (this.forceEspressoRebuild) {
+      logger.debug(`Capability 'forceEspressoRebuild' on. Deleting file '${this.modServerPath}'`);
+      await fs.unlink(this.modServerPath);
     }
 
-    let tmpTestApkPath = await this.buildNewModServer();
-    await this.signAndInstall(this.modServerPath, TEST_APK_PKG);
+    let needsUninstall = false;
+    if (!(await fs.exists(this.modServerPath))) {
+      await this.buildNewModServer();
+      needsUninstall = true;
+    }
+    needsUninstall = await this.checkAndSignCert(this.modServerPath) || needsUninstall;
+    if (needsUninstall) {
+      logger.info("New server was built, uninstalling any instances of it");
+      await this.adb.uninstallApk(TEST_APK_PKG);
+    }
+    await this.adb.install(this.modServerPath);
+    logger.info(`Installed Espresso Test Server apk '${this.modServerPath}' (pkg: '${TEST_APK_PKG}')`);
   }
 
   async buildNewModServer () {
@@ -44,20 +53,10 @@ class EspressoRunner {
     logger.info(`Creating new manifest: '${newManifestPath}'`);
     await fs.mkdir(packageTmpDir);
     await fs.copyFile(TEST_MANIFEST_PATH, newManifestPath);
-    if (await fs.exists(this.modServerPath)) {
-      await fs.unlink(this.modServerPath);
-    }
     await this.adb.initAapt(); // TODO this should be internal to adb
     await this.adb.compileManifest(newManifestPath, TEST_APK_PKG, this.appPackage); // creates a file `${newManifestPath}.apk`
     await this.adb.insertManifest(newManifestPath, TEST_APK_PATH, this.modServerPath); // copies from second are to third and add manifest
     logger.info(`Repackaged espresso server ready: '${this.modServerPath}'`);
-  }
-
-  // TODO duplicated from uiautomator2
-  async signAndInstall (apk, apkPackage) {
-    await this.checkAndSignCert(apk, apkPackage);
-    await this.adb.install(apk);
-    logger.info(`Installed Espresso Test Server apk '${apk}' (pkg: '${apkPackage}')`);
   }
 
   // TODO duplicated from uiautomator2, should be a lib method

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "eslint-plugin-mocha": "^4.9.0",
     "eslint-plugin-promise": "^3.5.0",
     "gulp": "^3.9.1",
+    "pre-commit": "^1.2.2",
     "sample-apps": "^2.0.4",
     "sinon": "^2.3.1",
     "wd": "^1.2.0"

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -1,0 +1,22 @@
+{
+  "laxcomma": true,
+  "undef": true,
+  "unused": true,
+  "trailing": true,
+  "node": true,
+  "eqeqeq": true,
+  "trailing": true,
+  "expr": true,
+  "white": true,
+  "indent": 2,
+  "esnext": true,
+  "experimental": ["asyncawait"],
+  "globals": {
+    "describe": true,
+    "it": true,
+    "before": true,
+    "after": true,
+    "beforeEach": true,
+    "afterEach": true
+  }
+}

--- a/test/functional/desired.js
+++ b/test/functional/desired.js
@@ -1,0 +1,18 @@
+import sampleApps from 'sample-apps';
+
+
+const GENERIC_CAPS = {
+  androidInstallTimeout: 90000,
+  deviceName: 'Android',
+  platformName: 'Android',
+  forceEspressoRebuild: true,
+};
+
+const APIDEMO_CAPS = Object.assign({},
+  GENERIC_CAPS,
+  {
+    app: sampleApps('ApiDemos-debug'),
+  }
+);
+
+export { GENERIC_CAPS, APIDEMO_CAPS };

--- a/test/functional/driver-e2e-specs.js
+++ b/test/functional/driver-e2e-specs.js
@@ -1,28 +1,25 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import _ from 'lodash';
-import ADB from 'appium-adb';
 import wd from 'wd';
-import sampleApps from 'sample-apps'
-import { startServer } from '../../..';
+import sampleApps from 'sample-apps';
+import { HOST, PORT, MOCHA_TIMEOUT } from './helpers/session';
+import { startServer } from '../..';
 
 
 chai.should();
 chai.use(chaiAsPromised);
-let expect = chai.expect;
-
-const HOST = '0.0.0.0',
-      PORT = 4994;
-const MOCHA_TIMEOUT = 60 * 1000 * (process.env.TRAVIS ? 8 : 4);
 
 let defaultCaps = {
   androidInstallTimeout: 90000,
   app: sampleApps('ApiDemos-debug'),
   deviceName: 'Android',
   platformName: 'Android',
+  forceEspressoRebuild: true,
 };
 
 describe('createSession', function () {
+  this.timeout(MOCHA_TIMEOUT);
+
   let driver;
   let server;
   before(async () => {
@@ -32,6 +29,9 @@ describe('createSession', function () {
   afterEach(async () => {
     try {
       await driver.quit();
+    } catch (ign) {}
+    try {
+      await server.close();
     } catch (ign) {}
   });
   it('should start android session focusing on default pkg and act', async () => {

--- a/test/functional/driver-e2e-specs.js
+++ b/test/functional/driver-e2e-specs.js
@@ -1,21 +1,13 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import wd from 'wd';
-import sampleApps from 'sample-apps';
 import { HOST, PORT, MOCHA_TIMEOUT } from './helpers/session';
+import { APIDEMO_CAPS } from './desired';
 import { startServer } from '../..';
 
 
 chai.should();
 chai.use(chaiAsPromised);
-
-let defaultCaps = {
-  androidInstallTimeout: 90000,
-  app: sampleApps('ApiDemos-debug'),
-  deviceName: 'Android',
-  platformName: 'Android',
-  forceEspressoRebuild: true,
-};
 
 describe('createSession', function () {
   this.timeout(MOCHA_TIMEOUT);
@@ -35,8 +27,8 @@ describe('createSession', function () {
     } catch (ign) {}
   });
   it('should start android session focusing on default pkg and act', async () => {
-    let status = await driver.init(defaultCaps);
+    let status = await driver.init(APIDEMO_CAPS);
 
-    status[1].app.should.eql(defaultCaps.app);
+    status[1].app.should.eql(APIDEMO_CAPS.app);
   });
 });

--- a/test/functional/helpers/session.js
+++ b/test/functional/helpers/session.js
@@ -1,0 +1,39 @@
+import wd from 'wd';
+import { startServer } from '../../..';
+
+
+const HOST = '0.0.0.0',
+      PORT = 4994;
+const MOCHA_TIMEOUT = 60 * 1000 * (process.env.TRAVIS ? 8 : 4);
+
+let driver, server;
+
+async function initDriver () {
+  driver = wd.promiseChainRemote(HOST, PORT);
+  server = await startServer(PORT, HOST);
+
+  return driver;
+}
+
+async function initSession (caps) {
+  await initDriver();
+  let serverRes = await driver.init(caps);
+  if (!caps.udid && !caps.fullReset && serverRes[1].udid) {
+    caps.udid = serverRes[1].udid;
+  }
+
+  // await driver.setImplicitWaitTimeout(5000);
+
+  return driver;
+}
+
+async function deleteSession () {
+  try {
+    await driver.quit();
+  } catch (ign) {}
+  try {
+    await server.close();
+  } catch (ign) {}
+}
+
+export { initDriver, initSession, deleteSession, HOST, PORT, MOCHA_TIMEOUT };


### PR DESCRIPTION
If we already have an espresso server apk with the correct version and instrumented for the correct package, we don't need to build it again.

But we want to be able to test changes we've made in development, so add the internal cap `forceEspressoRebuild` to allow us to blow away the one that is already there.

Also add the pre-commit hooks and fix some linting issues.