### PR TITLE
add window rect for w3c and add timeout

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetWindowRect.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetWindowRect.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.espressoserver.lib.handlers;
+
+import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
+import io.appium.espressoserver.lib.helpers.Logger;
+import io.appium.espressoserver.lib.model.AppiumParams;
+import io.appium.espressoserver.lib.model.WindowRect;
+import io.appium.espressoserver.lib.model.WindowSize;
+
+public class GetWindowRect implements RequestHandler<AppiumParams, WindowSize> {
+
+    @Override
+    public WindowSize handle(AppiumParams params) throws AppiumException {
+        Logger.info("Get window rect of the device");
+
+        final WindowSize windowSize = new GetWindowSize().handle(params);
+
+        final WindowRect windowRect = new WindowRect();
+        windowRect.setHeight(windowSize.getHeight());
+        windowRect.setWidth(windowSize.getWidth());
+
+        return windowRect;
+    }
+}

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetWindowRect.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetWindowRect.java
@@ -16,23 +16,35 @@
 
 package io.appium.espressoserver.lib.handlers;
 
+import android.content.Context;
+import android.support.test.InstrumentationRegistry;
+import android.util.DisplayMetrics;
+import android.view.WindowManager;
+
 import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
 import io.appium.espressoserver.lib.helpers.Logger;
 import io.appium.espressoserver.lib.model.AppiumParams;
 import io.appium.espressoserver.lib.model.WindowRect;
-import io.appium.espressoserver.lib.model.WindowSize;
 
