### PR TITLE
Try to start the app with adb if `autoLaunch` is enabled

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -241,6 +241,18 @@ class EspressoDriver extends BaseDriver {
       // set up app under test
       // prepare our actual AUT, get it on the device, etc...
       await this.initAUT();
+      await this.adb.startApp({
+        pkg: this.opts.appPackage,
+        activity: this.opts.appActivity,
+        action: this.opts.intentAction,
+        category: this.opts.intentCategory,
+        flags: this.opts.intentFlags,
+        waitPkg: this.opts.appWaitPackage,
+        waitActivity: this.opts.appWaitActivity,
+        optionalIntentArguments: this.opts.optionalIntentArguments,
+        stopApp: !this.opts.dontStopAppOnReset,
+        retry: false
+      });
     }
     //Adding AUT package name in the capabilities if package name not exist in caps
     if (!this.caps.appPackage) {


### PR DESCRIPTION
Quite often instruments fail to launch app activity when startSession is called. I hope this  can help to resolve the problem. UIA2 has the same workaround