### PR TITLE
Can match list of XPaths instead of just one

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/SourceDocument.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/SourceDocument.java
@@ -8,7 +8,9 @@ import org.w3c.dom.*;
 import org.w3c.dom.Element;
 
 import java.io.StringWriter;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.annotation.Nullable;
@@ -23,6 +25,7 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
@@ -122,16 +125,21 @@ public class SourceDocument {
         return stringWriter.toString();
     }
 
-    @Nullable
-    public static View findViewByXPath(String xpathSelector) throws XPathLookupException {
+    public static List<View> findViewsByXPath(String xpathSelector) throws XPathLookupException {
         try {
+            // Get the Nodes that match the provided xpath
             SourceDocument sourceDocument = new SourceDocument(true);
             XPath xpath = XPathFactory.newInstance().newXPath();
-            Element elementNode = (Element) xpath.evaluate(xpathSelector, sourceDocument.doc, XPathConstants.NODE);
-            if (elementNode == null) {
-                return null;
+            XPathExpression expr = xpath.compile(xpathSelector);
+            NodeList list= (NodeList) expr.evaluate(sourceDocument.doc, XPathConstants.NODESET);
+
+            // Get a list of elements that are associated with that node
+            List<View> views = new ArrayList<>();
+            for (int i=0; i<list.getLength(); i++) {
+                Element element = (Element) list.item(i);
+                views.add(sourceDocument.viewMap.get(element));
             }
-            return sourceDocument.viewMap.get(elementNode);
+            return views;
         } catch (ParserConfigurationException pe) {
             throw new XPathLookupException(xpathSelector, pe.getMessage());
         } catch (XPathExpressionException xe) {

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/SourceDocument.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/SourceDocument.java
@@ -41,6 +41,7 @@ public class SourceDocument {
     private final DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
     private final TransformerFactory transformerFactory = TransformerFactory.newInstance();
     private Transformer transformer;
+    private static XPath xpath = XPathFactory.newInstance().newXPath();
 
     public SourceDocument() throws ParserConfigurationException, TransformerException {
         init();
@@ -129,7 +130,6 @@ public class SourceDocument {
         try {
             // Get the Nodes that match the provided xpath
             SourceDocument sourceDocument = new SourceDocument(true);
-            XPath xpath = XPathFactory.newInstance().newXPath();
             XPathExpression expr = xpath.compile(xpathSelector);
             NodeList list= (NodeList) expr.evaluate(sourceDocument.doc, XPathConstants.NODESET);
 

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/SourceDocument.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/SourceDocument.java
@@ -75,9 +75,10 @@ public class SourceDocument {
 
     /**
      * Recursively visit all of the views and map them to XML elements
-     * @param doc XML Document
+     *
+     * @param doc           XML Document
      * @param parentElement Element that this new element will be appended to
-     * @param view Android View that will map to an Element
+     * @param view          Android View that will map to an Element
      */
     private void buildXML(Document doc, Element parentElement, View view) {
         Element element = doc.createElement(getSimpleClassName(view.getClass().getName()));
@@ -131,11 +132,11 @@ public class SourceDocument {
             // Get the Nodes that match the provided xpath
             SourceDocument sourceDocument = new SourceDocument(true);
             XPathExpression expr = xpath.compile(xpathSelector);
-            NodeList list= (NodeList) expr.evaluate(sourceDocument.doc, XPathConstants.NODESET);
+            NodeList list = (NodeList) expr.evaluate(sourceDocument.doc, XPathConstants.NODESET);
 
             // Get a list of elements that are associated with that node
             List<View> views = new ArrayList<>();
-            for (int i=0; i<list.getLength(); i++) {
+            for (int i = 0; i < list.getLength(); i++) {
                 Element element = (Element) list.item(i);
                 views.add(sourceDocument.viewMap.get(element));
             }
@@ -152,7 +153,7 @@ public class SourceDocument {
     // Original Google code here broke UTF characters
     private static String stripInvalidXMLChars(CharSequence charSequence) {
         final StringBuilder sb = new StringBuilder(charSequence.length());
-        for (int i=0; i<charSequence.length(); i++) {
+        for (int i = 0; i < charSequence.length(); i++) {
             char c = charSequence.charAt(i);
             if (XMLChar.isValid(c)) {
                 sb.append(c);

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/viewmatcher/WithXPath.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/viewmatcher/WithXPath.java
@@ -7,17 +7,31 @@ import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 
 
+import java.util.List;
+
 import io.appium.espressoserver.lib.handlers.exceptions.XPathLookupException;
 import io.appium.espressoserver.lib.model.SourceDocument;
 
 public class WithXPath {
-    public static Matcher<View> withXPath(final String xpath) throws XPathLookupException {
-        final View matchedXPathView = SourceDocument.findViewByXPath(xpath);
+    public static Matcher<View> withXPath(final String xpath, final Integer index) throws XPathLookupException {
+
+        // Get a list of the Views that match the provided xpath
+        final List<View> matchedXPathViews = SourceDocument.findViewsByXPath(xpath);
 
         return new TypeSafeMatcher<View>() {
             @Override
             protected boolean matchesSafely(View item) {
-                return item.equals(matchedXPathView);
+                try {
+                    if (index != null) {
+                        // If index is not null, match it with the xpath in the list at the provided index
+                        return matchedXPathViews.get(index).equals(item);
+                    } else {
+                        // If index is null, then we only check that the view is contained in the list of matched xpaths
+                        return matchedXPathViews.contains(item);
+                    }
+                } catch (NullPointerException npe) {
+                    return false;
+                }
             }
 
             @Override
@@ -25,5 +39,9 @@ public class WithXPath {
                 description.appendText(String.format("Looked for element with XPath %s", xpath));
             }
         };
+    }
+
+    public static Matcher<View> withXPath(final String xpath) throws XPathLookupException {
+        return withXPath(xpath, null);
     }
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/viewmatcher/WithXPath.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/viewmatcher/WithXPath.java
@@ -1,5 +1,6 @@
 package io.appium.espressoserver.lib.viewmatcher;
 
+import android.support.annotation.Nullable;
 import android.view.View;
 
 import org.hamcrest.Description;
@@ -13,7 +14,7 @@ import io.appium.espressoserver.lib.handlers.exceptions.XPathLookupException;
 import io.appium.espressoserver.lib.model.SourceDocument;
 
 public class WithXPath {
-    public static Matcher<View> withXPath(final String xpath, final Integer index) throws XPathLookupException {
+    public static Matcher<View> withXPath(final String xpath, @Nullable final Integer index) throws XPathLookupException {
 
         // Get a list of the Views that match the provided xpath
         final List<View> matchedXPathViews = SourceDocument.findViewsByXPath(xpath);
@@ -25,10 +26,10 @@ public class WithXPath {
                     if (index != null) {
                         // If index is not null, match it with the xpath in the list at the provided index
                         return matchedXPathViews.get(index).equals(item);
-                    } else {
-                        // If index is null, then we only check that the view is contained in the list of matched xpaths
-                        return matchedXPathViews.contains(item);
                     }
+
+                    // If index is null, then we only check that the view is contained in the list of matched xpaths
+                    return matchedXPathViews.contains(item);
                 } catch (NullPointerException npe) {
                     return false;
                 }


### PR DESCRIPTION
* Changed SourceDocument so that when it queries the XML it gets _all_ of the matching views
* Changed withXpath so that you can optionally provide and index to match just one of the views
* This is intended to be used in a future change where we can get a list of elements instead of just one