### PR TITLE
add gradle build files to gitignore, there's no need for this files(98% sure) 

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+./espresso-server/build/generated
+./espresso-server/build/intermediates
+./espresso-server/build/tmp
+./espresso-server/.gradle


### PR DESCRIPTION
and it's generating the module to be more than 100MB