### PR TITLE
Cache elements by view instead of view interaction

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/Clear.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/Clear.java
@@ -33,7 +33,7 @@ public class Clear implements RequestHandler<AppiumParams, Void> {
     @Override
     @Nullable
     public Void handle(AppiumParams params) throws AppiumException {
-        ViewInteraction viewInteraction = Element.getById(params.getElementId());
+        ViewInteraction viewInteraction = Element.getViewInteractionById(params.getElementId());
         try {
             viewInteraction.perform(clearText());
         } catch (PerformException e) {

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/Click.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/Click.java
@@ -33,7 +33,7 @@ public class Click implements RequestHandler<AppiumParams, Void> {
     @Override
     @Nullable
     public Void handle(AppiumParams params) throws AppiumException {
-        ViewInteraction viewInteraction = Element.getById(params.getElementId());
+        ViewInteraction viewInteraction = Element.getViewInteractionById(params.getElementId());
         try {
             viewInteraction.perform(click());
         } catch (PerformException e) {

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/ElementScreenshot.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/ElementScreenshot.java
@@ -17,6 +17,7 @@
 package io.appium.espressoserver.lib.handlers;
 
 import android.support.test.espresso.ViewInteraction;
+import android.view.View;
 
 import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
 import io.appium.espressoserver.lib.helpers.ScreenshotsHelper;
@@ -28,7 +29,7 @@ public class ElementScreenshot implements RequestHandler<AppiumParams, String> {
 
     @Override
     public String handle(AppiumParams params) throws AppiumException {
-        final ViewInteraction viewInteraction = Element.getViewInteractionById(params.getElementId());
-        return new ScreenshotsHelper(new ViewFinder().getView(viewInteraction)).getScreenshot();
+        final View view = Element.getViewById(params.getElementId());
+        return new ScreenshotsHelper(view).getScreenshot();
     }
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/ElementScreenshot.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/ElementScreenshot.java
@@ -28,7 +28,7 @@ public class ElementScreenshot implements RequestHandler<AppiumParams, String> {
 
     @Override
     public String handle(AppiumParams params) throws AppiumException {
-        final ViewInteraction viewInteraction = Element.getById(params.getElementId());
+        final ViewInteraction viewInteraction = Element.getViewInteractionById(params.getElementId());
         return new ScreenshotsHelper(new ViewFinder().getView(viewInteraction)).getScreenshot();
     }
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/FindActive.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/FindActive.java
@@ -17,6 +17,7 @@
 package io.appium.espressoserver.lib.handlers;
 
 import android.support.test.espresso.ViewInteraction;
+import android.view.View;
 
 import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
 import io.appium.espressoserver.lib.handlers.exceptions.NoSuchElementException;
@@ -28,10 +29,10 @@ import static io.appium.espressoserver.lib.helpers.ViewFinder.findActive;
 public class FindActive implements RequestHandler<AppiumParams, Element> {
     @Override
     public Element handle(AppiumParams params) throws AppiumException {
-        ViewInteraction matcher = findActive();
-        if (matcher == null) {
+        View view = findActive();
+        if (view == null) {
             throw new NoSuchElementException("No elements are currently focused");
         }
-        return new Element(matcher);
+        return new Element(view);
     }
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/FindElement.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/FindElement.java
@@ -43,14 +43,14 @@ public class FindElement implements RequestHandler<Locator, Element> {
             throw new MissingCommandsException("No locator provided");
         }
         // Test the selector
-        ViewInteraction matcher = findBy(parentView, locator.getUsing(), locator.getValue());
-        if (matcher == null) {
+        View view = findBy(parentView, locator.getUsing(), locator.getValue());
+        if (view == null) {
             throw new NoSuchElementException(
                     String.format("Could not find element with strategy %s and selector %s",
                             locator.getUsing(), locator.getValue()));
         }
 
         // If we have a match, return success
-        return new Element(matcher);
+        return new Element(view);
     }
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/FindElement.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/FindElement.java
@@ -35,7 +35,7 @@ public class FindElement implements RequestHandler<Locator, Element> {
     public Element handle(Locator locator) throws AppiumException {
         View parentView = null;
         if (locator.getElementId() != null) {
-            parentView = new ViewFinder().getView(Element.getById(locator.getElementId()));
+            parentView = new ViewFinder().getView(Element.getViewInteractionById(locator.getElementId()));
         }
         if (locator.getUsing() == null) {
             throw new InvalidStrategyException("Locator strategy cannot be empty");

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/FindElements.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/FindElements.java
@@ -37,7 +37,7 @@ public class FindElements implements RequestHandler<Locator, List<Element>> {
     public List<Element> handle(Locator locator) throws AppiumException {
         View parentView = null;
         if (locator.getElementId() != null) {
-            parentView = new ViewFinder().getView(Element.getById(locator.getElementId()));
+            parentView = new ViewFinder().getView(Element.getViewInteractionById(locator.getElementId()));
         }
         if (locator.getUsing() == null) {
             throw new InvalidStrategyException("Locator strategy cannot be empty");

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/FindElements.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/FindElements.java
@@ -46,13 +46,13 @@ public class FindElements implements RequestHandler<Locator, List<Element>> {
         }
 
         // Get the viewInteractions
-        List<ViewInteraction> viewInteractions = findAllBy(parentView,
+        List<View> views = findAllBy(parentView,
                 locator.getUsing(), locator.getValue());
 
         // Turn it into a list of elements
         List<Element> elements = new ArrayList<>();
-        for (ViewInteraction viewInteraction : viewInteractions) {
-            elements.add(new Element(viewInteraction));
+        for (View view : views) {
+            elements.add(new Element(view));
         }
 
         // If we have a match, return success

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetAttribute.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetAttribute.java
@@ -41,7 +41,7 @@ public class GetAttribute implements RequestHandler<AppiumParams, String> {
                     String.format("Attribute name should be one of %s. '%s' is given instead",
                             supportedAttributeNames, attributeName));
         }
-        final ViewInteraction viewInteraction = Element.getById(params.getElementId());
+        final ViewInteraction viewInteraction = Element.getViewInteractionById(params.getElementId());
         if (dstAttribute == ViewAttributesEnum.TEXT) {
             return new ViewTextGetter().get(viewInteraction).toString();
         }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetAttribute.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetAttribute.java
@@ -1,6 +1,7 @@
 package io.appium.espressoserver.lib.handlers;
 
 import android.support.test.espresso.ViewInteraction;
+import android.view.View;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -42,10 +43,11 @@ public class GetAttribute implements RequestHandler<AppiumParams, String> {
                             supportedAttributeNames, attributeName));
         }
         final ViewInteraction viewInteraction = Element.getViewInteractionById(params.getElementId());
+        final View view = Element.getViewById(params.getElementId());
         if (dstAttribute == ViewAttributesEnum.TEXT) {
             return new ViewTextGetter().get(viewInteraction).toString();
         }
-        final ViewElement viewElement = new ViewElement(new ViewFinder().getView(viewInteraction));
+        final ViewElement viewElement = new ViewElement(view);
         switch (dstAttribute) {
             case CONTENT_DESC:
                 return viewElement.getContentDescription() == null ?

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetDisplayed.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetDisplayed.java
@@ -16,17 +16,11 @@
 
 package io.appium.espressoserver.lib.handlers;
 
-import android.support.test.espresso.NoMatchingViewException;
-import android.support.test.espresso.ViewInteraction;
-
 import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
 import io.appium.espressoserver.lib.handlers.exceptions.StaleElementException;
 
 import io.appium.espressoserver.lib.model.AppiumParams;
 import io.appium.espressoserver.lib.model.Element;
-
-import static android.support.test.espresso.assertion.ViewAssertions.matches;
-import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 
 public class GetDisplayed implements RequestHandler<AppiumParams, Boolean> {
 
@@ -34,7 +28,7 @@ public class GetDisplayed implements RequestHandler<AppiumParams, Boolean> {
     public Boolean handle(AppiumParams params) throws AppiumException {
         try {
             // either finish, throw StaleElementException, or throw NoSuchElementException
-            Element.getById(params.getElementId());
+            Element.getViewInteractionById(params.getElementId());
             return true;
         } catch (StaleElementException e) {
             // element exists but is not displayed

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetEnabled.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetEnabled.java
@@ -30,7 +30,7 @@ public class GetEnabled implements RequestHandler<AppiumParams, Boolean> {
 
     @Override
     public Boolean handle(AppiumParams params) throws AppiumException {
-        final ViewInteraction viewInteraction = Element.getById(params.getElementId());
+        final ViewInteraction viewInteraction = Element.getViewInteractionById(params.getElementId());
         try {
             viewInteraction.check(matches(isEnabled()));
             return true;

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetLocation.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetLocation.java
@@ -29,7 +29,7 @@ public class GetLocation implements RequestHandler<AppiumParams, Location> {
 
     @Override
     public Location handle(AppiumParams params) throws AppiumException {
-        final ViewInteraction viewInteraction = Element.getById(params.getElementId());
+        final ViewInteraction viewInteraction = Element.getViewInteractionById(params.getElementId());
         final ViewElement viewElement = new ViewElement(new ViewFinder().getView(viewInteraction));
         final Location result = new Location();
         result.setX(viewElement.getBounds().left);

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetLocation.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetLocation.java
@@ -17,6 +17,7 @@
 package io.appium.espressoserver.lib.handlers;
 
 import android.support.test.espresso.ViewInteraction;
+import android.view.View;
 
 import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
 import io.appium.espressoserver.lib.model.AppiumParams;
@@ -29,8 +30,8 @@ public class GetLocation implements RequestHandler<AppiumParams, Location> {
 
     @Override
     public Location handle(AppiumParams params) throws AppiumException {
-        final ViewInteraction viewInteraction = Element.getViewInteractionById(params.getElementId());
-        final ViewElement viewElement = new ViewElement(new ViewFinder().getView(viewInteraction));
+        final View view = Element.getViewById(params.getElementId());
+        final ViewElement viewElement = new ViewElement(view);
         final Location result = new Location();
         result.setX(viewElement.getBounds().left);
         result.setY(viewElement.getBounds().top);

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetLocationInView.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetLocationInView.java
@@ -29,7 +29,7 @@ public class GetLocationInView implements RequestHandler<AppiumParams, Location>
 
     @Override
     public Location handle(AppiumParams params) throws AppiumException {
-        final ViewInteraction viewInteraction = Element.getById(params.getElementId());
+        final ViewInteraction viewInteraction = Element.getViewInteractionById(params.getElementId());
         final ViewElement viewElement = new ViewElement(new ViewFinder().getView(viewInteraction));
         final Location result = new Location();
         result.setX(viewElement.getRelativeLeft());

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetLocationInView.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetLocationInView.java
@@ -17,6 +17,7 @@
 package io.appium.espressoserver.lib.handlers;
 
 import android.support.test.espresso.ViewInteraction;
+import android.view.View;
 
 import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
 import io.appium.espressoserver.lib.model.AppiumParams;
@@ -29,8 +30,8 @@ public class GetLocationInView implements RequestHandler<AppiumParams, Location>
 
     @Override
     public Location handle(AppiumParams params) throws AppiumException {
-        final ViewInteraction viewInteraction = Element.getViewInteractionById(params.getElementId());
-        final ViewElement viewElement = new ViewElement(new ViewFinder().getView(viewInteraction));
+        final View view = Element.getViewById(params.getElementId());
+        final ViewElement viewElement = new ViewElement(view);
         final Location result = new Location();
         result.setX(viewElement.getRelativeLeft());
         result.setY(viewElement.getRelativeTop());

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetName.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetName.java
@@ -17,6 +17,7 @@
 package io.appium.espressoserver.lib.handlers;
 
 import android.support.test.espresso.ViewInteraction;
+import android.view.View;
 
 import javax.annotation.Nullable;
 
@@ -31,8 +32,8 @@ public class GetName implements RequestHandler<AppiumParams, String> {
     @Override
     @Nullable
     public String handle(AppiumParams params) throws AppiumException {
-        final ViewInteraction viewInteraction = Element.getViewInteractionById(params.getElementId());
-        final ViewElement viewElement = new ViewElement(new ViewFinder().getView(viewInteraction));
+        final View view = Element.getViewById(params.getElementId());
+        final ViewElement viewElement = new ViewElement(view);
         return viewElement.getContentDescription() == null ?
                 null :
                 viewElement.getContentDescription().toString();

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetName.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetName.java
@@ -31,7 +31,7 @@ public class GetName implements RequestHandler<AppiumParams, String> {
     @Override
     @Nullable
     public String handle(AppiumParams params) throws AppiumException {
-        final ViewInteraction viewInteraction = Element.getById(params.getElementId());
+        final ViewInteraction viewInteraction = Element.getViewInteractionById(params.getElementId());
         final ViewElement viewElement = new ViewElement(new ViewFinder().getView(viewInteraction));
         return viewElement.getContentDescription() == null ?
                 null :

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetOrientation.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetOrientation.java
@@ -34,8 +34,7 @@ public class GetOrientation implements RequestHandler<AppiumParams, Integer> {
     @Override
     @Nullable
     public Integer handle(AppiumParams params) throws AppiumException {
-        final ViewInteraction viewInteraction = Element.getViewInteractionById(params.getElementId());
-        final View view = new ViewFinder().getView(viewInteraction);
+        final View view = Element.getViewById(params.getElementId());
         final Activity activity = new ViewElement(view).extractActivity();
         try {
             switch (activity.getRequestedOrientation()) {

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetOrientation.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetOrientation.java
@@ -34,7 +34,7 @@ public class GetOrientation implements RequestHandler<AppiumParams, Integer> {
     @Override
     @Nullable
     public Integer handle(AppiumParams params) throws AppiumException {
-        final ViewInteraction viewInteraction = Element.getById(params.getElementId());
+        final ViewInteraction viewInteraction = Element.getViewInteractionById(params.getElementId());
         final View view = new ViewFinder().getView(viewInteraction);
         final Activity activity = new ViewElement(view).extractActivity();
         try {

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetRect.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetRect.java
@@ -29,7 +29,7 @@ public class GetRect implements RequestHandler<AppiumParams, Rect> {
 
     @Override
     public Rect handle(AppiumParams params) throws AppiumException {
-        final ViewInteraction viewInteraction = Element.getById(params.getElementId());
+        final ViewInteraction viewInteraction = Element.getViewInteractionById(params.getElementId());
         final ViewElement viewElement = new ViewElement(new ViewFinder().getView(viewInteraction));
         final Rect result = new Rect();
         final android.graphics.Rect elementBounds = viewElement.getBounds();

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetRect.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetRect.java
@@ -17,6 +17,7 @@
 package io.appium.espressoserver.lib.handlers;
 
 import android.support.test.espresso.ViewInteraction;
+import android.view.View;
 
 import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
 import io.appium.espressoserver.lib.model.AppiumParams;
@@ -29,8 +30,8 @@ public class GetRect implements RequestHandler<AppiumParams, Rect> {
 
     @Override
     public Rect handle(AppiumParams params) throws AppiumException {
-        final ViewInteraction viewInteraction = Element.getViewInteractionById(params.getElementId());
-        final ViewElement viewElement = new ViewElement(new ViewFinder().getView(viewInteraction));
+        final View view = Element.getViewById(params.getElementId());
+        final ViewElement viewElement = new ViewElement(view);
         final Rect result = new Rect();
         final android.graphics.Rect elementBounds = viewElement.getBounds();
         result.setX(elementBounds.left);

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetSelected.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetSelected.java
@@ -30,7 +30,7 @@ public class GetSelected implements RequestHandler<AppiumParams, Boolean> {
 
     @Override
     public Boolean handle(AppiumParams params) throws AppiumException {
-        final ViewInteraction viewInteraction = Element.getById(params.getElementId());
+        final ViewInteraction viewInteraction = Element.getViewInteractionById(params.getElementId());
         try {
             viewInteraction.check(matches(isSelected()));
             return true;

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetSize.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetSize.java
@@ -17,6 +17,7 @@
 package io.appium.espressoserver.lib.handlers;
 
 import android.support.test.espresso.ViewInteraction;
+import android.view.View;
 
 import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
 import io.appium.espressoserver.lib.model.AppiumParams;
@@ -29,8 +30,8 @@ public class GetSize implements RequestHandler<AppiumParams, Size> {
 
     @Override
     public Size handle(AppiumParams params) throws AppiumException {
-        final ViewInteraction viewInteraction = Element.getViewInteractionById(params.getElementId());
-        final ViewElement viewElement = new ViewElement(new ViewFinder().getView(viewInteraction));
+        final View view = Element.getViewById(params.getElementId());
+        final ViewElement viewElement = new ViewElement(view);
         final Size result = new Size();
         result.setHeight(viewElement.getBounds().height());
         result.setWidth(viewElement.getBounds().width());

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetSize.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetSize.java
@@ -29,7 +29,7 @@ public class GetSize implements RequestHandler<AppiumParams, Size> {
 
     @Override
     public Size handle(AppiumParams params) throws AppiumException {
-        final ViewInteraction viewInteraction = Element.getById(params.getElementId());
+        final ViewInteraction viewInteraction = Element.getViewInteractionById(params.getElementId());
         final ViewElement viewElement = new ViewElement(new ViewFinder().getView(viewInteraction));
         final Size result = new Size();
         result.setHeight(viewElement.getBounds().height());

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/MoveTo.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/MoveTo.java
@@ -29,7 +29,7 @@ public class MoveTo implements RequestHandler<MoveToParams, Void> {
     @Override
     public Void handle(MoveToParams params) throws AppiumException {
         // Get a reference to the view and call onData. This will automatically scroll to the view.
-        ViewInteraction viewInteraction = Element.getById(params.getElementId());
+        ViewInteraction viewInteraction = Element.getViewInteractionById(params.getElementId());
 
         try {
             // Try performing espresso's scrollTo, which will only work if

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/SendKeys.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/SendKeys.java
@@ -36,7 +36,7 @@ public class SendKeys implements RequestHandler<TextParams, Void> {
     @Override
     public Void handle(TextParams params) throws AppiumException {
         String id = params.getElementId();
-        ViewInteraction viewInteraction = Element.getById(id);
+        ViewInteraction viewInteraction = Element.getViewInteractionById(id);
 
         // Convert the array of text to a String
         String[] textArray = params.getValue();

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/SendKeys.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/SendKeys.java
@@ -37,6 +37,7 @@ public class SendKeys implements RequestHandler<TextParams, Void> {
     public Void handle(TextParams params) throws AppiumException {
         String id = params.getElementId();
         ViewInteraction viewInteraction = Element.getViewInteractionById(id);
+        View view = Element.getViewById(id);
 
         // Convert the array of text to a String
         String[] textArray = params.getValue();
@@ -47,7 +48,6 @@ public class SendKeys implements RequestHandler<TextParams, Void> {
 
         String value = stringBuilder.toString();
 
-        final View view = new ViewFinder().getView(viewInteraction);
         try {
             if (view instanceof ProgressBar) {
                 ((ProgressBar) view).setProgress(Integer.parseInt(value));

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/SetOrientation.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/SetOrientation.java
@@ -32,7 +32,7 @@ public class SetOrientation implements RequestHandler<OrientationParams, Void> {
     @Override
     @Nullable
     public Void handle(OrientationParams params) throws AppiumException {
-        final ViewInteraction viewInteraction = Element.getById(params.getElementId());
+        final ViewInteraction viewInteraction = Element.getViewInteractionById(params.getElementId());
         final String orientation = params.getOrientation();
         if (orientation == null ||
                 !Arrays.asList(new String[] {"LANDSCAPE", "PORTRAIT"}).

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/Text.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/Text.java
@@ -30,7 +30,7 @@ public class Text implements RequestHandler<AppiumParams, CharSequence> {
     @Override
     @Nullable
     public CharSequence handle(AppiumParams params) throws AppiumException {
-        ViewInteraction viewInteraction = Element.getById(params.getElementId());
+        ViewInteraction viewInteraction = Element.getViewInteractionById(params.getElementId());
         return new ViewTextGetter().get(viewInteraction);
     }
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c_actions/ActionsHelpers.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c_actions/ActionsHelpers.java
@@ -26,6 +26,7 @@ import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.MotionEvent.PointerCoords;
 import android.view.MotionEvent.PointerProperties;
+import android.view.View;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -172,8 +173,8 @@ public class ActionsHelpers {
         final PointerCoords result = new PointerCoords();
         final Rect bounds;
         try {
-            final ViewInteraction viewInteraction = Element.getViewInteractionById(elementId);
-            final ViewElement viewElement = new ViewElement(new ViewFinder().getView(viewInteraction));
+            final View view = Element.getViewById(elementId);
+            final ViewElement viewElement = new ViewElement(view);
             bounds = viewElement.getBounds();
         } catch (Exception e) {
             throw new ActionsParseException(String.format(

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c_actions/ActionsHelpers.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c_actions/ActionsHelpers.java
@@ -172,7 +172,7 @@ public class ActionsHelpers {
         final PointerCoords result = new PointerCoords();
         final Rect bounds;
         try {
-            final ViewInteraction viewInteraction = Element.getById(elementId);
+            final ViewInteraction viewInteraction = Element.getViewInteractionById(elementId);
             final ViewElement viewElement = new ViewElement(new ViewFinder().getView(viewInteraction));
             bounds = viewElement.getBounds();
         } catch (Exception e) {

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/Element.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/Element.java
@@ -18,6 +18,7 @@ package io.appium.espressoserver.lib.model;
 
 import android.support.test.espresso.NoMatchingViewException;
 import android.support.test.espresso.ViewInteraction;
+import android.view.View;
 
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -25,31 +26,37 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 import io.appium.espressoserver.lib.handlers.exceptions.StaleElementException;
+import io.appium.espressoserver.lib.helpers.Logger;
+import io.appium.espressoserver.lib.viewaction.ViewFinder;
 
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.Espresso.onView;
+import static io.appium.espressoserver.lib.viewmatcher.WithView.withView;
 
 
 @SuppressWarnings("unused")
 public class Element {
     private final String ELEMENT;
-    private final static Map<String, ViewInteraction> cache = new ConcurrentHashMap<>();
+    private final static Map<String, View> cache = new ConcurrentHashMap<>();
 
     public Element (ViewInteraction interaction) {
         ELEMENT = UUID.randomUUID().toString();
-        cache.put(ELEMENT, interaction);
+        View view = (new ViewFinder()).getView(interaction);
+        cache.put(ELEMENT, view);
     }
 
     public String getElementId() {
         return ELEMENT;
     }
 
-    public static ViewInteraction getById(String elementId) throws NoSuchElementException, StaleElementException {
+    public static ViewInteraction getViewInteractionById(String elementId) throws NoSuchElementException, StaleElementException {
+        Logger.info(String.format("Retrieving element %s", elementId));
         if (!exists(elementId)) {
             throw new NoSuchElementException(String.format("Invalid element ID %s", elementId));
         }
-
-        ViewInteraction viewInteraction = cache.get(elementId);
+        View view = cache.get(elementId);
+        ViewInteraction viewInteraction = onView(withView(view));
 
         // Check if the element is stale
         try {

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/viewmatcher/WithView.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/viewmatcher/WithView.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.espressoserver.lib.viewmatcher;
+
+import android.support.annotation.Nullable;
+import android.view.View;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+
+import java.util.List;
+
+import io.appium.espressoserver.lib.handlers.exceptions.XPathLookupException;
+import io.appium.espressoserver.lib.model.SourceDocument;
+
+public class WithView {
+    public static Matcher<View> withView(final View view) {
+
+        return new TypeSafeMatcher<View>() {
+            @Override
+            protected boolean matchesSafely(View item) {
+                return item.equals(view);
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText(String.format("Looked for element with View %s", view.toString()));
+            }
+        };
+    }
+}

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "e2e-test": "gulp e2e-test",
     "watch": "gulp watch",
     "coverage": "gulp coveralls",
+    "prepublish": "npm run build:server",
     "precommit-msg": "echo 'Pre-commit checks...' && exit 0",
     "precommit-test": "REPORTER=dot gulp once",
     "lint": "gulp eslint",

--- a/test/functional/commands/find-e2e-specs.js
+++ b/test/functional/commands/find-e2e-specs.js
@@ -52,4 +52,9 @@ describe('elementByXPath', function () {
     await el.click();
     await el.click().should.eventually.be.rejectedWith(/no longer attached /);
   });
+  it('should get the isDisplayed attribute on the same element twice', async function () {
+    let el = await driver.elementByXPath("//*[@content-desc='Animation']");
+    await el.isDisplayed().should.eventually.be.true;
+    await el.isDisplayed().should.eventually.be.true;
+  });
 });


### PR DESCRIPTION
* Updated the element finding logic so that instead of getting View Interactions it gets the actual Views
* Updated the Element.java class to cache the actual views
* The reasoning for this is that it appears that viewInteractions become stale after using them once, so you can't operate on an "Element" more than once
* @jlipps I think  this may solve your issue with finding elements too