### PR TITLE
Edit Session class

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/CreateSession.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/CreateSession.java
@@ -16,7 +16,7 @@ public class CreateSession implements RequestHandler<SessionParams, Session> {
 
     @Override
     public Session handle(SessionParams params) throws AppiumException {
-        Session appiumSession = new Session();
+        Session appiumSession = Session.createGlobalSession();
         String activityName = params.getDesiredCapabilities().getAppActivity();
         try {
             if (activityName != null) { // TODO: Remove this,  using it now for testing purposes

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/Session.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/Session.java
@@ -8,7 +8,7 @@ import io.appium.espressoserver.lib.handlers.exceptions.SessionNotCreatedExcepti
 @SuppressWarnings("unused")
 public class Session {
     // Only one session can run at a time so globally cache the current Session ID
-    private static String ID;
+    private static volatile String ID;
 
     private final String id;
 
@@ -38,7 +38,7 @@ public class Session {
         return new Session(Session.ID);
     }
 
-    public synchronized static void deleteGlobalSession() {
+    public static void deleteGlobalSession() {
         Session.ID = null;
     }
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/Session.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/Session.java
@@ -30,7 +30,7 @@ public class Session {
      * @return Serializable Session object
      * @throws SessionNotCreatedException Thrown if a Session is already running
      */
-    public static Session createGlobalSession() throws SessionNotCreatedException {
+    public synchronized static Session createGlobalSession() throws SessionNotCreatedException {
         if (Session.ID != null) {
             throw new SessionNotCreatedException(String.format("Session %s is already in progress. Appium Espresso Server can only handle one session at a time.", Session.ID));
         }
@@ -38,7 +38,7 @@ public class Session {
         return new Session(Session.ID);
     }
 
-    public static void deleteGlobalSession() {
+    public synchronized static void deleteGlobalSession() {
         Session.ID = null;
     }
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/Session.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/Session.java
@@ -2,29 +2,40 @@ package io.appium.espressoserver.lib.model;
 
 import java.util.UUID;
 
+import io.appium.espressoserver.lib.handlers.exceptions.SessionNotCreatedException;
+
 
 @SuppressWarnings("unused")
 public class Session {
-    private final String id;
-
     // Only one session can run at a time so globally cache the current Session ID
     private static String ID;
 
-    public Session() {
-        if (Session.ID != null) {
-            this.id = Session.ID;
-        } else {
-            this.id = UUID.randomUUID().toString();
-            Session.ID = this.id;
-        }
+    private final String id;
+
+    private Session(String id) {
+        // Instances of Session are private and only returned by 'createGlobalSession'
+        this.id = id;
     }
 
-    public String getId () {
+    public String getId() {
         return id;
     }
 
     public static String getGlobalSessionId() {
         return Session.ID;
+    }
+
+    /**
+     * Create a global session. Only one session can run per server instance so throw an exception if one already is in progress
+     * @return Serializable Session object
+     * @throws SessionNotCreatedException Thrown if a Session is already running
+     */
+    public static Session createGlobalSession() throws SessionNotCreatedException {
+        if (Session.ID != null) {
+            throw new SessionNotCreatedException(String.format("Session %s is already in progress. Appium Espresso Server can only handle one session at a time.", Session.ID));
+        }
+        Session.ID = UUID.randomUUID().toString();
+        return new Session(Session.ID);
     }
 
     public static void deleteGlobalSession() {


### PR DESCRIPTION
* Made it so that you can’t instantiate Session, you can only call `createGlobalSession`, `deleteGlobalSession` and `getGlobalSessionID` from static context
* `createGlobalSession` returns an instance of Session with just an `id` field. This object is needed for GSON serialization.
* If `createGlobalSession` is called while a session is in progress, throws an exception. We can only run one at a time.
* This fixes a Codacy complaint of static variable being accessed inside of a constructor. 