### PR TITLE
Make accessibility selector scroll into view

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetAttribute.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetAttribute.java
@@ -85,7 +85,6 @@ public class GetAttribute implements RequestHandler<AppiumParams, String> {
                 return Integer.toString(viewElement.getIndex());
             case PACKAGE:
                 return viewElement.getPackageName();
-            // case INSTANCE:
             default:
                 throw new NotYetImplementedException();
         }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/ViewFinder.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/ViewFinder.java
@@ -171,17 +171,8 @@ public class ViewFinder {
 
                 // If the item is not found on the screen, use 'onData' to try
                 // to scroll it into view and then locate it again
-                if (views.isEmpty()) {
-                    try {
-                        DataInteraction dataInteraction = onData(
-                                hasEntry(Matchers.equalTo("contentDescription"), is(selector))
-                        );
-                        dataInteraction.check(matches(isDisplayed()));
-                    } catch (Exception e) {
-                        // Didn't find it. Don't do anything
-                    } finally {
-                        views = getViews(root, withContentDescription(selector), findOne);
-                    }
+                if (views.isEmpty() && canScrollToViewWithContentDescription(selector)) {
+                    views = getViews(root, withContentDescription(selector), findOne);
                 }
                 break;
             case XPATH:
@@ -198,6 +189,24 @@ public class ViewFinder {
         }
 
         return views;
+    }
+
+    /**
+     * Attempts to scroll to a view with the content description using onData
+     * @param contentDesc Content description
+     * @return
+     */
+    private static boolean canScrollToViewWithContentDescription (String contentDesc) {
+        try {
+            DataInteraction dataInteraction = onData(
+                    hasEntry(Matchers.equalTo("contentDescription"), is(contentDesc))
+            );
+            dataInteraction.check(matches(isDisplayed()));
+        } catch (Exception e) {
+            return false;
+        } finally {
+            return true;
+        }
     }
 
     private static List<View> getViews(

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/ViewFinder.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/ViewFinder.java
@@ -18,17 +18,21 @@ package io.appium.espressoserver.lib.helpers;
 
 import android.content.Context;
 import android.support.test.InstrumentationRegistry;
+import android.support.test.espresso.DataInteraction;
 import android.support.test.espresso.NoMatchingViewException;
+import android.support.test.espresso.ViewAssertion;
 import android.support.test.espresso.ViewInteraction;
 import android.view.View;
 
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeMatcher;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import javax.annotation.Nullable;
 
@@ -36,15 +40,23 @@ import io.appium.espressoserver.lib.handlers.exceptions.InvalidStrategyException
 import io.appium.espressoserver.lib.handlers.exceptions.XPathLookupException;
 import io.appium.espressoserver.lib.model.Strategy;
 
+import static android.support.test.espresso.Espresso.onData;
 import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.RootMatchers.withDecorView;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.withClassName;
 import static android.support.test.espresso.matcher.ViewMatchers.withContentDescription;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 import static io.appium.espressoserver.lib.viewmatcher.WithXPath.withXPath;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.core.IsEqual.equalTo;
 
 /**
  * Helper methods to find elements based on locator strategies and selectors
@@ -155,8 +167,22 @@ public class ViewFinder {
                 views = getViews(root, withText(selector), findOne);
                 break;
             case ACCESSIBILITY_ID:
-                // with content description
                 views = getViews(root, withContentDescription(selector), findOne);
+
+                // If the item is not found on the screen, use 'onData' to try
+                // to scroll it into view and then locate it again
+                if (views.isEmpty()) {
+                    try {
+                        DataInteraction dataInteraction = onData(
+                                hasEntry(Matchers.equalTo("contentDescription"), is(selector))
+                        );
+                        dataInteraction.check(matches(isDisplayed()));
+                    } catch (Exception e) {
+                        // Didn't find it. Don't do anything
+                    } finally {
+                        views = getViews(root, withContentDescription(selector), findOne);
+                    }
+                }
                 break;
             case XPATH:
                 // If we're only looking for one item that matches xpath, pass it index 0 or else

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/ViewFinder.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/ViewFinder.java
@@ -204,9 +204,9 @@ public class ViewFinder {
             dataInteraction.check(matches(isDisplayed()));
         } catch (Exception e) {
             return false;
-        } finally {
-            return true;
         }
+
+        return true;
     }
 
     private static List<View> getViews(

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.java
@@ -134,8 +134,6 @@ class Router {
 
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/appium/device/press_keycode", new PressKeyCode(), KeyEventParams.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/appium/device/long_press_keycode", new LongPressKeyCode(), KeyEventParams.class));
-        routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/appium/device/start_activity", new StartActivity(), StartActivityParams.class));
-
 
         // Not implemented
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/touch/click", new NotYetImplemented(), AppiumParams.class));

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.java
@@ -102,8 +102,6 @@ class Router {
         routeMap.addRoute(new RouteDefinition(Method.DELETE, "/session/:sessionId", new DeleteSession(), AppiumParams.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/back", new Back(), AppiumParams.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/accept_alert", new AcceptAlert(), AppiumParams.class));
-        routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/appium/device/press_keycode", new PressKeyCode(), KeyEventParams.class));
-        routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/appium/device/long_press_keycode", new LongPressKeyCode(), KeyEventParams.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/dismiss_alert", new DismissAlert(), AppiumParams.class));
         routeMap.addRoute(new RouteDefinition(Method.GET, "/session/:sessionId/alert_text", new GetAlertText(), AppiumParams.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/orientation", new SetOrientation(), OrientationParams.class));
@@ -134,6 +132,8 @@ class Router {
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/moveto", new MoveTo(), MoveToParams.class));
         routeMap.addRoute(new RouteDefinition(Method.GET, "/sessions", new GetSessions(), AppiumParams.class));
 
+        routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/appium/device/press_keycode", new PressKeyCode(), KeyEventParams.class));
+        routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/appium/device/long_press_keycode", new LongPressKeyCode(), KeyEventParams.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/appium/device/start_activity", new StartActivity(), StartActivityParams.class));
 
 

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/SourceDocument.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/SourceDocument.java
@@ -135,7 +135,7 @@ public class SourceDocument {
         }
 
         // If it's an AdapterView, get the adapters as a String
-        try {
+        if (view instanceof AdapterView) {
             AdapterView adapterView = (AdapterView) view;
             Adapter adapter = adapterView.getAdapter();
             StringBuilder adapterData = new StringBuilder();
@@ -148,30 +148,11 @@ public class SourceDocument {
 
                 // Get the type of the adapter item
                 if (i == 0) {
-                    String adapterItemType = "Object";
-                    if (adapterItem instanceof Map) {
-                        adapterItemType = "Map";
-                    } else if (adapterItem instanceof String) {
-                        adapterItemType = "String";
-                    } else if (adapterItem instanceof Integer) {
-                        adapterItemType = "Integer";
-                    } else if (adapterItem instanceof Number) {
-                        adapterItemType = "Number";
-                    } else if (adapterItem instanceof Boolean) {
-                        adapterItemType = "Boolean";
-                    } else if (adapterItem instanceof Collection) {
-                        adapterItemType = "Collection";
-                    } else if (adapter instanceof CursorAdapter) {
-                        adapterItemType = "Cursor";
-                    }
-
-                    setAttribute(element, ViewAttributesEnum.ADAPTER_TYPE, adapterItemType);
+                    setAttribute(element, ViewAttributesEnum.ADAPTER_TYPE, adapterItem.getClass().getSimpleName());
                 }
                 setAttribute(element, ViewAttributesEnum.ADAPTERS, adapterData);
 
             }
-        } catch (ClassCastException cce) {
-            // Do nothing
         }
 
         // If cacheElementReferences == true, then cache a reference to the View

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/SourceDocument.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/SourceDocument.java
@@ -18,6 +18,11 @@ package io.appium.espressoserver.lib.model;
 
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Adapter;
+import android.widget.AdapterView;
+import android.widget.CheckedTextView;
+import android.widget.CursorAdapter;
+import android.widget.ListView;
 
 import org.apache.xml.utils.XMLChar;
 import org.w3c.dom.*;
@@ -25,6 +30,7 @@ import org.w3c.dom.Element;
 
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -46,6 +52,7 @@ import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
 import io.appium.espressoserver.lib.handlers.exceptions.XPathLookupException;
+import io.appium.espressoserver.lib.helpers.Logger;
 import io.appium.espressoserver.lib.viewaction.ViewFinder;
 
 public class SourceDocument {
@@ -125,6 +132,46 @@ public class SourceDocument {
             doc.appendChild(element);
         } else {
             parentElement.appendChild(element);
+        }
+
+        // If it's an AdapterView, get the adapters as a String
+        try {
+            AdapterView adapterView = (AdapterView) view;
+            Adapter adapter = adapterView.getAdapter();
+            StringBuilder adapterData = new StringBuilder();
+            for (int i = 0; i < adapter.getCount(); i++) {
+                Object adapterItem = adapter.getItem(i);
+                adapterData.append(adapterItem);
+                if (i < adapter.getCount() - 1) {
+                    adapterData.append(",");
+                }
+
+                // Get the type of the adapter item
+                if (i == 0) {
+                    String adapterItemType = "Object";
+                    if (adapterItem instanceof Map) {
+                        adapterItemType = "Map";
+                    } else if (adapterItem instanceof String) {
+                        adapterItemType = "String";
+                    } else if (adapterItem instanceof Integer) {
+                        adapterItemType = "Integer";
+                    } else if (adapterItem instanceof Number) {
+                        adapterItemType = "Number";
+                    } else if (adapterItem instanceof Boolean) {
+                        adapterItemType = "Boolean";
+                    } else if (adapterItem instanceof Collection) {
+                        adapterItemType = "Collection";
+                    } else if (adapter instanceof CursorAdapter) {
+                        adapterItemType = "Cursor";
+                    }
+
+                    setAttribute(element, ViewAttributesEnum.ADAPTER_TYPE, adapterItemType);
+                }
+                setAttribute(element, ViewAttributesEnum.ADAPTERS, adapterData);
+
+            }
+        } catch (ClassCastException cce) {
+            // Do nothing
         }
 
         // If cacheElementReferences == true, then cache a reference to the View

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/SourceDocument.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/SourceDocument.java
@@ -151,7 +151,6 @@ public class SourceDocument {
                     setAttribute(element, ViewAttributesEnum.ADAPTER_TYPE, adapterItem.getClass().getSimpleName());
                 }
                 setAttribute(element, ViewAttributesEnum.ADAPTERS, adapterData);
-
             }
         }
 

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/ViewAttributesEnum.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/ViewAttributesEnum.java
@@ -36,7 +36,9 @@ public enum ViewAttributesEnum {
     BOUNDS,
     RESOURCE_ID,
     INSTANCE,
-    INDEX;
+    INDEX,
+    ADAPTERS,
+    ADAPTER_TYPE;
 
 
     @Override

--- a/test/functional/commands/find-e2e-specs.js
+++ b/test/functional/commands/find-e2e-specs.js
@@ -57,4 +57,12 @@ describe('elementByXPath', function () {
     await el.isDisplayed().should.eventually.be.true;
     await el.isDisplayed().should.eventually.be.true;
   });
+  it('should match an element if the element is off-screen but has an accessibility id', async function () {
+    let el = await driver.elementByAccessibilityId('Views');
+    await el.click();
+
+    // Click on an element that is at the bottom of the list
+    let moveToEl = await driver.elementByAccessibilityId('WebView');
+    await moveToEl.click();
+  });
 });

--- a/test/functional/commands/keyboard-e2e-specs.js
+++ b/test/functional/commands/keyboard-e2e-specs.js
@@ -13,7 +13,7 @@ describe('keyboard', function () {
   let driver;
   before(async function () {
     let caps = Object.assign({
-      appActivity: 'io.appium.android.apis.view.TextFields'
+      appActivity: 'io.appium.android.apis.view.AutoComplete4'
     }, APIDEMO_CAPS);
     driver = await initSession(caps);
   });
@@ -22,7 +22,7 @@ describe('keyboard', function () {
   });
 
   it('should send keys to the correct element', async function () {
-    let el = await driver.elementById('id/edit1');
+    let el = await driver.elementByXPath('//android.widget.AutoCompleteTextView');
     await el.click();
 
     try {


### PR DESCRIPTION
* When locating an element by accessibility ID, if it isn't found on the first time, try using onData to see if it can be matched with a Hamcrest matcher and scrolled into view (see https://medium.com/google-developers/adapterviews-and-espresso-f4172aa853cf for info on how `onData` works)
* Added `adapter-type` and `adapters` as an attribute to source. This was from a previous experimental branch I worked on. I think in the future I'd like to use a Hamcrest matcher strategy for locating elements so we have other ways to target elements that aren't visible
* Added a test for finding an element that is off the screen (has an accessibility ID called WebView which is the bottom of the list)