### PR TITLE
Save desiredCapabilities with global session

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/CreateSession.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/CreateSession.java
@@ -16,7 +16,7 @@ public class CreateSession implements RequestHandler<SessionParams, Session> {
 
     @Override
     public Session handle(SessionParams params) throws AppiumException {
-        Session appiumSession = Session.createGlobalSession();
+        Session appiumSession = Session.createGlobalSession(params.getDesiredCapabilities());
         String activityName = params.getDesiredCapabilities().getAppActivity();
         try {
             if (activityName != null) { // TODO: Remove this,  using it now for testing purposes

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetSession.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetSession.java
@@ -1,0 +1,18 @@
+package io.appium.espressoserver.lib.handlers;
+
+import javax.annotation.Nullable;
+
+import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
+import io.appium.espressoserver.lib.model.AppiumParams;
+import io.appium.espressoserver.lib.model.Session;
+import io.appium.espressoserver.lib.model.SessionParams;
+
+public class GetSession implements RequestHandler<AppiumParams, SessionParams.DesiredCapabilities> {
+
+    @Override
+    @Nullable
+    public SessionParams.DesiredCapabilities handle(AppiumParams params) throws AppiumException {
+        return Session.getGlobalSession().getDesiredCapabilities();
+    }
+
+}

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetSessions.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetSessions.java
@@ -1,17 +1,26 @@
 package io.appium.espressoserver.lib.handlers;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
 import javax.annotation.Nullable;
 
 import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
 import io.appium.espressoserver.lib.model.AppiumParams;
 import io.appium.espressoserver.lib.model.Session;
 
-public class GetSessions implements RequestHandler<AppiumParams, String[]> {
+public class GetSessions implements RequestHandler<AppiumParams, Collection<String>> {
 
     @Override
     @Nullable
-    public String[] handle(AppiumParams params) throws AppiumException {
-        return new String[]{ Session.getGlobalSession().getId() };
+    public Collection<String> handle(AppiumParams params) throws AppiumException {
+        // Returns all of
+        List<String> list = new ArrayList<>();
+        if(Session.getGlobalSession() != null)
+            list.add(Session.getGlobalSession().getId());
+        return Collections.unmodifiableList(list);
     }
 
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetSessions.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetSessions.java
@@ -1,26 +1,24 @@
 package io.appium.espressoserver.lib.handlers;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.singletonList;
 
 import javax.annotation.Nullable;
 
 import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
 import io.appium.espressoserver.lib.model.AppiumParams;
-import io.appium.espressoserver.lib.model.Session;
+import static io.appium.espressoserver.lib.model.Session.getGlobalSession;
 
 public class GetSessions implements RequestHandler<AppiumParams, Collection<String>> {
 
     @Override
     @Nullable
     public Collection<String> handle(AppiumParams params) throws AppiumException {
-        // Returns all of
-        List<String> list = new ArrayList<>();
-        if(Session.getGlobalSession() != null)
-            list.add(Session.getGlobalSession().getId());
-        return Collections.unmodifiableList(list);
+        if(getGlobalSession() == null)
+            return unmodifiableList(Collections.<String>emptyList());
+        return unmodifiableList(singletonList(getGlobalSession().getId()));
     }
 
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetSessions.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetSessions.java
@@ -1,0 +1,17 @@
+package io.appium.espressoserver.lib.handlers;
+
+import javax.annotation.Nullable;
+
+import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
+import io.appium.espressoserver.lib.model.AppiumParams;
+import io.appium.espressoserver.lib.model.Session;
+
+public class GetSessions implements RequestHandler<AppiumParams, String[]> {
+
+    @Override
+    @Nullable
+    public String[] handle(AppiumParams params) throws AppiumException {
+        return new String[]{ Session.getGlobalSession().getId() };
+    }
+
+}

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/RouteMap.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/RouteMap.java
@@ -21,13 +21,12 @@ class RouteMap {
     }
 
     @Nullable
-    public RouteDefinition findMatchingRoute(String uri) {
-        for (Map.Entry<Method, Map<String, RouteDefinition>> methodMap: routeMap.entrySet()) {
-           for (Map.Entry<String, RouteDefinition> route: methodMap.getValue().entrySet()) {
-               RouteDefinition routeDefinition = route.getValue();
-               if (routeDefinition.isMatch(uri)) {
-                   return routeDefinition;
-               }
+    public RouteDefinition findMatchingRoute(Method method, String uri) {
+        Map<String, RouteDefinition> methodMap = routeMap.get(method);
+        for (Map.Entry<String, RouteDefinition> route: methodMap.entrySet()) {
+           RouteDefinition routeDefinition = route.getValue();
+           if (routeDefinition.isMatch(uri)) {
+               return routeDefinition;
            }
         }
 

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/RouteMap.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/RouteMap.java
@@ -22,6 +22,9 @@ class RouteMap {
 
     @Nullable
     public RouteDefinition findMatchingRoute(Method method, String uri) {
+        if (!routeMap.containsKey(method)) {
+            return null;
+        }
         Map<String, RouteDefinition> methodMap = routeMap.get(method);
         for (Map.Entry<String, RouteDefinition> route: methodMap.entrySet()) {
            RouteDefinition routeDefinition = route.getValue();

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.java
@@ -12,6 +12,8 @@ import fi.iki.elonen.NanoHTTPD.Method;
 import fi.iki.elonen.NanoHTTPD.IHTTPSession;
 import io.appium.espressoserver.lib.handlers.Click;
 import io.appium.espressoserver.lib.handlers.CreateSession;
+import io.appium.espressoserver.lib.handlers.GetSession;
+import io.appium.espressoserver.lib.handlers.GetSessions;
 import io.appium.espressoserver.lib.handlers.exceptions.InvalidStrategyException;
 import io.appium.espressoserver.lib.handlers.exceptions.SessionNotCreatedException;
 import io.appium.espressoserver.lib.handlers.Finder;
@@ -41,9 +43,11 @@ class Router {
         routeMap = new RouteMap();
 
         // TODO: Map EVERY JSONWP route and have it throw not yet implemented if there's no handler
-        routeMap.addRoute(new RouteDefinition(Method.POST, "/session", new CreateSession(), SessionParams.class));
-        routeMap.addRoute(new RouteDefinition(Method.DELETE, "/session/:sessionId", new DeleteSession(), AppiumParams.class));
         routeMap.addRoute(new RouteDefinition(Method.GET, "/status", new Status(), AppiumParams.class));
+        routeMap.addRoute(new RouteDefinition(Method.POST, "/session", new CreateSession(), SessionParams.class));
+        routeMap.addRoute(new RouteDefinition(Method.GET, "/sessions", new GetSessions(), AppiumParams.class));
+        routeMap.addRoute(new RouteDefinition(Method.GET, "/session/:sessionId", new GetSession(), AppiumParams.class));
+        routeMap.addRoute(new RouteDefinition(Method.DELETE, "/session/:sessionId", new DeleteSession(), AppiumParams.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/element", new Finder(), Locator.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/element/:elementId/click", new Click(), AppiumParams.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/element/:elementId/value", new SendKeys(), TextParams.class));
@@ -55,7 +59,7 @@ class Router {
         Method method = session.getMethod();
 
         // Look for a route that matches this URL
-        RouteDefinition matchingRoute = routeMap.findMatchingRoute(uri);
+        RouteDefinition matchingRoute = routeMap.findMatchingRoute(method, uri);
 
         // If no route found, return a 404 Error Response
         if (matchingRoute == null) {
@@ -79,7 +83,7 @@ class Router {
         appiumParams.setElementId(uriParams.get("elementId"));
 
         // Validate the sessionId
-        if (appiumParams.getSessionId() != null && !appiumParams.getSessionId().equals(Session.getGlobalSessionId())) {
+        if (appiumParams.getSessionId() != null && !appiumParams.getSessionId().equals(Session.getGlobalSession().getId())) {
             return new AppiumResponse<>(AppiumStatus.UNKNOWN_ERROR, "Invalid session ID " + appiumParams.getSessionId());
         }
 

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/Session.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/Session.java
@@ -3,26 +3,33 @@ package io.appium.espressoserver.lib.model;
 import java.util.UUID;
 
 import io.appium.espressoserver.lib.handlers.exceptions.SessionNotCreatedException;
+import io.appium.espressoserver.lib.model.SessionParams.DesiredCapabilities;
 
 
 @SuppressWarnings("unused")
 public class Session {
     // Only one session can run at a time so globally cache the current Session ID
-    private static volatile String ID;
+    private static volatile Session globalSession;
 
     private final String id;
+    private final DesiredCapabilities desiredCapabilities;
 
-    private Session(String id) {
+    private Session(String id, DesiredCapabilities desiredCapabilities) {
         // Instances of Session are private and only returned by 'createGlobalSession'
         this.id = id;
+        this.desiredCapabilities = desiredCapabilities;
     }
 
     public String getId() {
         return id;
     }
 
-    public static String getGlobalSessionId() {
-        return Session.ID;
+    public DesiredCapabilities getDesiredCapabilities() {
+        return desiredCapabilities;
+    }
+
+    public static Session getGlobalSession() {
+        return globalSession;
     }
 
     /**
@@ -30,15 +37,16 @@ public class Session {
      * @return Serializable Session object
      * @throws SessionNotCreatedException Thrown if a Session is already running
      */
-    public synchronized static Session createGlobalSession() throws SessionNotCreatedException {
-        if (Session.ID != null) {
-            throw new SessionNotCreatedException(String.format("Session %s is already in progress. Appium Espresso Server can only handle one session at a time.", Session.ID));
+    public synchronized static Session createGlobalSession(DesiredCapabilities desiredCapabilities) throws SessionNotCreatedException {
+        if (globalSession != null) {
+            throw new SessionNotCreatedException(String.format("Session %s is already in progress. Appium Espresso Server can only handle one session at a time.", globalSession.getId()));
         }
-        Session.ID = UUID.randomUUID().toString();
-        return new Session(Session.ID);
+        String globalSessionId = UUID.randomUUID().toString();
+        Session.globalSession = new Session(globalSessionId, desiredCapabilities);
+        return Session.globalSession;
     }
 
     public static void deleteGlobalSession() {
-        Session.ID = null;
+        Session.globalSession = null;
     }
 }


### PR DESCRIPTION
* Instead of a static global session ID have a static instance of Session which contains the ID and the desiredCapabilities
* Refactored Session and other methods that use Session to use this new format
* Added routes GET /session/:sessionId and GET /sessions
* Fixed bug in RouteMap; wasn't narrowing down route matches by method