### PR TITLE
Ignore more files for npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,6 @@
 ./espresso-server/build/intermediates
 ./espresso-server/build/tmp
 ./espresso-server/.gradle
+./espresso-server/app/build/generated
+./espresso-server/app/build/intermediates
+./espresso-server/app/build/tmp


### PR DESCRIPTION
The npm package is down significantly (from 111Mb to ~76) but can be reduced further.