### PR TITLE
fix creating w3c session

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -88,11 +88,10 @@ class EspressoDriver extends BaseDriver {
     this.apkStrings = {}; // map of language -> strings obj
   }
 
-  async createSession (caps) {
+  async createSession (...args) {
     try {
       // TODO handle otherSessionData for multiple sessions
-      let sessionId;
-      [sessionId] = await super.createSession(caps);
+      let [sessionId, caps] = await super.createSession(...args);
 
       let serverDetails = {
         platform: 'LINUX',


### PR DESCRIPTION
With current Espresso driver, we wasn't able to create W3C session even the desired capability was same as `uiautomator2` which could work as W3C session.
(I faced when fixing https://github.com/appium/appium-espresso-driver/pull/121)

## Before
Couldn't create a W3C session since the `createSession` handle the caps as `MJSONWP` everytime.

```
[HTTP] --> POST /wd/hub/session
[HTTP] {"desiredCapabilities":{"platformName":"android","automationName":"espresso","app":"/Users/kazuaki/GitHub/ruby_lib_core/test/functional/app/api.apk","platformVersion":"8.1.0","deviceName":"Android Emulator","appPackage":"io.appium.android.apis","appActivity":"io.appium.android.apis.ApiDemos","unicodeKeyboard":true,"resetKeyboard":true,"newCommandTimeout":300},"capabilities":{"alwaysMatch":{"platformName":"android","appium:automationName":"espresso","appium:app":"/Users/kazuaki/GitHub/ruby_lib_core/test/functional/app/api.apk","appium:platformVersion":"8.1.0","appium:deviceName":"Android Emulator","appium:appPackage":"io.appium.android.apis","appium:appActivity":"io.appium.android.apis.ApiDemos","appium:unicodeKeyboard":true,"appium:resetKeyboard":true,"appium:newCommandTimeout":300},"firstMatch":[{}]}}
[debug] [MJSONWP] Calling AppiumDriver.createSession() with args: [{"platformName":"android","automationName":"espresso","app":"/Users/kazuaki/GitHub/ruby_lib_core/test/functional/app/api.apk","platformVersion":"8.1.0","deviceName":"Android Emulator","appPackage":"io.appium.android.apis","appActivity":"io.appium.android.apis.ApiDemos","unicodeKeyboard":true,"resetKeyboard":true,"newCommandTimeout":300},null,{"alwaysMatch":{"platformName":"android","appium:automationName":"espresso","appium:app":"/Users/kazuaki/GitHub/ruby_lib_core/test/functional/app/api.apk","appium:platformVersion":"8.1.0","appium:deviceName":"Android Emulator","appium:appPackage":"io.appium.android.apis","appium:appActivity":"io.appium.android.apis.ApiDemos","appium:unicodeKeyboard":true,"appium:resetKeyboard":true,"appium:newCommandTimeout":300},"firstMatch":[{}]}]
[debug] [BaseDriver] Event 'newSessionRequested' logged at 1527176419811 (00:40:19 GMT+0900 (JST))
[Appium] The Appium Espresso driver is currently in early beta and meant only for experimental usage. Its API is not yet complete or guaranteed to work. Please report bugs to the Appium team on GitHub.
[Appium] Unable to get version of driver 'EspressoDriver'
[Appium] Creating new EspressoDriver session
[Appium] Capabilities:
[Appium]   platformName: android
[Appium]   automationName: espresso
[Appium]   app: /Users/kazuaki/GitHub/ruby_lib_core/test/functional/app/api.apk
[Appium]   platformVersion: 8.1.0
[Appium]   deviceName: Android Emulator
[Appium]   appPackage: io.appium.android.apis
[Appium]   appActivity: io.appium.android.apis.ApiDemos
[Appium]   unicodeKeyboard: true
[Appium]   resetKeyboard: true
[Appium]   newCommandTimeout: 300
[debug] [BaseDriver] Creating session with MJSONWP desired capabilities: {"platformName":"android","...
[BaseDriver] Session created with session id: c99971e4-bcdb-42e2-a1f2-7227bcc712bb
[BaseDriver] Using local app '/Users/kazuaki/GitHub/ruby_lib_core/test/functional/app/api.apk'
[debug] [Espresso] Checking whether app is actually present
[Espresso] EspressoDriver version: 1.0.0-beta.10
```


## After
Can create a W3C session since  the `createSession` handle the caps as `W3C`.

```
[HTTP] --> POST /wd/hub/session
[HTTP] {"desiredCapabilities":{"platformName":"android","automationName":"espresso","app":"/Users/kazuaki/GitHub/ruby_lib_core/test/functional/app/api.apk","platformVersion":"8.1.0","deviceName":"Android Emulator","appPackage":"io.appium.android.apis","appActivity":"io.appium.android.apis.ApiDemos","someCapability":"some_capability","unicodeKeyboard":true,"resetKeyboard":true,"newCommandTimeout":300},"capabilities":{"alwaysMatch":{"platformName":"android","appium:automationName":"espresso","appium:app":"/Users/kazuaki/GitHub/ruby_lib_core/test/functional/app/api.apk","appium:platformVersion":"8.1.0","appium:deviceName":"Android Emulator","appium:appPackage":"io.appium.android.apis","appium:appActivity":"io.appium.android.apis.ApiDemos","appium:someCapability":"some_capability","appium:unicodeKeyboard":true,"appium:resetKeyboard":true,"appium:newCommandTimeout":300},"firstMatch":[{}]}}
[debug] [W3C] Calling AppiumDriver.createSession() with args: [{"platformName":"android","automationName":"espresso","app":"/Users/kazuaki/GitHub/ruby_lib_core/test/functional/app/api.apk","platformVersion":"8.1.0","deviceName":"Android Emulator","appPackage":"io.appium.android.apis","appActivity":"io.appium.android.apis.ApiDemos","someCapability":"some_capability","unicodeKeyboard":true,"resetKeyboard":true,"newCommandTimeout":300},null,{"alwaysMatch":{"platformName":"android","appium:automationName":"espresso","appium:app":"/Users/kazuaki/GitHub/ruby_lib_core/test/functional/app/api.apk","appium:platformVersion":"8.1.0","appium:deviceName":"Android Emulator","appium:appPackage":"io.appium.android.apis","appium:appActivity":"io.appium.android.apis.ApiDemos","appium:someCapability":"some_capability","appium:unicodeKeyboard":true,"appium:resetKeyboard":true,"appium:newCommandTimeout":300},"firstMatch":[{}]}]
[debug] [BaseDriver] Event 'newSessionRequested' logged at 1527178079812 (01:07:59 GMT+0900 (JST))
[Appium] The Appium Espresso driver is currently in early beta and meant only for experimental usage. Its API is not yet complete or guaranteed to work. Please report bugs to the Appium team on GitHub.
[Appium] Unable to get version of driver 'EspressoDriver'
[Appium] Creating new EspressoDriver session
[Appium] Capabilities:
[Appium]   platformName: android
[Appium]   automationName: espresso
[Appium]   app: /Users/kazuaki/GitHub/ruby_lib_core/test/functional/app/api.apk
[Appium]   platformVersion: 8.1.0
[Appium]   deviceName: Android Emulator
[Appium]   appPackage: io.appium.android.apis
[Appium]   appActivity: io.appium.android.apis.ApiDemos
[Appium]   someCapability: some_capability
[Appium]   unicodeKeyboard: true
[Appium]   resetKeyboard: true
[Appium]   newCommandTimeout: 300
[debug] [BaseDriver] W3C capabilities {"alwaysMatch":{"platformNa... and MJSONWP desired capabilities [object Object] were provided
```