### PR TITLE
Run remaining tests in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
     - NODE_VERSION=6
     - DEVICE=android
     - START_EMU=1
-    - ANDROID_EMU_TARGET=android-24
+    - ANDROID_EMU_TARGET=android-19
     - ANDROID_EMU_NAME=test
     - ANDROID_EMU_ABI=armeabi-v7a
     - ANDROID_BUILD_TOOLS=27.0.3

--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ Note: this is an experimental work in progress and is not ready for use.
 ## Developers
 
 ### Building Espresso Server
-
+```
+npm run build:server
+```
+or
 ```
 cd espresso-server
 ./gradlew clean assembleDebug assembleAndroidTest

--- a/espresso-server/AndroidManifest-test.xml
+++ b/espresso-server/AndroidManifest-test.xml
@@ -6,7 +6,7 @@
           platformBuildVersionCode="25"
           platformBuildVersionName="7.1.1">
 
-    <uses-sdk android:minSdkVersion="21"
+    <uses-sdk android:minSdkVersion="19"
               android:targetSdkVersion="25" />
 
     <instrumentation android:functionalTest="false"

--- a/lib/espresso-runner.js
+++ b/lib/espresso-runner.js
@@ -94,13 +94,17 @@ class EspressoRunner {
     });
 
     await this.instProcess.start((stdout, stderr) => {
+      // for any call to the start detector, one of stdout or stderr will have
+      // content, so merge for checks here
+      const out = stdout.trim() || stderr.trim();
+
       // adb always prints this out on success. If this is found not to be the
       // case, add other conditions
-      if (stdout.includes('io.appium.espressoserver.EspressoServerRunnerTest:')) {
+      if (out.includes('io.appium.espressoserver.EspressoServerRunnerTest:')) {
         return true;
       }
-      if (stderr.includes('Exception')) {
-        throw new Error(stderr.trim());
+      if (out.toLowerCase().includes('exception')) {
+        throw new Error(out);
       }
     }, this.serverLaunchTimeout);
 

--- a/test/functional/commands/find-e2e-specs.js
+++ b/test/functional/commands/find-e2e-specs.js
@@ -1,40 +1,27 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import wd from 'wd';
-import { HOST, PORT, MOCHA_TIMEOUT } from '../helpers/session';
+import { initSession, deleteSession, MOCHA_TIMEOUT } from '../helpers/session';
 import { APIDEMO_CAPS } from '../desired';
-import { startServer } from '../../..';
 
 
 chai.should();
 chai.use(chaiAsPromised);
 
-describe('elementByXPath @skip-ci', function () {
+describe('elementByXPath', function () {
   this.timeout(MOCHA_TIMEOUT);
 
   let driver;
-  let server;
   before(async function () {
-    server = await startServer(PORT, HOST);
-    driver = wd.promiseChainRemote(HOST, PORT);
+    driver = await initSession(APIDEMO_CAPS);
   });
   after(async function () {
-    try {
-      await server.close();
-    } catch (ign) {}
-  });
-  beforeEach(async function () {
-    try {
-      await driver.init(APIDEMO_CAPS);
-    } catch (ign) {}
+    await deleteSession();
   });
   afterEach(async function () {
-    try {
-      await driver.quit();
-    } catch (ign) {}
+    await driver.back();
   });
 
-  it('should find an element by it\'s xpath', async function () {
+  it(`should find an element by it's xpath`, async function () {
     let el = await driver.elementByXPath("//*[@text='Animation']");
     el.should.exist;
     await el.click();
