### PR TITLE
Move routing logic into separate classes

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/EspressoServerRunnerTest.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/EspressoServerRunnerTest.java
@@ -8,7 +8,6 @@ import org.junit.runner.RunWith;
 
 import java.io.IOException;
 
-import io.appium.espressoserver.lib.exceptions.DuplicateRouteException;
 import io.appium.espressoserver.lib.http.Server;
 
 /**
@@ -21,7 +20,7 @@ import io.appium.espressoserver.lib.http.Server;
 public class EspressoServerRunnerTest {
 
     @Test
-    public void startEspressoServer() throws InterruptedException, IOException, DuplicateRouteException {
+    public void startEspressoServer() throws InterruptedException, IOException {
         new Server();
         // TODO: Figure out how to keep Runner open forever
         Thread.sleep(3000000);

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/exceptions/DuplicateRouteException.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/exceptions/DuplicateRouteException.java
@@ -1,6 +1,0 @@
-package io.appium.espressoserver.lib.exceptions;
-
-public class DuplicateRouteException extends Throwable {
-    public DuplicateRouteException() {
-    }
-}

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/Click.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/Click.java
@@ -2,6 +2,8 @@ package io.appium.espressoserver.lib.handlers;
 
 import android.support.test.espresso.ViewInteraction;
 
+import javax.annotation.Nullable;
+
 import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
 import io.appium.espressoserver.lib.model.AppiumParams;
 import io.appium.espressoserver.lib.model.Element;
@@ -11,6 +13,7 @@ import static android.support.test.espresso.action.ViewActions.click;
 public class Click implements RequestHandler<AppiumParams, Void> {
 
     @Override
+    @Nullable
     public Void handle(AppiumParams params) throws AppiumException {
         ViewInteraction viewInteraction = Element.getById(params.getElementId());
         try {

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/DeleteSession.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/DeleteSession.java
@@ -1,11 +1,14 @@
 package io.appium.espressoserver.lib.handlers;
 
+import javax.annotation.Nullable;
+
 import io.appium.espressoserver.lib.model.AppiumParams;
 import io.appium.espressoserver.lib.model.Session;
 
 public class DeleteSession implements RequestHandler<AppiumParams, Void> {
 
     @Override
+    @Nullable
     public Void handle(AppiumParams params) {
         Session.deleteGlobalSession();
         return null;

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/ScrollTo.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/ScrollTo.java
@@ -3,6 +3,8 @@ package io.appium.espressoserver.lib.handlers;
 import android.support.test.espresso.NoMatchingViewException;
 import android.support.test.espresso.ViewInteraction;
 
+import javax.annotation.Nullable;
+
 import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
 import io.appium.espressoserver.lib.handlers.exceptions.NoSuchElementException;
 import io.appium.espressoserver.lib.model.ScrollToParams;
@@ -14,6 +16,7 @@ import static android.support.test.espresso.matcher.ViewMatchers.withText;
 public class ScrollTo implements RequestHandler<ScrollToParams, Void> {
 
     @Override
+    @Nullable
     public Void handle(ScrollToParams params) throws AppiumException {
 
         try {

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/SendKeys.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/SendKeys.java
@@ -3,6 +3,8 @@ package io.appium.espressoserver.lib.handlers;
 import android.support.test.espresso.PerformException;
 import android.support.test.espresso.ViewInteraction;
 
+import javax.annotation.Nullable;
+
 import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
 import io.appium.espressoserver.lib.model.Element;
 import io.appium.espressoserver.lib.model.TextParams;
@@ -13,6 +15,7 @@ import static android.support.test.espresso.action.ViewActions.typeText;
 public class SendKeys implements RequestHandler<TextParams, Void> {
 
     @Override
+    @Nullable
     public Void handle(TextParams params) throws AppiumException {
         String id = params.getElementId();
         ViewInteraction viewInteraction = Element.getById(id);

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/Status.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/Status.java
@@ -1,10 +1,13 @@
 package io.appium.espressoserver.lib.handlers;
 
+import javax.annotation.Nullable;
+
 import io.appium.espressoserver.lib.model.AppiumParams;
 
 public class Status implements RequestHandler<AppiumParams, Void> {
 
     @Override
+    @Nullable
     public Void handle(AppiumParams params) {
         return null;
     }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/RouteDefinition.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/RouteDefinition.java
@@ -15,7 +15,7 @@ class RouteDefinition {
     private final Class<? extends AppiumParams> paramClass;
     private final RequestHandler<? extends AppiumParams, ?> handler;
 
-    public RouteDefinition(Method method, String routeUri, RequestHandler<? extends AppiumParams, ?> handler, Class<? extends AppiumParams> paramClass) {
+    RouteDefinition(Method method, String routeUri, RequestHandler<? extends AppiumParams, ?> handler, Class<? extends AppiumParams> paramClass) {
         testRegex = buildTestRegex(routeUri);
         this.routeUri = routeUri;
         this.method = method;
@@ -23,11 +23,11 @@ class RouteDefinition {
         this.handler = handler;
     }
 
-    boolean isMatch (String uri) {
+    public boolean isMatch (String uri) {
         return uri.matches(testRegex);
     }
 
-    Map<String, String> getUriParams(String uri) {
+    public Map<String, String> getUriParams(String uri) {
         Map<String, String> uriParams = new HashMap<>();
         String[] uriTokens = uri.split("/");
 
@@ -42,19 +42,19 @@ class RouteDefinition {
         return uriParams;
     }
 
-    Class<? extends AppiumParams> getParamClass() {
+    public Class<? extends AppiumParams> getParamClass() {
         return paramClass;
     }
 
-    Method getMethod () {
+    public Method getMethod () {
         return method;
     }
 
-    RequestHandler<? extends AppiumParams, ?> getHandler() {
+    public RequestHandler<? extends AppiumParams, ?> getHandler() {
         return handler;
     }
 
-    String getRouteUri () {
+    public String getRouteUri () {
         return routeUri;
     }
 
@@ -62,15 +62,13 @@ class RouteDefinition {
         StringBuilder testRegex = new StringBuilder("^");
 
         // Convert route to a regex
-        int index = 0;
         for (String uriToken : uri.split("/")) {
             if (uriToken.startsWith(":")) {
                 testRegex.append("/[\\w\\W]*");
-            } else if (!"".equals(uriToken)) {
+            } else if (!uriToken.isEmpty()) {
                 testRegex.append("/");
                 testRegex.append(uriToken);
             }
-            index++;
         }
         testRegex.append("$");
         return testRegex.toString();

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/RouteDefinition.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/RouteDefinition.java
@@ -1,0 +1,78 @@
+package io.appium.espressoserver.lib.http;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import fi.iki.elonen.NanoHTTPD.Method;
+import io.appium.espressoserver.lib.handlers.RequestHandler;
+import io.appium.espressoserver.lib.model.AppiumParams;
+
+class RouteDefinition {
+
+    private final String testRegex;
+    private final String routeUri;
+    private final Method method;
+    private final Class<? extends AppiumParams> paramClass;
+    private final RequestHandler<? extends AppiumParams, ?> handler;
+
+    public RouteDefinition(Method method, String routeUri, RequestHandler<? extends AppiumParams, ?> handler, Class<? extends AppiumParams> paramClass) {
+        testRegex = buildTestRegex(routeUri);
+        this.routeUri = routeUri;
+        this.method = method;
+        this.paramClass = paramClass;
+        this.handler = handler;
+    }
+
+    boolean isMatch (String uri) {
+        return uri.matches(testRegex);
+    }
+
+    Map<String, String> getUriParams(String uri) {
+        Map<String, String> uriParams = new HashMap<>();
+        String[] uriTokens = uri.split("/");
+
+        int index = 0;
+        for (String routeUriToken : routeUri.split("/")) {
+            // If a token starts with ':', then what's after is an identifier
+            if (routeUriToken.startsWith(":")) {
+                uriParams.put(routeUriToken.substring(1), uriTokens[index]);
+            }
+            index++;
+        }
+        return uriParams;
+    }
+
+    Class<? extends AppiumParams> getParamClass() {
+        return paramClass;
+    }
+
+    Method getMethod () {
+        return method;
+    }
+
+    RequestHandler<? extends AppiumParams, ?> getHandler() {
+        return handler;
+    }
+
+    String getRouteUri () {
+        return routeUri;
+    }
+
+    private String buildTestRegex(String uri) {
+        StringBuilder testRegex = new StringBuilder("^");
+
+        // Convert route to a regex
+        int index = 0;
+        for (String uriToken : uri.split("/")) {
+            if (uriToken.startsWith(":")) {
+                testRegex.append("/[\\w\\W]*");
+            } else if (!"".equals(uriToken)) {
+                testRegex.append("/");
+                testRegex.append(uriToken);
+            }
+            index++;
+        }
+        testRegex.append("$");
+        return testRegex.toString();
+    }
+}

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/RouteDefinition.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/RouteDefinition.java
@@ -16,7 +16,7 @@ class RouteDefinition {
     private final RequestHandler<? extends AppiumParams, ?> handler;
 
     RouteDefinition(Method method, String routeUri, RequestHandler<? extends AppiumParams, ?> handler, Class<? extends AppiumParams> paramClass) {
-        testRegex = buildTestRegex(routeUri);
+        testRegex = RouteDefinition.buildTestRegex(routeUri);
         this.routeUri = routeUri;
         this.method = method;
         this.paramClass = paramClass;
@@ -58,7 +58,7 @@ class RouteDefinition {
         return routeUri;
     }
 
-    private String buildTestRegex(String uri) {
+    private static String buildTestRegex(String uri) {
         StringBuilder testRegex = new StringBuilder("^");
 
         // Convert route to a regex

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/RouteMap.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/RouteMap.java
@@ -1,7 +1,7 @@
 package io.appium.espressoserver.lib.http;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.annotation.Nullable;
 
@@ -10,11 +10,11 @@ import fi.iki.elonen.NanoHTTPD.Method;
 
 class RouteMap {
 
-    private final Map<Method, Map<String, RouteDefinition>> routeMap = new HashMap<>();
+    private final Map<Method, Map<String, RouteDefinition>> routeMap = new ConcurrentHashMap<>();
 
     void addRoute(RouteDefinition route) {
         if (!routeMap.containsKey(route.getMethod())) {
-            routeMap.put(route.getMethod(), new HashMap<String, RouteDefinition>());
+            routeMap.put(route.getMethod(), new ConcurrentHashMap<String, RouteDefinition>());
         }
         Map<String, RouteDefinition> methodMap = routeMap.get(route.getMethod());
         methodMap.put(route.getRouteUri(), route);

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/RouteMap.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/RouteMap.java
@@ -3,19 +3,16 @@ package io.appium.espressoserver.lib.http;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.annotation.Nullable;
+
 import fi.iki.elonen.NanoHTTPD.Method;
 
 
 class RouteMap {
 
-    private final Map<Method, Map<String, RouteDefinition>> routeMap;
+    private final Map<Method, Map<String, RouteDefinition>> routeMap = new HashMap<>();
 
-    RouteMap() {
-        routeMap = new HashMap<>();
-
-    }
-
-    public void addRoute(RouteDefinition route) {
+    void addRoute(RouteDefinition route) {
         if (!routeMap.containsKey(route.getMethod())) {
             routeMap.put(route.getMethod(), new HashMap<String, RouteDefinition>());
         }
@@ -23,6 +20,7 @@ class RouteMap {
         methodMap.put(route.getRouteUri(), route);
     }
 
+    @Nullable
     public RouteDefinition findMatchingRoute(String uri) {
         for (Map.Entry<Method, Map<String, RouteDefinition>> methodMap: routeMap.entrySet()) {
            for (Map.Entry<String, RouteDefinition> route: methodMap.getValue().entrySet()) {

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/RouteMap.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/RouteMap.java
@@ -1,0 +1,39 @@
+package io.appium.espressoserver.lib.http;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import fi.iki.elonen.NanoHTTPD.Method;
+
+
+class RouteMap {
+
+    private final Map<Method, Map<String, RouteDefinition>> routeMap;
+
+    RouteMap() {
+        routeMap = new HashMap<>();
+
+    }
+
+    public void addRoute(RouteDefinition route) {
+        if (!routeMap.containsKey(route.getMethod())) {
+            routeMap.put(route.getMethod(), new HashMap<String, RouteDefinition>());
+        }
+        Map<String, RouteDefinition> methodMap = routeMap.get(route.getMethod());
+        methodMap.put(route.getRouteUri(), route);
+    }
+
+    public RouteDefinition findMatchingRoute(String uri) {
+        for (Map.Entry<Method, Map<String, RouteDefinition>> methodMap: routeMap.entrySet()) {
+           for (Map.Entry<String, RouteDefinition> route: methodMap.getValue().entrySet()) {
+               RouteDefinition routeDefinition = route.getValue();
+               if (routeDefinition.isMatch(uri)) {
+                   return routeDefinition;
+               }
+           }
+        }
+
+        return null;
+    }
+
+}

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Server.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Server.java
@@ -6,7 +6,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 
 import fi.iki.elonen.NanoHTTPD;
-import io.appium.espressoserver.lib.exceptions.DuplicateRouteException;
 import io.appium.espressoserver.lib.http.response.BaseResponse;
 import io.appium.espressoserver.lib.http.response.ErrorResponse;
 import io.appium.espressoserver.lib.model.AppiumStatus;
@@ -16,7 +15,7 @@ public class Server extends NanoHTTPD {
 
     private Router router;
 
-    public Server() throws IOException, DuplicateRouteException {
+    public Server() throws IOException {
         super(8080);
         start(NanoHTTPD.SOCKET_READ_TIMEOUT, false);
         System.out.println("\nRunning! Point your browsers to http://localhost:8080/ \n");


### PR DESCRIPTION
* Codacy was complaining about the complexity of Router so figured I’d fix it up now
* Add RouteDefinition class which stores the routing uri, the test regex to match incoming routes against, the HTTP method, the parameter class and the handler
* RouteDefinition can check if an incoming URI is a match against it’s own testRegex, and can return URI Params of an incoming URI as a HashMap
* Uses HashMap instead of ConcurrentHashMap because the writing is all done at the beginning and the rest are just reads, therefore it is thread-safe
* Add RouteMap class which contains all of the route definitions in a Map that maps HTTP method to another Map that maps the URI to the RouteDefinition
* When an incoming URL comes into Router.java, it checks RouteMap for a matching RouteDefinition and if it finds one, calls it’s handler