### PR TITLE
Add handlers for dialogs/alerts

### DIFF
--- a/espresso-server/app/build.gradle
+++ b/espresso-server/app/build.gradle
@@ -2,10 +2,10 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '26.0.2'
+    buildToolsVersion '27.0.1'
     defaultConfig {
         applicationId "io.appium.espressoserver"
-        minSdkVersion 15
+        minSdkVersion 18
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -28,7 +28,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+    androidTestCompile('com.android.support.test.espresso:espresso-core:3.0.1', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
     compile 'com.android.support:appcompat-v7:25.4.0'
@@ -36,16 +36,20 @@ dependencies {
 
     testCompile 'junit:junit:4.12'
     testCompile 'com.android.support.test.espresso:espresso-core:3.0.1'
+    testCompile 'com.android.support.test.espresso:espresso-contrib:3.0.1'
     testCompile 'com.android.support.test:runner:1.0.1'
     testCompile 'org.nanohttpd:nanohttpd-webserver:2.3.1'
     testCompile 'com.google.code.gson:gson:2.8.2'
     testCompile 'javax.ws.rs:jsr311-api:1.1.1'
     testCompile 'xalan:xalan:2.7.2'
+    testCompile 'com.android.support.test.uiautomator:uiautomator-v18:2.1.3'
 
     androidTestCompile 'com.android.support.test.espresso:espresso-core:3.0.1'
+    androidTestCompile 'com.android.support.test.espresso:espresso-contrib:3.0.1'
     androidTestCompile 'com.android.support.test:runner:1.0.1'
     androidTestCompile 'org.nanohttpd:nanohttpd-webserver:2.3.1'
     androidTestCompile 'com.google.code.gson:gson:2.8.2'
     androidTestCompile 'javax.ws.rs:jsr311-api:1.1.1'
     androidTestCompile 'xalan:xalan:2.7.2'
+    androidTestCompile 'com.android.support.test.uiautomator:uiautomator-v18:2.1.3'
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/AcceptAlert.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/AcceptAlert.java
@@ -44,7 +44,7 @@ public class AcceptAlert implements RequestHandler<AppiumParams, Void> {
         if (dialogs.isEmpty()) {
             throw new AppiumException("No alerts can be detected on the screen");
         }
-        // TODO: Does the first button always the one we need to click in order to accept the alert?
+        // TODO: Is the first button always the one we need to click in order to accept the alert?
         final List<UiObject2> buttons = dialogs.get(0)
                 .findObjects(By.clazz(Button.class));
         if (buttons.isEmpty()) {

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/AcceptAlert.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/AcceptAlert.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.espressoserver.lib.handlers;
+
+import android.app.Dialog;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.uiautomator.By;
+import android.support.test.uiautomator.UiDevice;
+import android.support.test.uiautomator.UiObject2;
+import android.widget.Button;
+
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
+import io.appium.espressoserver.lib.helpers.Logger;
+import io.appium.espressoserver.lib.model.AppiumParams;
+
+public class AcceptAlert implements RequestHandler<AppiumParams, Void> {
+
+    @Override
+    @Nullable
+    public Void handle(AppiumParams params) throws AppiumException {
+        // We use UIA2 here, since Espresso is limited to application sandbox
+        // and cannot handle security alerts
+        final UiDevice mDevice = UiDevice
+                .getInstance(InstrumentationRegistry.getInstrumentation());
+        final List<UiObject2> dialogs = mDevice.findObjects(By.clazz(Dialog.class));
+        if (dialogs.isEmpty()) {
+            throw new AppiumException("No alerts can be detected on the screen");
+        }
+        // TODO: Does the first button always the one we need to click in order to accept the alert?
+        final List<UiObject2> buttons = dialogs.get(0)
+                .findObjects(By.clazz(Button.class));
+        if (buttons.isEmpty()) {
+            throw new AppiumException("No buttons can be detected on the alert");
+        }
+        Logger.info(String.format("Clicking dialog button '%s' in order to accept it",
+                buttons.get(0).getText()));
+        buttons.get(0).click();
+        return null;
+    }
+}

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/AlertText.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/AlertText.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.espressoserver.lib.handlers;
+
+import android.app.Dialog;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.uiautomator.By;
+import android.support.test.uiautomator.UiDevice;
+import android.support.test.uiautomator.UiObject2;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
+import io.appium.espressoserver.lib.model.AppiumParams;
+
+public class AlertText implements RequestHandler<AppiumParams, String> {
+
+    @Override
+    public String handle(AppiumParams params) throws AppiumException {
+        // We use UIA2 here, since Espresso is limited to application sandbox
+        // and cannot handle security alerts
+        final UiDevice mDevice = UiDevice
+                .getInstance(InstrumentationRegistry.getInstrumentation());
+        final List<UiObject2> dialogs = mDevice.findObjects(By.clazz(Dialog.class));
+        if (dialogs.isEmpty()) {
+            throw new AppiumException("No alerts can be detected on the screen");
+        }
+        final List<UiObject2> elementsWithText = dialogs.get(0)
+                .findObjects(By.text(Pattern.compile("\\S+")));
+        if (elementsWithText.isEmpty()) {
+            return "";
+        }
+        final StringBuilder result = new StringBuilder();
+        for (final UiObject2 element : elementsWithText) {
+            if (!element.getClassName().contains("Button")) {
+                result.append(element.getText());
+                result.append("\n");
+            }
+        }
+        return result.toString();
+    }
+}

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/DismissAlert.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/DismissAlert.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.espressoserver.lib.handlers;
+
+import android.app.Dialog;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.uiautomator.By;
+import android.support.test.uiautomator.UiDevice;
+import android.support.test.uiautomator.UiObject2;
+
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
+import io.appium.espressoserver.lib.helpers.Logger;
+import io.appium.espressoserver.lib.model.AppiumParams;
+
+public class DismissAlert implements RequestHandler<AppiumParams, Void> {
+
+    @Override
+    @Nullable
+    public Void handle(AppiumParams params) throws AppiumException {
+        // We use UIA2 here, since Espresso is limited to application sandbox
+        // and cannot handle security alerts
+        final UiDevice mDevice = UiDevice
+                .getInstance(InstrumentationRegistry.getInstrumentation());
+        final List<UiObject2> dialogs = mDevice.findObjects(By.clazz(Dialog.class));
+        if (dialogs.isEmpty()) {
+            throw new AppiumException("No alerts can be detected on the screen");
+        }
+        Logger.info("Pressing Back button in order to dismiss the alert");
+        mDevice.pressBack();
+        return null;
+    }
+}

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetAlertText.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetAlertText.java
@@ -22,13 +22,16 @@ import android.support.test.uiautomator.By;
 import android.support.test.uiautomator.UiDevice;
 import android.support.test.uiautomator.UiObject2;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
 
 import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
 import io.appium.espressoserver.lib.model.AppiumParams;
 
-public class AlertText implements RequestHandler<AppiumParams, String> {
+import static android.text.TextUtils.join;
+
+public class GetAlertText implements RequestHandler<AppiumParams, String> {
 
     @Override
     public String handle(AppiumParams params) throws AppiumException {
@@ -45,13 +48,12 @@ public class AlertText implements RequestHandler<AppiumParams, String> {
         if (elementsWithText.isEmpty()) {
             return "";
         }
-        final StringBuilder result = new StringBuilder();
+        final List<String> result = new ArrayList<>();
         for (final UiObject2 element : elementsWithText) {
             if (!element.getClassName().contains("Button")) {
-                result.append(element.getText());
-                result.append("\n");
+                result.add(element.getText());
             }
         }
-        return result.toString();
+        return join("\n", result);
     }
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.java
@@ -22,7 +22,10 @@ import java.util.Map;
 
 import fi.iki.elonen.NanoHTTPD;
 import fi.iki.elonen.NanoHTTPD.Method;
+import io.appium.espressoserver.lib.handlers.AcceptAlert;
+import io.appium.espressoserver.lib.handlers.AlertText;
 import io.appium.espressoserver.lib.handlers.Clear;
+import io.appium.espressoserver.lib.handlers.DismissAlert;
 import io.appium.espressoserver.lib.handlers.GetAttribute;
 import io.appium.espressoserver.lib.handlers.Back;
 import io.appium.espressoserver.lib.handlers.Click;
@@ -85,6 +88,9 @@ class Router {
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/actions", new W3CActions(), W3CActionsParams.class));
         routeMap.addRoute(new RouteDefinition(Method.DELETE, "/session/:sessionId", new DeleteSession(), AppiumParams.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/back", new Back(), AppiumParams.class));
+        routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/accept_alert", new AcceptAlert(), AppiumParams.class));
+        routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/dismiss_alert", new DismissAlert(), AppiumParams.class));
+        routeMap.addRoute(new RouteDefinition(Method.GET, "/session/:sessionId/alert_text", new AlertText(), AppiumParams.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/orientation", new SetOrientation(), OrientationParams.class));
         routeMap.addRoute(new RouteDefinition(Method.GET, "/session/:sessionId/orientation", new GetOrientation(), AppiumParams.class));
         routeMap.addRoute(new RouteDefinition(Method.GET, "/session/:sessionId/source", new Source(), AppiumParams.class));
@@ -146,11 +152,8 @@ class Router {
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/keys", new NotYetImplemented(), AppiumParams.class));
         routeMap.addRoute(new RouteDefinition(Method.GET, "/session/:sessionId/element/:elementId/equals/:otherId", new NotYetImplemented(), AppiumParams.class));
         routeMap.addRoute(new RouteDefinition(Method.GET, "/session/:sessionId/element/:elementId/css/:propertyName", new NotYetImplemented(), AppiumParams.class));
-        routeMap.addRoute(new RouteDefinition(Method.GET, "/session/:sessionId/alert_text", new NotYetImplemented(), AppiumParams.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/alert_text", new NotYetImplemented(), AppiumParams.class));
         routeMap.addRoute(new RouteDefinition(Method.GET, "/session/:sessionId/element/:elementId/attribute", new NotYetImplemented(), AppiumParams.class));
-        routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/accept_alert", new NotYetImplemented(), AppiumParams.class));
-        routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/dismiss_alert", new NotYetImplemented(), AppiumParams.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/click", new NotYetImplemented(), AppiumParams.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/touch/click", new NotYetImplemented(), AppiumParams.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/touch/down", new NotYetImplemented(), AppiumParams.class));

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import fi.iki.elonen.NanoHTTPD;
 import fi.iki.elonen.NanoHTTPD.Method;
 import io.appium.espressoserver.lib.handlers.AcceptAlert;
-import io.appium.espressoserver.lib.handlers.AlertText;
+import io.appium.espressoserver.lib.handlers.GetAlertText;
 import io.appium.espressoserver.lib.handlers.Clear;
 import io.appium.espressoserver.lib.handlers.DismissAlert;
 import io.appium.espressoserver.lib.handlers.GetAttribute;
@@ -90,7 +90,7 @@ class Router {
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/back", new Back(), AppiumParams.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/accept_alert", new AcceptAlert(), AppiumParams.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/dismiss_alert", new DismissAlert(), AppiumParams.class));
-        routeMap.addRoute(new RouteDefinition(Method.GET, "/session/:sessionId/alert_text", new AlertText(), AppiumParams.class));
+        routeMap.addRoute(new RouteDefinition(Method.GET, "/session/:sessionId/alert_text", new GetAlertText(), AppiumParams.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/orientation", new SetOrientation(), OrientationParams.class));
         routeMap.addRoute(new RouteDefinition(Method.GET, "/session/:sessionId/orientation", new GetOrientation(), AppiumParams.class));
         routeMap.addRoute(new RouteDefinition(Method.GET, "/session/:sessionId/source", new Source(), AppiumParams.class));

--- a/espresso-server/gradle/wrapper/gradle-wrapper.properties
+++ b/espresso-server/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Oct 04 11:37:07 CEST 2017
+#Tue Dec 26 17:14:13 CET 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-rc-3-all.zip


### PR DESCRIPTION
Espresso is unable to handle things outside the application sandbox, for example system notifications or security alerts. I've added basic UIA2 integration as described in http://qathread.blogspot.de/2015/05/espresso-uiautomator-perfect-tandem.html in order to improve the state of things.