### PR TITLE
Remove 20s delay when creating instrumentation process

### DIFF
--- a/lib/espresso-runner.js
+++ b/lib/espresso-runner.js
@@ -1,4 +1,3 @@
-import { exec } from 'teen_process';
 import { JWProxy } from 'appium-base-driver';
 import { retryInterval } from 'asyncbox';
 import logger from './logger';
@@ -65,46 +64,30 @@ class EspressoRunner {
     return !signed;
   }
 
-  // TODO duplicated from uiautomator2, should be a lib method
-  async getAPKVersion (apk) {
-    let args = ['dump', 'badging', apk];
-    await this.adb.initAapt();
-    let {stdout} = await exec(this.adb.binaries.aapt, args);
-    let apkVersion = new RegExp(/versionName='([^']+)'/g).exec(stdout);
-    if (apkVersion && apkVersion.length >= 2) {
-      apkVersion = apkVersion[1];
-    } else {
-      apkVersion = null;
-    }
-    return apkVersion.toString();
-  }
-
-  // TODO duplicated from uiautomator2, should be a lib method
-  async getInstalledPackageVersion (pkg) {
-    let stdout =  await this.adb.shell(['dumpsys', 'package', pkg]);
-    let pkgVersion = new RegExp(/versionName=([^\s\s]+)/g).exec(stdout);
-    if (pkgVersion && pkgVersion.length >= 2) {
-      pkgVersion = pkgVersion[1];
-    } else {
-      pkgVersion = null;
-    }
-    return pkgVersion.toString();
-  }
-
   async startSession (caps) {
     let cmd = ['am', 'instrument', '-w', '-e', 'debug', 'false',
       `${TEST_APK_PKG}/android.support.test.runner.AndroidJUnitRunner`];
 
     logger.info(`Starting Espresso Server /*TODO VERSION*/ with cmd: ${cmd.join(' ')}`);
 
-    await this.adb.shell(cmd);
+    // start the instrumentation process, but do not wait for it
+    // otherwise it will block for longer than needed for the device to be ready
+    let err;
+    this.adb.shell(cmd).catch((e) => { // eslint-disable-line
+      // handle asynchronous errors that no longer get thrown
+      err = e;
+    });
 
     logger.info('Waiting for Espresso to be online...');
+
     // wait 20s for espresso to be online
     await retryInterval(20, 1000, async () => {
+      if (err) return; // eslint-disable-line curly
       await this.jwproxy.command('/status', 'GET');
     });
+    if (err) throw err; // eslint-disable-line curly
     await this.jwproxy.command('/session', 'POST', {desiredCapabilities: caps});
+    if (err) throw err; // eslint-disable-line curly
   }
 
   async deleteSession () {
@@ -120,4 +103,5 @@ class EspressoRunner {
   }
 }
 
+export { EspressoRunner, REQUIRED_PARAMS };
 export default EspressoRunner;

--- a/test/unit/espresso-runner-specs.js
+++ b/test/unit/espresso-runner-specs.js
@@ -1,0 +1,50 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { withMocks } from 'appium-test-support';
+import ADB from 'appium-adb';
+import B from 'bluebird';
+import { EspressoRunner, REQUIRED_PARAMS } from '../../lib/espresso-runner';
+
+
+chai.should();
+chai.use(chaiAsPromised);
+const expect = chai.expect;
+
+describe('espresso-runner', function () {
+  let adb = new ADB();
+
+  function getOpts (params) {
+    let opts = {};
+    for (let j = 0; j < params.length; j++) {
+      opts[params[j]] = 'value';
+    }
+    return opts;
+  }
+  describe('constructor', function () {
+    function runConstructorTest (opts, missingParam) {
+      it(`should error out if missing '${missingParam}' parameter`, function () {
+        expect(() => {
+          new EspressoRunner(opts);
+        }).to.throw(`Option '${missingParam}' is required!`);
+      });
+    }
+    for (let i = 0; i < REQUIRED_PARAMS.length; i++) {
+      let params = REQUIRED_PARAMS.filter((el) => el !== REQUIRED_PARAMS[i]);
+      let opts = getOpts(params);
+      runConstructorTest(opts, REQUIRED_PARAMS[i]);
+    }
+  });
+  describe('startSession', withMocks({adb}, (mocks) => {
+    let opts = getOpts(REQUIRED_PARAMS);
+    opts.adb = adb;
+    it('should throw an error if running instrumentation process errors', async function () {
+      mocks.adb.expects('shell').withExactArgs(["am", "instrument", "-w", "-e", "debug", "false", "io.appium.espressoserver.test/android.support.test.runner.AndroidJUnitRunner"])
+        .returns(B.reject("Problem with instrumentation"));
+
+      let espressoRunner = new EspressoRunner(opts);
+      await espressoRunner.startSession({}).should.eventually.be.rejectedWith(/Problem with instrumentation/);
+
+      mocks.adb.verify();
+    });
+  }));
+});


### PR DESCRIPTION
Stop `await`ing the `exec` of the instrumentation process. This makes error handling a bit wonky, but has the advantage of stripping 20s off each session.