### PR TITLE
Switch to SubProcess for better control

### DIFF
--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -20,6 +20,9 @@ let espressoCapConstraints = {
   forceEspressoRebuild: {
     isBoolean: true
   },
+  espressoServerLaunchTimeout: {
+    isNumber: true
+  },
 };
 
 let desiredCapConstraints = {};

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -283,6 +283,7 @@ class EspressoDriver extends BaseDriver {
       appPackage: this.opts.appPackage,
       appActivity: this.opts.appActivity,
       forceEspressoRebuild: !!this.opts.forceEspressoRebuild,
+      serverLaunchTimeout: this.opts.espressoServerLaunchTimeout,
     });
     this.proxyReqRes = this.espresso.proxyReqRes.bind(this.espresso);
   }

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -10,6 +10,7 @@ import desiredCapConstraints from './desired-caps';
 import { version } from '../../package.json'; // eslint-disable-line import/no-unresolved
 import { findAPortNotInUse } from 'portscanner';
 
+
 // TODO merge our own helpers onto this later
 const helpers = androidHelpers;
 

--- a/lib/espresso-runner.js
+++ b/lib/espresso-runner.js
@@ -10,6 +10,7 @@ const TEST_APK_PATH = path.resolve(__dirname, '..', '..', 'espresso-server', 'ap
 const TEST_MANIFEST_PATH = path.resolve(__dirname, '..', '..', 'espresso-server', 'AndroidManifest-test.xml');
 const TEST_APK_PKG = 'io.appium.espressoserver.test';
 const REQUIRED_PARAMS = ['adb', 'tmpDir', 'host', 'systemPort', 'devicePort', 'appPackage', 'forceEspressoRebuild'];
+const ESPRESSO_SERVER_LAUNCH_TIMEOUT = 30000;
 
 class EspressoRunner {
   constructor (opts = {}) {
@@ -23,6 +24,8 @@ class EspressoRunner {
     this.proxyReqRes = this.jwproxy.proxyReqRes.bind(this.jwproxy);
 
     this.modServerPath = path.resolve(this.tmpDir, `${TEST_APK_PKG}_${version}_${this.appPackage}.apk`);
+
+    this.serverLaunchTimeout = opts.serverLaunchTimeout || ESPRESSO_SERVER_LAUNCH_TIMEOUT;
   }
 
   async installTestApk () {
@@ -92,14 +95,14 @@ class EspressoRunner {
 
     await this.instProcess.start((stdout, stderr) => {
       // adb always prints this out on success. If this is found not to be the
-      // case (in which case startup hangs at this point), add other conditions
+      // case, add other conditions
       if (stdout.includes('io.appium.espressoserver.EspressoServerRunnerTest:')) {
         return true;
       }
       if (stderr.includes('Exception')) {
         throw new Error(stderr.trim());
       }
-    });
+    }, this.serverLaunchTimeout);
 
     logger.info('Waiting for Espresso to be online...');
 

--- a/lib/espresso-runner.js
+++ b/lib/espresso-runner.js
@@ -46,12 +46,10 @@ class EspressoRunner {
 
   async buildNewModServer () {
     logger.info(`Repackaging espresso server for: '${this.appPackage}'`);
-    let packageTmpDir = path.resolve(this.tmpDir, this.appPackage);
-    let newManifestPath = path.resolve(this.tmpDir, 'AndroidManifest.xml');
-    if (await fs.exists(newManifestPath)) {
-      logger.info(`Deleting old temporary manifest: '${newManifestPath}'`);
-      await fs.unlink(newManifestPath);
-    }
+    const packageTmpDir = path.resolve(this.tmpDir, this.appPackage);
+    const newManifestPath = path.resolve(this.tmpDir, 'AndroidManifest.xml');
+    await fs.rimraf(newManifestPath);
+
     logger.info(`Creating new manifest: '${newManifestPath}'`);
     await mkdirp(packageTmpDir);
     await fs.copyFile(TEST_MANIFEST_PATH, newManifestPath);
@@ -70,8 +68,13 @@ class EspressoRunner {
   }
 
   async startSession (caps) {
-    let cmd = ['shell', 'am', 'instrument', '-w', '-e', 'debug', process.env.ESPRESSO_JAVA_DEBUG === 'true' ? 'true' : 'false',
-      `${TEST_APK_PKG}/android.support.test.runner.AndroidJUnitRunner`];
+    const cmd = [
+      'shell',
+      'am', 'instrument',
+      '-w',
+      '-e', 'debug', process.env.ESPRESSO_JAVA_DEBUG === 'true' ? 'true' : 'false',
+      `${TEST_APK_PKG}/android.support.test.runner.AndroidJUnitRunner`,
+    ];
 
     logger.info(`Starting Espresso Server v${version} with cmd: adb ${cmd.join(' ')}`);
 
@@ -88,6 +91,8 @@ class EspressoRunner {
     });
 
     await this.instProcess.start((stdout, stderr) => {
+      // adb always prints this out on success. If this is found not to be the
+      // case (in which case startup hangs at this point), add other conditions
       if (stdout.includes('io.appium.espressoserver.EspressoServerRunnerTest:')) {
         return true;
       }
@@ -116,7 +121,9 @@ class EspressoRunner {
           `Error was: ${err}`);
     }
 
-    await this.instProcess.stop();
+    if (this.instProcess && this.instProcess.isRunning) {
+      await this.instProcess.stop();
+    }
   }
 }
 

--- a/lib/espresso-runner.js
+++ b/lib/espresso-runner.js
@@ -2,13 +2,13 @@ import { JWProxy } from 'appium-base-driver';
 import { retryInterval } from 'asyncbox';
 import logger from './logger';
 import path from 'path';
-import { fs, util } from 'appium-support';
+import { fs, util, mkdirp } from 'appium-support';
 import { version } from '../../package.json'; // eslint-disable-line import/no-unresolved
 
 
 const TEST_APK_PATH = path.resolve(__dirname, '..', '..', 'espresso-server', 'app', 'build', 'outputs', 'apk', 'androidTest', 'debug', 'app-debug-androidTest.apk');
 const TEST_MANIFEST_PATH = path.resolve(__dirname, '..', '..', 'espresso-server', 'AndroidManifest-test.xml');
-const TEST_APK_PKG = "io.appium.espressoserver.test";
+const TEST_APK_PKG = 'io.appium.espressoserver.test';
 const REQUIRED_PARAMS = ['adb', 'tmpDir', 'host', 'systemPort', 'devicePort', 'appPackage', 'forceEspressoRebuild'];
 
 class EspressoRunner {
@@ -39,6 +39,7 @@ class EspressoRunner {
       logger.info("New server was built, uninstalling any instances of it");
       await this.adb.uninstallApk(TEST_APK_PKG);
     }
+
     await this.adb.installOrUpgrade(this.modServerPath, TEST_APK_PKG);
     logger.info(`Installed Espresso Test Server apk '${this.modServerPath}' (pkg: '${TEST_APK_PKG}')`);
   }
@@ -47,10 +48,13 @@ class EspressoRunner {
     logger.info(`Repackaging espresso server for: '${this.appPackage}'`);
     let packageTmpDir = path.resolve(this.tmpDir, this.appPackage);
     let newManifestPath = path.resolve(this.tmpDir, 'AndroidManifest.xml');
+    if (await fs.exists(newManifestPath)) {
+      logger.info(`Deleting old temporary manifest: '${newManifestPath}'`);
+      await fs.unlink(newManifestPath);
+    }
     logger.info(`Creating new manifest: '${newManifestPath}'`);
-    await fs.mkdir(packageTmpDir);
+    await mkdirp(packageTmpDir);
     await fs.copyFile(TEST_MANIFEST_PATH, newManifestPath);
-    await this.adb.initAapt(); // TODO this should be internal to adb
     await this.adb.compileManifest(newManifestPath, TEST_APK_PKG, this.appPackage); // creates a file `${newManifestPath}.apk`
     await this.adb.insertManifest(newManifestPath, TEST_APK_PATH, this.modServerPath); // copies from second to third and add manifest
     logger.info(`Repackaged espresso server ready: '${this.modServerPath}'`);
@@ -66,29 +70,39 @@ class EspressoRunner {
   }
 
   async startSession (caps) {
-    let cmd = ['am', 'instrument', '-w', '-e', 'debug', process.env.ESPRESSO_JAVA_DEBUG === 'true' ? 'true' : 'false',
+    let cmd = ['shell', 'am', 'instrument', '-w', '-e', 'debug', process.env.ESPRESSO_JAVA_DEBUG === 'true' ? 'true' : 'false',
       `${TEST_APK_PKG}/android.support.test.runner.AndroidJUnitRunner`];
 
-    logger.info(`Starting Espresso Server v${version} with cmd: ${cmd.join(' ')}`);
+    logger.info(`Starting Espresso Server v${version} with cmd: adb ${cmd.join(' ')}`);
 
-    // start the instrumentation process, but do not wait for it
-    // otherwise it will block for longer than needed for the device to be ready
-    let err;
-    this.adb.shell(cmd).catch((e) => { // eslint-disable-line
-      // handle asynchronous errors that no longer get thrown
-      err = e;
+    // start the instrumentation process
+    this.instProcess = this.adb.createSubProcess(cmd);
+    this.instProcess.on('exit', (code, signal) => {
+      logger.info(`Instrumentation process exited with code ${code} from signal ${signal}`);
+    });
+    this.instProcess.on('die', (code, signal) => {
+      logger.error(`Instrumentation process died with code ${code} and signal ${signal}`);
+    });
+    this.instProcess.on('stream-line', line => {
+      logger.debug(`[Instrumentation]${line.trim()}`);
+    });
+
+    await this.instProcess.start((stdout, stderr) => {
+      if (stdout.includes('io.appium.espressoserver.EspressoServerRunnerTest:')) {
+        return true;
+      }
+      if (stderr.includes('Exception')) {
+        throw new Error(stderr.trim());
+      }
     });
 
     logger.info('Waiting for Espresso to be online...');
 
     // wait 20s for espresso to be online
     await retryInterval(20, 1000, async () => {
-      if (err) return; // eslint-disable-line curly
       await this.jwproxy.command('/status', 'GET');
     });
-    if (err) throw err; // eslint-disable-line curly
     await this.jwproxy.command('/session', 'POST', {desiredCapabilities: caps});
-    if (err) throw err; // eslint-disable-line curly
   }
 
   async deleteSession () {
@@ -101,6 +115,8 @@ class EspressoRunner {
       logger.warn(`Did not get confirmation Espresso deleteSession worked; ` +
           `Error was: ${err}`);
     }
+
+    await this.instProcess.stop();
   }
 }
 

--- a/test/unit/espresso-runner-specs.js
+++ b/test/unit/espresso-runner-specs.js
@@ -1,8 +1,5 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { withMocks } from 'appium-test-support';
-import ADB from 'appium-adb';
-import B from 'bluebird';
 import { EspressoRunner, REQUIRED_PARAMS } from '../../lib/espresso-runner';
 
 
@@ -11,8 +8,6 @@ chai.use(chaiAsPromised);
 const expect = chai.expect;
 
 describe('espresso-runner', function () {
-  let adb = new ADB();
-
   function getOpts (params) {
     let opts = {};
     for (let j = 0; j < params.length; j++) {
@@ -34,17 +29,4 @@ describe('espresso-runner', function () {
       runConstructorTest(opts, REQUIRED_PARAMS[i]);
     }
   });
-  describe('startSession', withMocks({adb}, (mocks) => {
-    let opts = getOpts(REQUIRED_PARAMS);
-    opts.adb = adb;
-    it('should throw an error if running instrumentation process errors', async function () {
-      mocks.adb.expects('shell').withExactArgs(["am", "instrument", "-w", "-e", "debug", "false", "io.appium.espressoserver.test/android.support.test.runner.AndroidJUnitRunner"])
-        .returns(B.reject("Problem with instrumentation"));
-
-      let espressoRunner = new EspressoRunner(opts);
-      await espressoRunner.startSession({}).should.eventually.be.rejectedWith(/Problem with instrumentation/);
-
-      mocks.verify();
-    });
-  }));
 });


### PR DESCRIPTION
`SubProcess` allows us to have a handle on the running instrumentation process, while `exec` is meant to be fire-and-forget.

Finally fix #124 in Travis.