### PR TITLE
Add very simple /status handler so driver can communicate

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/Handlers/Status.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/Handlers/Status.java
@@ -1,0 +1,17 @@
+package io.appium.espressoserver.lib.Handlers;
+
+import java.util.Map;
+
+import fi.iki.elonen.NanoHTTPD;
+
+import io.appium.espressoserver.lib.Http.Response.AppiumResponse;
+import io.appium.espressoserver.lib.Http.Response.BaseResponse;
+
+public class Status implements RequestHandler {
+
+    public BaseResponse handle(NanoHTTPD.IHTTPSession session, Map<String, String> uriParams) {
+        AppiumResponse appiumResponse = new AppiumResponse();
+        appiumResponse.setAppiumStatus(0);
+        return appiumResponse;
+    }
+}

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/Http/Router.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/Http/Router.java
@@ -11,6 +11,7 @@ import io.appium.espressoserver.lib.Handlers.Finder;
 import io.appium.espressoserver.lib.Handlers.RequestHandler;
 import io.appium.espressoserver.lib.Handlers.CreateSession;
 import io.appium.espressoserver.lib.Handlers.SendKeys;
+import io.appium.espressoserver.lib.Handlers.Status;
 import io.appium.espressoserver.lib.Http.Response.BaseResponse;
 import io.appium.espressoserver.lib.Http.Response.NotFoundResponse;
 import io.appium.espressoserver.lib.Http.Response.InternalErrorResponse;
@@ -24,6 +25,7 @@ public class Router {
         routerMap = new HashMap<Method, HashMap<String, RequestHandler>>();
 
         addRoute(Method.POST, "/session", new CreateSession());
+        addRoute(Method.GET, "/status", new Status());
         addRoute(Method.POST, "/sessions/:sessionId/elements", new Finder());
         addRoute(Method.POST, "/sessions/:sessionId/elements/:elementId/click", new Click());
         addRoute(Method.POST, "/sessions/:sessionId/elements/:elementId/value", new SendKeys());


### PR DESCRIPTION
In order to make sure the server is running we use the `/status` endpoint.