@@ -42,10 +29,12 @@ describe('elementByXPath @skip-ci', function () {
   it('should find multiple elements that match one xpath', async function () {
     let els = await driver.elementsByXPath('//android.widget.TextView');
     els.length.should.be.above(1);
+    await els[0].click();
   });
   it('should get the first element of an xpath that matches more than one element', async function () {
     let el = await driver.elementByXPath('//android.widget.TextView');
     el.should.exist;
+    await el.click();
   });
   it('should throw a stale element exception if clicking on element that does not exist', async function () {
     let el = await driver.elementByXPath("//*[@content-desc='Animation']");
@@ -56,6 +45,7 @@ describe('elementByXPath @skip-ci', function () {
     let el = await driver.elementByXPath("//*[@content-desc='Animation']");
     await el.isDisplayed().should.eventually.be.true;
     await el.isDisplayed().should.eventually.be.true;
+    await el.click();
   });
   it('should match an element if the element is off-screen but has an accessibility id', async function () {
     let el = await driver.elementByAccessibilityId('Views');

--- a/test/functional/commands/keyboard-e2e-specs.js
+++ b/test/functional/commands/keyboard-e2e-specs.js
@@ -7,7 +7,7 @@ import { APIDEMO_CAPS } from '../desired';
 chai.should();
 chai.use(chaiAsPromised);
 
-describe('keyboard @skip-ci', function () {
+describe('keyboard', function () {
   this.timeout(MOCHA_TIMEOUT);
 
   let driver;
@@ -24,12 +24,6 @@ describe('keyboard @skip-ci', function () {
   it('should send keys to the correct element', async function () {
     let el = await driver.elementByXPath('//android.widget.AutoCompleteTextView');
     await el.click();
-
-    try {
-      await el.click();
-    } catch (err) {
-      console.log(err); // eslint-disable-line
-    }
 
     await el.sendKeys('hello');
   });

--- a/test/functional/commands/move-to-e2e-specs.js
+++ b/test/functional/commands/move-to-e2e-specs.js
@@ -7,7 +7,9 @@ import { APIDEMO_CAPS } from '../desired';
 chai.should();
 chai.use(chaiAsPromised);
 
-describe('moveTo @skip-ci', function () {
+// TODO: what is this test supposed to do? finding an element in this driver
+// automatically scrolls to make it visible, so this test always fails
+describe.skip('moveTo', function () {
   this.timeout(MOCHA_TIMEOUT);
 
   let driver;

--- a/test/functional/commands/size-e2e-specs.js
+++ b/test/functional/commands/size-e2e-specs.js
@@ -1,37 +1,21 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import wd from 'wd';
-import { HOST, PORT, MOCHA_TIMEOUT } from '../helpers/session';
+import { initSession, deleteSession, MOCHA_TIMEOUT } from '../helpers/session';
 import { APIDEMO_CAPS } from '../desired';
-import { startServer } from '../../..';
 
 
 chai.should();
 chai.use(chaiAsPromised);
 
-describe('Size @skip-ci', function () {
+describe('Size', function () {
   this.timeout(MOCHA_TIMEOUT);
 
   let driver;
-  let server;
   before(async function () {
-    server = await startServer(PORT, HOST);
-    driver = wd.promiseChainRemote(HOST, PORT);
+    driver = await initSession(APIDEMO_CAPS);
   });
   after(async function () {
-    try {
-      await server.close();
-    } catch (ign) {}
-  });
-  beforeEach(async function () {
-    try {
-      await driver.init(APIDEMO_CAPS);
-    } catch (ign) {}
-  });
-  afterEach(async function () {
-    try {
-      await driver.quit();
-    } catch (ign) {}
+    await deleteSession();
   });
 
   it('should find size of window', async function () {

--- a/test/functional/commands/source-e2e-specs.js
+++ b/test/functional/commands/source-e2e-specs.js
@@ -1,54 +1,50 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import wd from 'wd';
-import path from 'path';
 import { DOMParser } from 'xmldom';
 import xpath from 'xpath';
-import { HOST, PORT, MOCHA_TIMEOUT } from '../helpers/session';
-import { APIDEMO_CAPS } from '../desired';
-import { startServer } from '../../..';
+import { initSession, deleteSession, MOCHA_TIMEOUT } from '../helpers/session';
+import { APIDEMO_CAPS, REACT_NATIVE_CAPS } from '../desired';
 
 
 chai.should();
 chai.use(chaiAsPromised);
 
-describe('source commands @skip-ci', function () {
+describe('source commands', function () {
   this.timeout(MOCHA_TIMEOUT);
 
   let driver;
-  let server;
-  before(async function () {
-    server = await startServer(PORT, HOST);
-  });
-  after(async function () {
-    try {
-      await server.close();
-    } catch (ign) {}
-  });
-  afterEach(async function () {
-    try {
-      await driver.quit();
-    } catch (ign) {}
-  });
-  it('should get sourceXML, parse it, and find a node by xpath', async function () {
-    driver = wd.promiseChainRemote(HOST, PORT);
-    await driver.init(APIDEMO_CAPS);
-    const sourceXML = await driver.source();
-    sourceXML.should.be.a.string;
-    const doc = new DOMParser().parseFromString(sourceXML, 'test/xml');
-    const node = xpath.select('//*[content-desc=Animation]', doc);
-    node.should.exist;
-  });
-  it('should get sourceXML from a react native app and have view-tag', async function () {
-    driver = wd.promiseChainRemote(HOST, PORT);
-    await driver.init({
-      ...APIDEMO_CAPS,
-      app: path.resolve(__dirname, '..', '..', 'assets', 'ReactNativeApp.apk'),
+  describe('regular app', function () {
+    before(async function () {
+      driver = await initSession(APIDEMO_CAPS);
     });
-    const sourceXML = await driver.source();
-    sourceXML.should.be.a.string;
-    const doc = new DOMParser().parseFromString(sourceXML, 'test/xml');
-    const node = xpath.select('//*[content-desc=Animation]', doc);
-    node.should.exist;
+    after(async function () {
+      await deleteSession();
+    });
+
+    it('should get sourceXML, parse it, and find a node by xpath', async function () {
+      const sourceXML = await driver.source();
+      sourceXML.should.be.a.string;
+      const doc = new DOMParser().parseFromString(sourceXML, 'test/xml');
+      const node = xpath.select('//*[content-desc=Animation]', doc);
+      node.should.exist;
+    });
+  });
+
+  // TODO: where is the app for this?
+  describe.skip('react native app', function () {
+    before(async function () {
+      driver = await initSession(REACT_NATIVE_CAPS);
+    });
+    after(async function () {
+      await deleteSession();
+    });
+
+    it('should get sourceXML with view-tags', async function () {
+      const sourceXML = await driver.source();
+      sourceXML.should.be.a.string;
+      const doc = new DOMParser().parseFromString(sourceXML, 'test/xml');
+      const node = xpath.select('//*[content-desc=Animation]', doc);
+      node.should.exist;
+    });
   });
 });

--- a/test/functional/desired.js
+++ b/test/functional/desired.js
@@ -8,6 +8,7 @@ const GENERIC_CAPS = {
   platformName: 'Android',
   forceEspressoRebuild: true,
   adbExecTimeout: process.env.CI ? 120000 : 20000,
+  espressoServerLaunchTimeout: process.env.CI ? 120000 : 30000,
 };
 
 const APIDEMO_CAPS = Object.assign({}, GENERIC_CAPS, {

--- a/test/functional/desired.js
+++ b/test/functional/desired.js
@@ -1,3 +1,4 @@
+import path from 'path';
 import gpsdemoApp from 'gps-demo-app';
 const apidemosApp = require.resolve('android-apidemos');
 
@@ -19,4 +20,8 @@ const GPS_CAPS = Object.assign({}, GENERIC_CAPS, {
   app: gpsdemoApp,
 });
 
-export { GENERIC_CAPS, APIDEMO_CAPS, GPS_CAPS };
+const REACT_NATIVE_CAPS = Object.assign({}, GENERIC_CAPS, {
+  app: path.resolve(__dirname, '..', '..', 'assets', 'ReactNativeApp.apk'),
+});
+
+export { GENERIC_CAPS, APIDEMO_CAPS, GPS_CAPS, REACT_NATIVE_CAPS };

--- a/test/functional/driver-e2e-specs.js
+++ b/test/functional/driver-e2e-specs.js
@@ -75,7 +75,7 @@ describe('EspressoDriver', function () {
       });
       it('should reject opening of appPackage with incorrect signature', async function () {
         await driver.init(Object.assign({
-          appPackage: 'com.android.settings'
+          appPackage: 'com.android.settings',
         }, APIDEMO_CAPS)).should.eventually.be.rejectedWith(/does not have a signature matching/i);
       });
     });


### PR DESCRIPTION
Un-quarantine, and clean up, all the tests except two:
1. [move-to](https://github.com/appium/appium-espresso-driver/blob/master/test/functional/commands/move-to-e2e-specs.js) - I can't figure out what this is supposed to do. But it doesn't work as written.
1. [react-native source](https://github.com/appium/appium-espresso-driver/blob/master/test/functional/commands/source-e2e-specs.js#L42-L53) - missing react native app as asset, which I presume is on the @dpgraham's computer, since he [added the test](https://github.com/appium/appium-espresso-driver/pull/125/files).