### PR TITLE
startActivity

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/CreateSession.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/CreateSession.java
@@ -18,16 +18,12 @@ package io.appium.espressoserver.lib.handlers;
 
 import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
 import io.appium.espressoserver.lib.handlers.exceptions.SessionNotCreatedException;
-import io.appium.espressoserver.lib.helpers.Logger;
 import io.appium.espressoserver.lib.model.Session;
 
 import io.appium.espressoserver.lib.model.SessionParams;
 
-import android.app.Activity;
-import android.app.Instrumentation;
-import android.app.Instrumentation.ActivityMonitor;
-import android.content.Intent;
-import android.support.test.InstrumentationRegistry;
+import static io.appium.espressoserver.lib.handlers.StartActivity.startActivity;
+
 
 public class CreateSession implements RequestHandler<SessionParams, Session> {
 
@@ -36,8 +32,8 @@ public class CreateSession implements RequestHandler<SessionParams, Session> {
         Session appiumSession = Session.createGlobalSession(params.getDesiredCapabilities());
         String activityName = params.getDesiredCapabilities().getAppActivity();
         try {
-            if (activityName != null) { // TODO: Remove this, using it now for testing purposes
-                StartActivity.startActivity(activityName, true);
+            if (activityName != null) {
+                startActivity(activityName, true);
             }
         } catch (RuntimeException e) {
             throw new SessionNotCreatedException(e.getCause().toString());

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/CreateSession.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/CreateSession.java
@@ -40,7 +40,7 @@ public class CreateSession implements RequestHandler<SessionParams, Session> {
                 startActivity(activityName);
             }
         } catch (RuntimeException e) {
-            throw new SessionNotCreatedException(e.getMessage());
+            throw new SessionNotCreatedException(e.getCause().toString());
         }
         return appiumSession;
     }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/CreateSession.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/CreateSession.java
@@ -37,24 +37,11 @@ public class CreateSession implements RequestHandler<SessionParams, Session> {
         String activityName = params.getDesiredCapabilities().getAppActivity();
         try {
             if (activityName != null) { // TODO: Remove this, using it now for testing purposes
-                startActivity(activityName);
+                StartActivity.startActivity(activityName, true);
             }
         } catch (RuntimeException e) {
             throw new SessionNotCreatedException(e.getCause().toString());
         }
         return appiumSession;
-    }
-
-    private void startActivity(String appActivity) {
-        Logger.info(String.format("Starting activity '%s'", appActivity));
-        Instrumentation mInstrumentation = InstrumentationRegistry.getInstrumentation();
-        ActivityMonitor mSessionMonitor = mInstrumentation.addMonitor(appActivity, null, false);
-        Intent intent = new Intent(Intent.ACTION_MAIN);
-        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        intent.setClassName(mInstrumentation.getTargetContext(), appActivity);
-        mInstrumentation.startActivitySync(intent);
-
-        Activity mCurrentActivity = mInstrumentation.waitForMonitor(mSessionMonitor);
-        Logger.info(String.format("Activity '%s' started", mCurrentActivity.getLocalClassName()));
     }
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/StartActivity.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/StartActivity.java
@@ -58,11 +58,11 @@ public class StartActivity implements RequestHandler<StartActivityParams, Void> 
         Context context = mInstrumentation.getTargetContext();
 
         // If it's not fully qualified, make it fully qualified
+        String fullyQualifiedAppActivity = appActivity;
         if (appActivity.startsWith(".")) {
-            String packageName = context.getPackageName();
-            appActivity = packageName + appActivity;
+            fullyQualifiedAppActivity = context.getPackageName() + appActivity;
         }
-        intent.setClassName(mInstrumentation.getTargetContext(), appActivity);
+        intent.setClassName(mInstrumentation.getTargetContext(), fullyQualifiedAppActivity);
         mInstrumentation.startActivitySync(intent);
 
         if (waitForActivity) {

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/StartActivity.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/StartActivity.java
@@ -38,7 +38,6 @@ import static android.support.test.espresso.action.ViewActions.click;
 public class StartActivity implements RequestHandler<StartActivityParams, Void> {
 
     @Override
-    @Nullable
     public Void handle(StartActivityParams params) throws AppiumException {
         StartActivity.startActivity(params.getAppActivity(), false);
         return null;
@@ -62,7 +61,8 @@ public class StartActivity implements RequestHandler<StartActivityParams, Void> 
         if (appActivity.startsWith(".")) {
             fullyQualifiedAppActivity = context.getPackageName() + appActivity;
         }
-        intent.setClassName(mInstrumentation.getTargetContext(), fullyQualifiedAppActivity);
+        intent.setClassName(mInstrumentation.getTargetContext(), fullyQualifiedAppActivity)
+        ;
         mInstrumentation.startActivitySync(intent);
 
         if (waitForActivity) {

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/StartActivity.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/StartActivity.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.espressoserver.lib.handlers;
+
+import android.app.Activity;
+import android.app.Instrumentation;
+import android.content.Context;
+import android.content.Intent;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.espresso.PerformException;
+import android.support.test.espresso.ViewInteraction;
+
+import javax.annotation.Nullable;
+
+import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
+import io.appium.espressoserver.lib.handlers.exceptions.InvalidElementStateException;
+import io.appium.espressoserver.lib.helpers.Logger;
+import io.appium.espressoserver.lib.model.AppiumParams;
+import io.appium.espressoserver.lib.model.Element;
+import io.appium.espressoserver.lib.model.StartActivityParams;
+
+import static android.support.test.espresso.action.ViewActions.click;
+
+public class StartActivity implements RequestHandler<StartActivityParams, Void> {
+
+    @Override
+    @Nullable
+    public Void handle(StartActivityParams params) throws AppiumException {
+        StartActivity.startActivity(params.getAppActivity(), false);
+        return null;
+    }
+
+    /**
+     * Start an activity with provided activity name
+     * @param appActivity
+     * @param waitForActivity
+     */
+    public static void startActivity(String appActivity, Boolean waitForActivity) {
+        Logger.info(String.format("Starting activity '%s'", appActivity));
+        Instrumentation mInstrumentation = InstrumentationRegistry.getInstrumentation();
+        Instrumentation.ActivityMonitor mSessionMonitor = mInstrumentation.addMonitor(appActivity, null, false);
+        Intent intent = new Intent(Intent.ACTION_MAIN);
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        Context context = mInstrumentation.getTargetContext();
+
+        // If it's not fully qualified, make it fully qualified
+        if (appActivity.startsWith(".")) {
+            String packageName = context.getPackageName();
+            appActivity = packageName + appActivity;
+        }
+        intent.setClassName(mInstrumentation.getTargetContext(), appActivity);
+        mInstrumentation.startActivitySync(intent);
+
+        if (waitForActivity) {
+            Activity mCurrentActivity = mInstrumentation.waitForMonitor(mSessionMonitor);
+            Logger.info(String.format("Activity '%s' started", mCurrentActivity.getLocalClassName()));
+        }
+    }
+}

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.java
@@ -52,6 +52,7 @@ import io.appium.espressoserver.lib.handlers.GetSelected;
 import io.appium.espressoserver.lib.handlers.GetSize;
 import io.appium.espressoserver.lib.handlers.SetOrientation;
 import io.appium.espressoserver.lib.handlers.Source;
+import io.appium.espressoserver.lib.handlers.StartActivity;
 import io.appium.espressoserver.lib.handlers.Text;
 import io.appium.espressoserver.lib.handlers.W3CActions;
 import io.appium.espressoserver.lib.handlers.exceptions.InvalidArgumentException;
@@ -85,6 +86,7 @@ import io.appium.espressoserver.lib.model.Session;
 import io.appium.espressoserver.lib.model.SessionParams;
 import io.appium.espressoserver.lib.model.TextParams;
 import io.appium.espressoserver.lib.model.W3CActionsParams;
+import io.appium.espressoserver.lib.model.StartActivityParams;
 
 class Router {
     private final RouteMap routeMap;
@@ -131,6 +133,8 @@ class Router {
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/elements", new FindElements(), Locator.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/moveto", new MoveTo(), MoveToParams.class));
         routeMap.addRoute(new RouteDefinition(Method.GET, "/sessions", new GetSessions(), AppiumParams.class));
+
+        routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/appium/device/start_activity", new StartActivity(), StartActivityParams.class));
 
 
         // Not implemented

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/StartActivityParams.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/StartActivityParams.java
@@ -1,10 +1,13 @@
 package io.appium.espressoserver.lib.model;
 
+import javax.annotation.Nullable;
+
 public class StartActivityParams extends AppiumParams {
 
-    private String appActivity = null;
+    private String appActivity;
 
 
+    @Nullable
     public String getAppActivity() {
         return appActivity;
     }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/StartActivityParams.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/StartActivityParams.java
@@ -1,0 +1,15 @@
+package io.appium.espressoserver.lib.model;
+
+public class StartActivityParams extends AppiumParams {
+
+    private String appActivity = null;
+
+
+    public String getAppActivity() {
+        return appActivity;
+    }
+
+    public void setAppActivity(String appActivity) {
+        this.appActivity = appActivity;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "yargs": "^11.0.0"
   },
   "scripts": {
-    "build": "gulp transpile",
+    "build": "gulp transpile && npm run build:server",
     "build:server": "cd espresso-server && ./gradlew clean assembleAndroidTest && cd ..",
     "mocha": "mocha",
     "test": "gulp once",

--- a/test/functional/driver-e2e-specs.js
+++ b/test/functional/driver-e2e-specs.js
@@ -38,12 +38,28 @@ describe('createSession', function () {
   it('should start android session focusing on specified activity', async function () {
     // for now the activity needs to be fully qualified
     let status = await driver.init(Object.assign({
-      appActivity: 'io.appium.android.apis.view.TextFields'
+      appActivity: 'io.appium.android.apis.accessibility.AccessibilityNodeProviderActivity'
     }, APIDEMO_CAPS));
 
     status[1].app.should.eql(APIDEMO_CAPS.app);
 
     let activity = await driver.getCurrentDeviceActivity();
-    activity.should.equal('.view.TextFields');
+    activity.should.equal('.accessibility.AccessibilityNodeProviderActivity');
+  });
+  it('should reject start session for non-existent activity', async function () {
+    // for now the activity needs to be fully qualified
+    await driver.init(Object.assign({
+      appActivity: 'io.appium.android.apis.some.fake.Activity'
+    }, APIDEMO_CAPS)).should.eventually.be.rejectedWith(/unable to resolve/i);
+  });
+  it('should reject opening of appPackage with incorrect signature', async function () {
+    await driver.init(Object.assign({
+      appPackage: 'com.android.settings'
+    }, APIDEMO_CAPS)).should.eventually.be.rejectedWith(/does not have a signature matching/i);
+  });
+  it.skip('should start new activity', async function () {
+    await driver.init(APIDEMO_CAPS);
+    await driver.startActivity({appActivity: '.accessibility.AccessibilityNodeProviderActivity'});
+    await driver.getCurrentDeviceActivity().should.eventually.eql('.accessibility.AccessibilityNodeProviderActivity');
   });
 });

--- a/test/functional/driver-e2e-specs.js
+++ b/test/functional/driver-e2e-specs.js
@@ -57,9 +57,16 @@ describe('createSession', function () {
       appPackage: 'com.android.settings'
     }, APIDEMO_CAPS)).should.eventually.be.rejectedWith(/does not have a signature matching/i);
   });
-  it.skip('should start new activity', async function () {
-    await driver.init(APIDEMO_CAPS);
-    await driver.startActivity({appActivity: '.accessibility.AccessibilityNodeProviderActivity'});
-    await driver.getCurrentDeviceActivity().should.eventually.eql('.accessibility.AccessibilityNodeProviderActivity');
+  describe('.startActivity', function () {
+    it('should start activity by name', async function () {
+      await driver.init(APIDEMO_CAPS);
+      await driver.startActivity({appActivity: '.accessibility.AccessibilityNodeProviderActivity'});
+      await driver.getCurrentDeviceActivity().should.eventually.eql('.accessibility.AccessibilityNodeProviderActivity');
+    });
+    it('should start activity by fully-qualified name', async function () {
+      await driver.init(APIDEMO_CAPS);
+      await driver.startActivity({appActivity: 'io.appium.android.apis.accessibility.AccessibilityNodeProviderActivity'});
+      await driver.getCurrentDeviceActivity().should.eventually.eql('.accessibility.AccessibilityNodeProviderActivity');
+    });
   });
 });


### PR DESCRIPTION
* Added the `start_activity` endpoint
* Moved startActivity into a common helper method
* Fixed one of the tests. It was trying to open a non-existent activity

* NOTE: I don't think we'll ever be able to use `appPackage` in Espresso Driver. Espresso only deals with the App-under-test

(connected to: https://github.com/appium/appium/issues/8670)