### PR TITLE
Fix base so we can proxy to the espresso server

### DIFF
--- a/lib/espresso-runner.js
+++ b/lib/espresso-runner.js
@@ -20,7 +20,7 @@ class EspressoRunner {
       }
       this[req] = opts[req];
     }
-    this.jwproxy = new JWProxy({host: this.host, port: this.systemPort});
+    this.jwproxy = new JWProxy({host: this.host, port: this.systemPort, base: ''});
     this.proxyReqRes = this.jwproxy.proxyReqRes.bind(this.jwproxy);
 
     this.modServerPath = path.resolve(this.tmpDir, `${TEST_APK_PKG}_${version}_${this.appPackage}.apk`);


### PR DESCRIPTION
Add base designation (set to empty string) so we don't have `/wd/hub` in proxying to espresso server on device.