### PR TITLE
Add handler for `/session/:sessionId/element/active` endpoint

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/FindActive.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/FindActive.java
@@ -16,21 +16,22 @@
 
 package io.appium.espressoserver.lib.handlers;
 
+import android.support.test.espresso.ViewInteraction;
+
 import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
+import io.appium.espressoserver.lib.handlers.exceptions.NoSuchElementException;
 import io.appium.espressoserver.lib.model.AppiumParams;
 import io.appium.espressoserver.lib.model.Element;
-import io.appium.espressoserver.lib.model.Locator;
-import io.appium.espressoserver.lib.model.Strategy;
-import io.appium.espressoserver.lib.model.ViewAttributesEnum;
+
+import static io.appium.espressoserver.lib.helpers.ViewFinder.findActive;
 
 public class FindActive implements RequestHandler<AppiumParams, Element> {
-
     @Override
     public Element handle(AppiumParams params) throws AppiumException {
-        final Locator locator = new Locator();
-        locator.initUriMapping(params);
-        locator.setUsing(Strategy.XPATH);
-        locator.setValue(String.format("//*[@%s='true']", ViewAttributesEnum.FOCUSED.toString()));
-        return new Finder().handle(locator);
+        ViewInteraction matcher = findActive();
+        if (matcher == null) {
+            throw new NoSuchElementException("No elements are currently focused");
+        }
+        return new Element(matcher);
     }
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/FindActive.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/FindActive.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.espressoserver.lib.handlers;
+
+import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
+import io.appium.espressoserver.lib.model.AppiumParams;
+import io.appium.espressoserver.lib.model.Element;
+import io.appium.espressoserver.lib.model.Locator;
+import io.appium.espressoserver.lib.model.Strategy;
+import io.appium.espressoserver.lib.model.ViewAttributesEnum;
+
+public class FindActive implements RequestHandler<AppiumParams, Element> {
+
+    @Override
+    public Element handle(AppiumParams params) throws AppiumException {
+        final Locator locator = new Locator();
+        locator.initUriMapping(params);
+        locator.setUsing(Strategy.XPATH);
+        locator.setValue(String.format("//*[@%s='true']", ViewAttributesEnum.FOCUSED.toString()));
+        return new Finder().handle(locator);
+    }
+}

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/ViewFinder.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/ViewFinder.java
@@ -102,6 +102,33 @@ public class ViewFinder {
         return findAllBy(root, strategy, selector, false);
     }
 
+    /**
+     * Returns the currently focused element or null in case
+     * if there is nu such element
+     *
+     * @return element instance or null
+     */
+    @Nullable
+    public static ViewInteraction findActive() {
+        List<ViewInteraction> viewInteractions = getViewInteractions(null,
+                new TypeSafeMatcher<View>() {
+                    @Override
+                    protected boolean matchesSafely(View item) {
+                        return item.isFocused();
+                    }
+
+                    @Override
+                    public void describeTo(Description description) {
+                        description.appendText("is focused");
+                    }
+                },
+                true);
+        if (viewInteractions.isEmpty()) {
+            return null;
+        }
+        return viewInteractions.get(0);
+    }
+
     ///Find By different strategies
     private static List<ViewInteraction> findAllBy(@Nullable View root,
                                                    Strategy strategy, String selector, boolean findOne)

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/ViewFinder.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/ViewFinder.java
@@ -103,10 +103,10 @@ public class ViewFinder {
     }
 
     /**
-     * Returns the currently focused element or null in case
-     * if there is nu such element
+     * Returns the currently focused element or null if
+     * there is no such element
      *
-     * @return element instance or null
+     * @return focused element instance or null
      */
     @Nullable
     public static ViewInteraction findActive() {

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import fi.iki.elonen.NanoHTTPD;
 import fi.iki.elonen.NanoHTTPD.Method;
 import io.appium.espressoserver.lib.handlers.AcceptAlert;
+import io.appium.espressoserver.lib.handlers.FindActive;
 import io.appium.espressoserver.lib.handlers.GetAlertText;
 import io.appium.espressoserver.lib.handlers.Clear;
 import io.appium.espressoserver.lib.handlers.DismissAlert;
@@ -96,6 +97,8 @@ class Router {
         routeMap.addRoute(new RouteDefinition(Method.GET, "/session/:sessionId/source", new Source(), AppiumParams.class));
         routeMap.addRoute(new RouteDefinition(Method.GET, "/session/:sessionId/screenshot", new Screenshot(), AppiumParams.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/element", new Finder(), Locator.class));
+        routeMap.addRoute(new RouteDefinition(Method.GET, "/session/:sessionId/element/active", new FindActive(), AppiumParams.class));
+        routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/element/active", new FindActive(), AppiumParams.class));
         routeMap.addRoute(new RouteDefinition(Method.GET, "/session/:sessionId/element/:elementId/attribute/:name", new GetAttribute(), AppiumParams.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/element/:elementId/clear", new Clear(), AppiumParams.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/element/:elementId/click", new Click(), AppiumParams.class));
@@ -147,7 +150,6 @@ class Router {
         routeMap.addRoute(new RouteDefinition(Method.DELETE, "/session/:sessionId/cookie", new NotYetImplemented(), AppiumParams.class));
         routeMap.addRoute(new RouteDefinition(Method.DELETE, "/session/:sessionId/cookie/:name", new NotYetImplemented(), AppiumParams.class));
         routeMap.addRoute(new RouteDefinition(Method.GET, "/session/:sessionId/title", new NotYetImplemented(), AppiumParams.class));
-        routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/element/active", new NotYetImplemented(), AppiumParams.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/element/:elementId/submit", new NotYetImplemented(), AppiumParams.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/keys", new NotYetImplemented(), AppiumParams.class));
         routeMap.addRoute(new RouteDefinition(Method.GET, "/session/:sessionId/element/:elementId/equals/:otherId", new NotYetImplemented(), AppiumParams.class));

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/AppiumParams.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/AppiumParams.java
@@ -21,6 +21,8 @@ import java.util.Map;
 
 import javax.annotation.Nullable;
 
+import static android.support.test.espresso.core.internal.deps.guava.base.Preconditions.checkNotNull;
+
 @SuppressWarnings("unused")
 public class AppiumParams {
     private static final String SESSION_ID_PARAM_NAME = "sessionId";
@@ -44,6 +46,10 @@ public class AppiumParams {
     public void initUriMapping(Map<String, String> params) {
         uriParams.clear();
         uriParams.putAll(params);
+    }
+
+    public void initUriMapping(AppiumParams other) {
+        initUriMapping(checkNotNull(other).uriParams);
     }
 
     @Nullable

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/AppiumParams.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/AppiumParams.java
@@ -21,8 +21,6 @@ import java.util.Map;
 
 import javax.annotation.Nullable;
 
-import static android.support.test.espresso.core.internal.deps.guava.base.Preconditions.checkNotNull;
-
 @SuppressWarnings("unused")
 public class AppiumParams {
     private static final String SESSION_ID_PARAM_NAME = "sessionId";
@@ -46,10 +44,6 @@ public class AppiumParams {
     public void initUriMapping(Map<String, String> params) {
         uriParams.clear();
         uriParams.putAll(params);
-    }
-
-    public void initUriMapping(AppiumParams other) {
-        initUriMapping(checkNotNull(other).uriParams);
     }
 
     @Nullable


### PR DESCRIPTION
There are both W3C and non-W3C routes