-public class GetWindowRect implements RequestHandler<AppiumParams, WindowSize> {
+public class GetWindowRect implements RequestHandler<AppiumParams, WindowRect> {
 
     @Override
-    public WindowSize handle(AppiumParams params) throws AppiumException {
+    public WindowRect handle(AppiumParams params) throws AppiumException {
         Logger.info("Get window rect of the device");
 
-        final WindowSize windowSize = new GetWindowSize().handle(params);
+        DisplayMetrics displayMetrics = new DisplayMetrics();
+        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        WindowManager winManager = (WindowManager) context.getApplicationContext().getSystemService(Context.WINDOW_SERVICE);
+
+        winManager.getDefaultDisplay().getMetrics(displayMetrics);
+        int height = displayMetrics.heightPixels;
+        int width = displayMetrics.widthPixels;
 
         final WindowRect windowRect = new WindowRect();
-        windowRect.setHeight(windowSize.getHeight());
-        windowRect.setWidth(windowSize.getWidth());
+        windowRect.setHeight(height);
+        windowRect.setWidth(width);
+        windowRect.setX(0);
+        windowRect.setY(0);
 
         return windowRect;
     }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.java
@@ -39,6 +39,7 @@ import io.appium.espressoserver.lib.handlers.GetLocation;
 import io.appium.espressoserver.lib.handlers.GetLocationInView;
 import io.appium.espressoserver.lib.handlers.GetRect;
 import io.appium.espressoserver.lib.handlers.GetOrientation;
+import io.appium.espressoserver.lib.handlers.GetWindowRect;
 import io.appium.espressoserver.lib.handlers.GetWindowSize;
 import io.appium.espressoserver.lib.handlers.LongPressKeyCode;
 import io.appium.espressoserver.lib.handlers.MoveTo;
@@ -128,6 +129,7 @@ class Router {
         routeMap.addRoute(new RouteDefinition(Method.GET, "/session/:sessionId/element/:elementId/text", new Text(), AppiumParams.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/element/:elementId/value", new SendKeys(), TextParams.class));
         routeMap.addRoute(new RouteDefinition(Method.GET, "/session/:sessionId/window/:windowHandle/size", new GetWindowSize(), AppiumParams.class));
+        routeMap.addRoute(new RouteDefinition(Method.GET, "/session/:sessionId/window/rect", new GetWindowRect(), AppiumParams.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/elements", new FindElements(), Locator.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/moveto", new MoveTo(), MoveToParams.class));
         routeMap.addRoute(new RouteDefinition(Method.GET, "/sessions", new GetSessions(), AppiumParams.class));

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/WindowRect.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/WindowRect.java
@@ -19,14 +19,45 @@ package io.appium.espressoserver.lib.model;
 import javax.annotation.Nullable;
 
 @SuppressWarnings("unused")
-public class WindowRect extends WindowSize {
+public class WindowRect extends AppiumParams {
+    private Integer width = null;
+    private Integer height = null;
+    private Integer x = null;
+    private Integer y = null;
+
     @Nullable
     public Integer getX() {
-        return 0;
+        return x;
+    }
+
+    public void setX(Integer x) {
+        this.x = x;
     }
 
     @Nullable
     public Integer getY() {
-        return 0;
+        return y;
+    }
+
+    public void setY(Integer y) {
+        this.y = y;
+    }
+
+    @Nullable
+    public Integer getHeight() {
+        return height;
+    }
+
+    public void setHeight(Integer height) {
+        this.height = height;
+    }
+
+    @Nullable
+    public Integer getWidth() {
+        return width;
+    }
+
+    public void setWidth(Integer width) {
+        this.width = width;
     }
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/WindowRect.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/WindowRect.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.espressoserver.lib.model;
+
+import javax.annotation.Nullable;
+
+@SuppressWarnings("unused")
+public class WindowRect extends WindowSize {
+    @Nullable
+    public Integer getX() {
+        return 0;
+    }
+
+    @Nullable
+    public Integer getY() {
+        return 0;
+    }
+}

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -62,6 +62,7 @@ const NO_PROXY = [
   ['POST', new RegExp('^/session/[^/]+/ime/[^/]+')],
   ['POST', new RegExp('^/session/[^/]+/log')],
   ['POST', new RegExp('^/session/[^/]+/network_connection')],
+  ['POST', new RegExp('^/session/[^/]+/timeouts')],
   ['POST', new RegExp('^/session/[^/]+/url')],
 ];
 


### PR DESCRIPTION
- server

```
[HTTP] <-- POST /wd/hub/session 200 12976 ms - 445
[HTTP]
[HTTP] --> POST /wd/hub/session/f578ee7b-060b-4324-bf9f-e261956ebd28/timeouts
[HTTP] {"implicit":30000}
[debug] [W3C] Calling AppiumDriver.timeouts() with args: [{"protocol":"W3C","implicit":30000},"f578ee7b-060b-4324-bf9f-e261956ebd28"]
[debug] [BaseDriver] script: undefined, pageLoad: undefined, implicit: 30000
[debug] [BaseDriver] Set implicit wait to 30000ms
[debug] [MJSONWP] Responding to client with driver.timeouts() result: null
[HTTP] <-- POST /wd/hub/session/f578ee7b-060b-4324-bf9f-e261956ebd28/timeouts 200 13 ms - 76
[HTTP]
[HTTP] --> GET /wd/hub/session/f578ee7b-060b-4324-bf9f-e261956ebd28/window/rect
[HTTP] {}
[W3C] Driver proxy active, passing request on via HTTP proxy
[debug] [JSONWP Proxy] Proxying [GET /wd/hub/session/f578ee7b-060b-4324-bf9f-e261956ebd28/window/rect] to [GET http://localhost:8080/session/6d762366-2af3-4b11-b314-dd7f299d3cd0/window/rect] with body: {}
[debug] [JSONWP Proxy] Got response with status 200: "{\"id\":\"c180101c-a577-48ea-943b-20eabb16020e\",\"sessionId\":\"6d762366-2af3-4b11-b314-dd7f299d3cd0\",\"status\":0,\"value\":{\"height\":1794,\"width\":1080,\"x\":0,\"y\":0,\"uriParams\":{}}}"
[JSONWP Proxy] Replacing sessionId 6d762366-2af3-4b11-b314-dd7f299d3cd0 with f578ee7b-060b-4324-bf9f-e261956ebd28
[HTTP] <-- GET /wd/hub/session/f578ee7b-060b-4324-bf9f-e261956ebd28/window/rect 200 28 ms - 171
[HTTP]
[debug] [ADB] Running '/Users/kazuaki/Library/Android/sdk/platform-tools/adb -P 5037 -s emulator-5554 shell am instrument -w -e de
```

- client(Ruby)
```
[45] pry(#<AppiumLibCoreTest::DriverTest>)> @@driver ||= @@core.start_driver
=> #<Appium::Core::Base::Driver:0x10fe030a28452c54 browser="unknown">
[46] pry(#<AppiumLibCoreTest::DriverTest>)> @@driver.window_rect
=> #<struct Selenium::WebDriver::Rectangle x=0, y=0, width=1080, height=1794>
[47] pry(#<AppiumLibCoreTest::DriverTest>)> 
```