### PR TITLE
Bump dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
   },
   "dependencies": {
     "appium-adb": "^6.0.1",
-    "appium-android-driver": "^1.40.0",
-    "appium-base-driver": "^2.8.1",
-    "appium-support": "^2.8.2",
+    "appium-android-driver": "^2.0.0",
+    "appium-base-driver": "^2.18.4",
+    "appium-support": "^2.12.0",
     "asyncbox": "^2.3.1",
     "babel-runtime": "=5.8.24",
     "bluebird": "^3.5.0",


### PR DESCRIPTION
We must use the latest appium-adb dependency which contains the recent fixes.