### PR TITLE
Run pointer move on main thread

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/BaseW3CActionAdapter.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/BaseW3CActionAdapter.java
@@ -2,6 +2,7 @@ package io.appium.espressoserver.lib.helpers.w3c.adapter;
 
 import java.util.concurrent.locks.ReentrantLock;
 
+import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
 import io.appium.espressoserver.lib.helpers.w3c.state.PointerInputState;
 
 public abstract class BaseW3CActionAdapter implements W3CActionAdapter {
@@ -51,8 +52,12 @@ public abstract class BaseW3CActionAdapter implements W3CActionAdapter {
         return 5;
     }
 
-    public void sleep(long duration) throws InterruptedException {
-        Thread.sleep(duration);
+    public void sleep(long duration) throws AppiumException {
+        try {
+            Thread.sleep(duration);
+        } catch (InterruptedException ie) {
+            throw new AppiumException(String.format("Could not run 'sleep' method: %s", ie.getCause()));
+        }
     }
 
     /**

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/EspressoW3CActionAdapter.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/EspressoW3CActionAdapter.java
@@ -13,6 +13,7 @@ import io.appium.espressoserver.lib.helpers.Logger;
 import io.appium.espressoserver.lib.helpers.w3c.dispatcher.KeyEvent;
 import io.appium.espressoserver.lib.helpers.w3c.models.InputSource;
 import io.appium.espressoserver.lib.helpers.w3c.state.KeyInputState;
+import io.appium.espressoserver.lib.model.AppiumParams;
 
 public class EspressoW3CActionAdapter extends BaseW3CActionAdapter {
 
@@ -86,7 +87,7 @@ public class EspressoW3CActionAdapter extends BaseW3CActionAdapter {
         //uiController.loopMainThreadUntilIdle();
     }
 
-    public void sleep(long duration) throws InterruptedException {
+    public void sleep(long duration) throws AppiumException {
         SystemClock.sleep(duration);
     }
     

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/EspressoW3CActionAdapter.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/EspressoW3CActionAdapter.java
@@ -13,7 +13,6 @@ import io.appium.espressoserver.lib.helpers.Logger;
 import io.appium.espressoserver.lib.helpers.w3c.dispatcher.KeyEvent;
 import io.appium.espressoserver.lib.helpers.w3c.models.InputSource;
 import io.appium.espressoserver.lib.helpers.w3c.state.KeyInputState;
-import io.appium.espressoserver.lib.model.AppiumParams;
 
 public class EspressoW3CActionAdapter extends BaseW3CActionAdapter {
 

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/W3CActionAdapter.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/W3CActionAdapter.java
@@ -11,6 +11,7 @@ import io.appium.espressoserver.lib.helpers.w3c.dispatcher.KeyEvent;
 import io.appium.espressoserver.lib.helpers.w3c.models.InputSource.PointerType;
 import io.appium.espressoserver.lib.helpers.w3c.state.KeyInputState;
 import io.appium.espressoserver.lib.helpers.w3c.state.PointerInputState;
+import io.appium.espressoserver.lib.model.AppiumParams;
 
 public interface W3CActionAdapter {
 
@@ -46,7 +47,7 @@ public interface W3CActionAdapter {
 
     int pointerMoveIntervalDuration();
 
-    void sleep(long duration) throws InterruptedException;
+    void sleep(long duration) throws AppiumException;
 
     void waitForUiThread();
 

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/W3CActionAdapter.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/W3CActionAdapter.java
@@ -11,7 +11,6 @@ import io.appium.espressoserver.lib.helpers.w3c.dispatcher.KeyEvent;
 import io.appium.espressoserver.lib.helpers.w3c.models.InputSource.PointerType;
 import io.appium.espressoserver.lib.helpers.w3c.state.KeyInputState;
 import io.appium.espressoserver.lib.helpers.w3c.state.PointerInputState;
-import io.appium.espressoserver.lib.model.AppiumParams;
 
 public interface W3CActionAdapter {
 

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/dispatcher/BaseDispatchResult.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/dispatcher/BaseDispatchResult.java
@@ -1,0 +1,23 @@
+package io.appium.espressoserver.lib.helpers.w3c.dispatcher;
+
+import java.util.concurrent.Callable;
+
+import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
+
+public abstract class BaseDispatchResult {
+
+    private Callable<BaseDispatchResult> next;
+    public boolean hasNext() {
+        return next != null;
+    }
+
+    public abstract void perform() throws AppiumException;
+
+    public Callable<BaseDispatchResult> getNext() {
+        return next;
+    }
+
+    public void setNext(Callable<BaseDispatchResult> next) {
+        this.next = next;
+    }
+}

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/dispatcher/BaseDispatchResult.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/dispatcher/BaseDispatchResult.java
@@ -2,6 +2,8 @@ package io.appium.espressoserver.lib.helpers.w3c.dispatcher;
 
 import java.util.concurrent.Callable;
 
+import javax.annotation.Nullable;
+
 import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
 
 public abstract class BaseDispatchResult {
@@ -13,6 +15,7 @@ public abstract class BaseDispatchResult {
 
     public abstract void perform() throws AppiumException;
 
+    @Nullable
     public Callable<BaseDispatchResult> getNext() {
         return next;
     }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/dispatcher/DispatchPointerMoveResult.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/dispatcher/DispatchPointerMoveResult.java
@@ -44,13 +44,6 @@ public class DispatchPointerMoveResult extends BaseDispatchResult {
         if (currentX != x || currentY != y) {
             dispatcherAdapter.pointerMove(sourceId, pointerType, currentX, currentY, x, y, buttons, globalKeyInputState);
         }
-        if (duration > 0) {
-            try {
-                dispatcherAdapter.sleep(dispatcherAdapter.pointerMoveIntervalDuration());
-            } catch (InterruptedException ie) {
-                throw new AppiumException(ie.getCause());
-            }
-        }
     }
 
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/dispatcher/DispatchPointerMoveResult.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/dispatcher/DispatchPointerMoveResult.java
@@ -18,7 +18,6 @@ public class DispatchPointerMoveResult extends BaseDispatchResult {
     private long y;
     private Set<Integer> buttons;
     private KeyInputState globalKeyInputState;
-    private long duration;
 
     public DispatchPointerMoveResult(final W3CActionAdapter dispatcherAdapter,
                                      final String sourceId,
@@ -26,8 +25,7 @@ public class DispatchPointerMoveResult extends BaseDispatchResult {
                                      final long currentX, final long currentY,
                                      final long x, final long y,
                                      final Set<Integer> buttons,
-                                     final KeyInputState globalKeyInputState,
-                                     final long duration) {
+                                     final KeyInputState globalKeyInputState) {
         this.dispatcherAdapter = dispatcherAdapter;
         this.sourceId = sourceId;
         this.pointerType = pointerType;
@@ -37,7 +35,6 @@ public class DispatchPointerMoveResult extends BaseDispatchResult {
         this.y = y;
         this.buttons = buttons;
         this.globalKeyInputState = globalKeyInputState;
-        this.duration = duration;
     }
 
     public void perform() throws AppiumException {

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/dispatcher/DispatchPointerMoveResult.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/dispatcher/DispatchPointerMoveResult.java
@@ -1,0 +1,56 @@
+package io.appium.espressoserver.lib.helpers.w3c.dispatcher;
+
+import java.util.Set;
+
+import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
+import io.appium.espressoserver.lib.helpers.w3c.adapter.W3CActionAdapter;
+import io.appium.espressoserver.lib.helpers.w3c.models.InputSource;
+import io.appium.espressoserver.lib.helpers.w3c.state.KeyInputState;
+
+public class DispatchPointerMoveResult extends BaseDispatchResult {
+
+    private W3CActionAdapter dispatcherAdapter;
+    private String sourceId;
+    private InputSource.PointerType pointerType;
+    private long currentX;
+    private long currentY;
+    private long x;
+    private long y;
+    private Set<Integer> buttons;
+    private KeyInputState globalKeyInputState;
+    private long duration;
+
+    public DispatchPointerMoveResult(final W3CActionAdapter dispatcherAdapter,
+                                     final String sourceId,
+                                     final InputSource.PointerType pointerType,
+                                     final long currentX, final long currentY,
+                                     final long x, final long y,
+                                     final Set<Integer> buttons,
+                                     final KeyInputState globalKeyInputState,
+                                     final long duration) {
+        this.dispatcherAdapter = dispatcherAdapter;
+        this.sourceId = sourceId;
+        this.pointerType = pointerType;
+        this.currentX = currentX;
+        this.currentY = currentY;
+        this.x = x;
+        this.y = y;
+        this.buttons = buttons;
+        this.globalKeyInputState = globalKeyInputState;
+        this.duration = duration;
+    }
+
+    public void perform() throws AppiumException {
+        if (currentX != x || currentY != y) {
+            dispatcherAdapter.pointerMove(sourceId, pointerType, currentX, currentY, x, y, buttons, globalKeyInputState);
+        }
+        if (duration > 0) {
+            try {
+                dispatcherAdapter.sleep(dispatcherAdapter.pointerMoveIntervalDuration());
+            } catch (InterruptedException ie) {
+                throw new AppiumException(ie.getCause());
+            }
+        }
+    }
+
+}

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/dispatcher/PointerDispatch.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/dispatcher/PointerDispatch.java
@@ -257,8 +257,7 @@ public class PointerDispatch {
                         sourceId, pointerInputState.getType(),
                         currentX, currentY, x, y,
                         pointerInputState.getButtons(),
-                        globalKeyInputState,
-                        duration
+                        globalKeyInputState
                 );
 
                 if (currentX != x || currentY != y) {
@@ -270,11 +269,7 @@ public class PointerDispatch {
 
                 // Sleep for a fixed period of time
                 if (duration > 0) {
-                    try {
-                        dispatcherAdapter.sleep(dispatcherAdapter.pointerMoveIntervalDuration());
-                    } catch (InterruptedException ie) {
-                        throw new AppiumException(ie.getCause());
-                    }
+                    dispatcherAdapter.sleep(dispatcherAdapter.pointerMoveIntervalDuration());
                 }
 
                 if (!isLast) {

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/dispatcher/PointerDispatch.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/dispatcher/PointerDispatch.java
@@ -268,6 +268,15 @@ public class PointerDispatch {
                     pointerInputState.setY(y);
                 }
 
+                // Sleep for a fixed period of time
+                if (duration > 0) {
+                    try {
+                        dispatcherAdapter.sleep(dispatcherAdapter.pointerMoveIntervalDuration());
+                    } catch (InterruptedException ie) {
+                        throw new AppiumException(ie.getCause());
+                    }
+                }
+
                 if (!isLast) {
                     // 11. Perform a pointer move with arguments source id, input state, duration, start x, start y, target x, target y)
                     dispatchResult.setNext(

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/models/ActionObject.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/models/ActionObject.java
@@ -7,6 +7,7 @@ import javax.annotation.Nullable;
 import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
 import io.appium.espressoserver.lib.handlers.exceptions.InvalidArgumentException;
 import io.appium.espressoserver.lib.helpers.w3c.adapter.W3CActionAdapter;
+import io.appium.espressoserver.lib.helpers.w3c.dispatcher.BaseDispatchResult;
 import io.appium.espressoserver.lib.helpers.w3c.models.InputSource.ActionType;
 import io.appium.espressoserver.lib.helpers.w3c.models.InputSource.InputSourceType;
 import io.appium.espressoserver.lib.helpers.w3c.models.InputSource.PointerType;
@@ -73,9 +74,9 @@ public class ActionObject {
      * @throws AppiumException
      */
     @Nullable
-    public Callable<Void> dispatch(W3CActionAdapter adapter,
-                             InputStateTable inputStateTable,
-                             long tickDuration, long timeAtBeginningOfTick) throws AppiumException {
+    public Callable<BaseDispatchResult> dispatch(W3CActionAdapter adapter,
+                                                 InputStateTable inputStateTable,
+                                                 long tickDuration, long timeAtBeginningOfTick) throws AppiumException {
         InputSourceType inputSourceType = this.getType();
         ActionType actionType = this.getSubType();
         adapter.getLogger().info(String.format(

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/models/Tick.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/models/Tick.java
@@ -7,6 +7,7 @@ import java.util.concurrent.Callable;
 
 import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
 import io.appium.espressoserver.lib.helpers.w3c.adapter.W3CActionAdapter;
+import io.appium.espressoserver.lib.helpers.w3c.dispatcher.BaseDispatchResult;
 import io.appium.espressoserver.lib.helpers.w3c.models.InputSource.ActionType;
 import io.appium.espressoserver.lib.helpers.w3c.models.InputSource.InputSourceType;
 import io.appium.espressoserver.lib.helpers.w3c.state.InputStateTable;
@@ -62,13 +63,13 @@ public class Tick implements Iterator<ActionObject> {
         return maxDuration;
     }
 
-    public List<Callable<Void>> dispatchAll(W3CActionAdapter adapter, InputStateTable inputStateTable, long tickDuration)
+    public List<Callable<BaseDispatchResult>> dispatchAll(W3CActionAdapter adapter, InputStateTable inputStateTable, long tickDuration)
             throws AppiumException {
         long timeAtBeginningOfTick = System.currentTimeMillis();
-        List<Callable<Void>> asyncOperations = new ArrayList<>();
+        List<Callable<BaseDispatchResult>> asyncOperations = new ArrayList<>();
         for(ActionObject actionObject: tickActions) {
             // 2. Run algorithm with arguments source id, action object, device state and tick duration
-            Callable<Void> dispatchResult = actionObject.dispatch(adapter,
+            Callable<BaseDispatchResult> dispatchResult = actionObject.dispatch(adapter,
                     inputStateTable, tickDuration, timeAtBeginningOfTick);
 
             // If it's an async operation, add it to the list

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/state/InputStateTable.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/state/InputStateTable.java
@@ -6,10 +6,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import io.appium.espressoserver.lib.helpers.w3c.models.ActionObject;
-
 import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
 import io.appium.espressoserver.lib.helpers.w3c.adapter.W3CActionAdapter;
+import io.appium.espressoserver.lib.helpers.w3c.models.ActionObject;
 
 /**
  * Keep the state of all active input sources

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Server.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Server.java
@@ -41,7 +41,7 @@ public class Server extends NanoHTTPD {
     private static final int DEFAULT_PORT = 8080;
 
     public Server() throws IOException, DuplicateRouteException {
-        super(DEFAULT_PORT); // TODO: Get this from an environment variable
+        super(DEFAULT_PORT);
         start(NanoHTTPD.SOCKET_READ_TIMEOUT, false);
         logger.info(String.format("\nRunning Appium Espresso Server at port %d \n", DEFAULT_PORT));
         router = new Router();

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/viewaction/ViewGetter.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/viewaction/ViewGetter.java
@@ -82,6 +82,4 @@ public class ViewGetter {
         viewInteraction.perform(new GetViewAction());
         return views[0];
     }
-
-    // TODO. getUiController()
 }

--- a/espresso-server/app/src/test/java/io/appium/espressoserver/test/helpers/w3c/TickTest.java
+++ b/espresso-server/app/src/test/java/io/appium/espressoserver/test/helpers/w3c/TickTest.java
@@ -17,6 +17,7 @@ import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
 import io.appium.espressoserver.lib.handlers.exceptions.InvalidArgumentException;
 import io.appium.espressoserver.lib.helpers.w3c.adapter.DummyW3CActionAdapter;
 import io.appium.espressoserver.lib.helpers.w3c.adapter.W3CActionAdapter;
+import io.appium.espressoserver.lib.helpers.w3c.dispatcher.BaseDispatchResult;
 import io.appium.espressoserver.lib.helpers.w3c.models.ActionObject;
 import io.appium.espressoserver.lib.helpers.w3c.models.InputSource.PointerType;
 import io.appium.espressoserver.lib.helpers.w3c.models.Origin;
@@ -224,16 +225,16 @@ public class TickTest {
 
         final W3CActionAdapter dummyAdapter = new ExtendedDummyW3CActionAdapter();
 
-        List<Callable<Void>> callables = tick.dispatchAll(dummyAdapter, inputStateTable, tick.calculateTickDuration());
+        List<Callable<BaseDispatchResult>> callables = tick.dispatchAll(dummyAdapter, inputStateTable, tick.calculateTickDuration());
         Executor executor = Executors.newFixedThreadPool(callables.size());
-        CompletionService<Void> completionService = new ExecutorCompletionService<>(executor);
-        for(Callable<Void> callable:callables) {
+        CompletionService<BaseDispatchResult> completionService = new ExecutorCompletionService<>(executor);
+        for(Callable<BaseDispatchResult> callable:callables) {
             completionService.submit(callable);
         }
 
         int received = 0;
         while (received < callables.size()) {
-            Future<Void> resultFuture = completionService.take(); //blocks if none available
+            Future<BaseDispatchResult> resultFuture = completionService.take(); //blocks if none available
             resultFuture.get();
             received ++;
         }


### PR DESCRIPTION
* Pointer move events were being called on a separate thread, which Espresso doesn't allow (must be main thread)
* Updated the logic so that the callable returns a class that has a `perform` method that gets called
* The perform method gets called on the main thread instead of on the thread