### PR TITLE
Override different serve definition in nanohttpd

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.java
@@ -124,10 +124,7 @@ class Router {
 
 
     @SuppressWarnings("unchecked")
-    public BaseResponse route(IHTTPSession session) {
-        String uri = session.getUri();
-        Method method = session.getMethod();
-
+    public BaseResponse route(String uri, Method method, Map<String, String> params,  Map<String, String> files) {
         // Look for a route that matches this URL
         RouteDefinition matchingRoute = routeMap.findMatchingRoute(method, uri);
 
@@ -141,15 +138,8 @@ class Router {
         Class<? extends AppiumParams> paramClass = matchingRoute.getParamClass();
         Map<String, String> uriParams = matchingRoute.getUriParams(uri);
 
-        // Parse the appium params
-        String postJson;
-        try {
-            postJson = parseBody(session);
-        } catch (IOException e) {
-            return new AppiumResponse<>(AppiumStatus.UNKNOWN_ERROR, e.getMessage());
-        } catch (NanoHTTPD.ResponseException e) {
-            return new AppiumResponse<>(AppiumStatus.UNKNOWN_ERROR, e.getMessage());
-        }
+        // Get the appium params
+        String postJson = files.get("postData");
 
         AppiumParams appiumParams;
         if (postJson == null) {
@@ -191,13 +181,5 @@ class Router {
         } catch (AppiumException e) {
             return new AppiumResponse<>(AppiumStatus.UNKNOWN_ERROR, e.getMessage());
         }
-    }
-
-    private static String parseBody (IHTTPSession session) throws IOException, NanoHTTPD.ResponseException {
-        String result;
-        Map<String, String> files = new HashMap<>();
-        session.parseBody(files);
-        result = files.get("postData");
-        return result;
     }
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Server.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Server.java
@@ -5,6 +5,7 @@ import com.google.gson.GsonBuilder;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import fi.iki.elonen.NanoHTTPD;
 import io.appium.espressoserver.lib.handlers.exceptions.DuplicateRouteException;
@@ -17,11 +18,12 @@ import javax.ws.rs.core.MediaType;
 public class Server extends NanoHTTPD {
 
     private Router router;
+    private static final int DEFAULT_PORT = 8080;
 
     public Server() throws IOException, DuplicateRouteException {
-        super(8080);
+        super(DEFAULT_PORT); // TODO: Get this from an environment variable
         start(NanoHTTPD.SOCKET_READ_TIMEOUT, false);
-        System.out.println("\nRunning! Point your browsers to http://localhost:8080/ \n");
+        System.out.println(String.format("\nRunning Appium Espresso Server at port %d \n", DEFAULT_PORT));
         router = new Router();
     }
 
@@ -34,11 +36,11 @@ public class Server extends NanoHTTPD {
     }
 
     @Override
-    public Response serve(IHTTPSession session) {
+    public Response serve(String uri, Method method, Map<String, String> headers, Map<String, String> parms, Map<String, String> files) {
         GsonBuilder gsonBuilder = new GsonBuilder().serializeNulls();
         BaseResponse response;
         try {
-            response = router.route(session);
+            response = router.route(uri, method, parms, files);
         } catch (RuntimeException e) {
             List<String> stackTrace = getStackTrace(e);
             response = new ErrorResponse(Response.Status.INTERNAL_ERROR, "Internal error has occurred", stackTrace);


### PR DESCRIPTION
* There appeared to be a race condition that was causing multiple routes to have the same POST body (Isaac had this problem during the hack week)
* This way appears to fix it and is cleaner too