### PR TITLE
Add touch/ and touch/multi endpoints

### DIFF
--- a/espresso-server/app/build.gradle
+++ b/espresso-server/app/build.gradle
@@ -34,6 +34,10 @@ dependencies {
     implementation 'xalan:xalan:2.7.2'
 
     testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-core:2.8.9'
+    testImplementation 'org.powermock:powermock-mockito-release-full:1.5.4'
+    testImplementation 'org.powermock:powermock-api-mockito:1.6.1'
+    testImplementation 'org.powermock:powermock-module-junit4:1.6.1'
     testImplementation('com.android.support.test.espresso:espresso-core:3.0.1', {
         exclude group: 'com.android.support'
         exclude group: 'com.android.support', module: 'appcompat'

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/MultiTouchAction.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/MultiTouchAction.java
@@ -1,0 +1,36 @@
+package io.appium.espressoserver.lib.handlers;
+
+import android.support.test.espresso.UiController;
+
+import java.util.List;
+
+import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
+import io.appium.espressoserver.lib.helpers.w3c.adapter.espresso.EspressoW3CActionAdapter;
+import io.appium.espressoserver.lib.helpers.w3c.models.Actions;
+import io.appium.espressoserver.lib.helpers.w3c.models.InputSource;
+import io.appium.espressoserver.lib.viewaction.UiControllerPerformer;
+import io.appium.espressoserver.lib.viewaction.UiControllerRunnable;
+
+import static io.appium.espressoserver.lib.model.TouchAction.toW3CInputSources;
+
+public class MultiTouchAction implements RequestHandler<MultiTouchActionsParams, Void> {
+
+    @Override
+    public Void handle(final MultiTouchActionsParams params) throws AppiumException {
+        UiControllerRunnable<Void> runnable = new UiControllerRunnable<Void>() {
+            @Override
+            public Void run(UiController uiController) throws AppiumException {
+                List<InputSource> inputSources = toW3CInputSources(params.getActions());
+                new Actions.ActionsBuilder()
+                        .withAdapter(new EspressoW3CActionAdapter(uiController))
+                        .withActions(inputSources)
+                        .build()
+                        .performActions(params.getSessionId());
+                return null;
+            }
+        };
+
+        new UiControllerPerformer<>(runnable).run();
+        return null;
+    }
+}

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/MultiTouchActionsParams.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/MultiTouchActionsParams.java
@@ -1,0 +1,19 @@
+package io.appium.espressoserver.lib.handlers;
+
+import java.util.List;
+
+import io.appium.espressoserver.lib.model.AppiumParams;
+import io.appium.espressoserver.lib.model.TouchAction;
+
+public class MultiTouchActionsParams extends AppiumParams {
+
+    private List<List<TouchAction>> actions;
+
+    public List<List<TouchAction>> getActions() {
+        return actions;
+    }
+
+    public void setActions(List<List<TouchAction>> actions) {
+        this.actions = actions;
+    }
+}

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/MultiTouchActionsParams.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/MultiTouchActionsParams.java
@@ -13,7 +13,7 @@ public class MultiTouchActionsParams extends AppiumParams {
         return actions;
     }
 
-    public void setActions(List<List<TouchAction>> actions) {
+    public void setActions(final List<List<TouchAction>> actions) {
         this.actions = actions;
     }
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/TouchAction.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/TouchAction.java
@@ -2,6 +2,7 @@ package io.appium.espressoserver.lib.handlers;
 
 import android.support.test.espresso.UiController;
 
+import java.util.Collections;
 import java.util.List;
 
 import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
@@ -13,21 +14,21 @@ import io.appium.espressoserver.lib.viewaction.UiControllerRunnable;
 
 import static io.appium.espressoserver.lib.model.TouchAction.toW3CInputSources;
 
-public class MultiTouchAction implements RequestHandler<MultiTouchActionsParams, Void> {
+public class TouchAction implements RequestHandler<TouchActionsParams, Void> {
 
     @Override
-    public Void handle(final MultiTouchActionsParams params) throws AppiumException {
+    public Void handle(final TouchActionsParams params) throws AppiumException {
         UiControllerRunnable<Void> runnable = new UiControllerRunnable<Void>() {
             @Override
             public Void run(UiController uiController) throws AppiumException {
-                List<InputSource> inputSources = toW3CInputSources(params.getActions());
+                List<InputSource> inputSources = toW3CInputSources(Collections.singletonList(params.getActions()));
                 Actions actions = new Actions.ActionsBuilder()
                         .withAdapter(new EspressoW3CActionAdapter(uiController))
                         .withActions(inputSources)
                         .build();
-
                 actions.perform(params.getSessionId());
                 actions.release(params.getSessionId());
+
                 return null;
             }
         };

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/TouchAction.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/TouchAction.java
@@ -8,6 +8,7 @@ import java.util.List;
 import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
 import io.appium.espressoserver.lib.helpers.w3c.adapter.espresso.EspressoW3CActionAdapter;
 import io.appium.espressoserver.lib.helpers.w3c.models.Actions;
+import io.appium.espressoserver.lib.helpers.w3c.models.Actions.ActionsBuilder;
 import io.appium.espressoserver.lib.helpers.w3c.models.InputSource;
 import io.appium.espressoserver.lib.viewaction.UiControllerPerformer;
 import io.appium.espressoserver.lib.viewaction.UiControllerRunnable;
@@ -22,7 +23,7 @@ public class TouchAction implements RequestHandler<TouchActionsParams, Void> {
             @Override
             public Void run(UiController uiController) throws AppiumException {
                 List<InputSource> inputSources = toW3CInputSources(Collections.singletonList(params.getActions()));
-                Actions actions = new Actions.ActionsBuilder()
+                Actions actions = new ActionsBuilder()
                         .withAdapter(new EspressoW3CActionAdapter(uiController))
                         .withActions(inputSources)
                         .build();

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/TouchActionsParams.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/TouchActionsParams.java
@@ -1,0 +1,19 @@
+package io.appium.espressoserver.lib.handlers;
+
+import java.util.List;
+
+import io.appium.espressoserver.lib.model.AppiumParams;
+import io.appium.espressoserver.lib.model.TouchAction;
+
+public class TouchActionsParams extends AppiumParams {
+
+    private List<TouchAction> actions;
+
+    public List<TouchAction> getActions() {
+        return actions;
+    }
+
+    public void setActions(List<TouchAction> actions) {
+        this.actions = actions;
+    }
+}

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/espresso/AndroidMotionEvent.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/espresso/AndroidMotionEvent.java
@@ -27,12 +27,12 @@ public class AndroidMotionEvent {
         this.uiController = uiController;
     }
 
-    public MotionEvent pointerUpOrDown(List<Long> x, List<Long> y,
-                                       int action,
-                                       Integer button, PointerType pointerType,
-                                       final KeyInputState globalKeyInputState,
-                                       final MotionEvent downEvent,
-                                       final long eventTime)
+    public MotionEvent pointerUpOrDownOrCancel(List<Long> x, List<Long> y,
+                                               int action,
+                                               Integer button, PointerType pointerType,
+                                               final KeyInputState globalKeyInputState,
+                                               final MotionEvent downEvent,
+                                               final long eventTime)
             throws AppiumException {
 
         int metaState = getMetaState(globalKeyInputState);
@@ -76,7 +76,6 @@ public class AndroidMotionEvent {
     }
 
     public void pointerCancel(List<Long> x, List<Long> y) throws AppiumException {
-
         (new MotionEventBuilder())
                 .withAction(ACTION_CANCEL)
                 .withDownTime(downTime)

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/espresso/AndroidMotionEvent.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/espresso/AndroidMotionEvent.java
@@ -27,12 +27,12 @@ public class AndroidMotionEvent {
         this.uiController = uiController;
     }
 
-    public MotionEvent pointerUpOrDownOrCancel(List<Long> x, List<Long> y,
-                                               int action,
-                                               Integer button, PointerType pointerType,
-                                               final KeyInputState globalKeyInputState,
-                                               final MotionEvent downEvent,
-                                               final long eventTime)
+    public MotionEvent pointerEvent(List<Long> x, List<Long> y,
+                                    int action,
+                                    Integer button, PointerType pointerType,
+                                    final KeyInputState globalKeyInputState,
+                                    final MotionEvent downEvent,
+                                    final long eventTime)
             throws AppiumException {
 
         int metaState = getMetaState(globalKeyInputState);

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/espresso/EspressoW3CActionAdapter.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/espresso/EspressoW3CActionAdapter.java
@@ -338,8 +338,8 @@ public class EspressoW3CActionAdapter extends BaseW3CActionAdapter {
     }
 
     public void sychronousTickActionsComplete() throws AppiumException {
-        AndroidLogger.logger.info("Pointer event: Tick complete");
         multiTouchState.perform(uiController);
+        AndroidLogger.logger.info("Pointer event: Tick complete");
     }
 
     public int getKeyCode(String keyValue, int location) throws AppiumException {
@@ -483,7 +483,7 @@ public class EspressoW3CActionAdapter extends BaseW3CActionAdapter {
     }
 
     public void sleep(long duration) throws AppiumException {
-        SystemClock.sleep(duration);
+        uiController.loopMainThreadForAtLeast(duration);
     }
     
     public Logger getLogger() {

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/espresso/EspressoW3CActionAdapter.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/espresso/EspressoW3CActionAdapter.java
@@ -288,11 +288,11 @@ public class EspressoW3CActionAdapter extends BaseW3CActionAdapter {
             AndroidMotionEvent androidMotionEvent = AndroidMotionEvent.getMotionEvent(sourceId, uiController);
             List<Long> xList = Collections.singletonList(x);
             List<Long> yList = Collections.singletonList(y);
-            androidMotionEvent.pointerUpOrDownOrCancel(
+            androidMotionEvent.pointerEvent(
                     xList, yList,
                     ACTION_DOWN, button, pointerType, globalKeyInputState, null, 0);
 
-            androidMotionEvent.pointerUpOrDownOrCancel(
+            androidMotionEvent.pointerEvent(
                     xList, yList,
                     ACTION_POINTER_DOWN, button, pointerType, globalKeyInputState, null, 0);
         }
@@ -309,9 +309,9 @@ public class EspressoW3CActionAdapter extends BaseW3CActionAdapter {
             List<Long> xList = Collections.singletonList(x);
             List<Long> yList = Collections.singletonList(y);
             AndroidMotionEvent androidMotionEvent = AndroidMotionEvent.getMotionEvent(sourceId, uiController);
-            androidMotionEvent.pointerUpOrDownOrCancel(xList, yList,
+            androidMotionEvent.pointerEvent(xList, yList,
                     ACTION_POINTER_UP, button, pointerType, globalKeyInputState, null, 0);
-            androidMotionEvent.pointerUpOrDownOrCancel(xList, yList,
+            androidMotionEvent.pointerEvent(xList, yList,
                     ACTION_UP, button, pointerType, globalKeyInputState, null, 0);
         }
     }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/espresso/EspressoW3CActionAdapter.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/espresso/EspressoW3CActionAdapter.java
@@ -288,11 +288,11 @@ public class EspressoW3CActionAdapter extends BaseW3CActionAdapter {
             AndroidMotionEvent androidMotionEvent = AndroidMotionEvent.getMotionEvent(sourceId, uiController);
             List<Long> xList = Collections.singletonList(x);
             List<Long> yList = Collections.singletonList(y);
-            androidMotionEvent.pointerUpOrDown(
+            androidMotionEvent.pointerUpOrDownOrCancel(
                     xList, yList,
                     ACTION_DOWN, button, pointerType, globalKeyInputState, null, 0);
 
-            androidMotionEvent.pointerUpOrDown(
+            androidMotionEvent.pointerUpOrDownOrCancel(
                     xList, yList,
                     ACTION_POINTER_DOWN, button, pointerType, globalKeyInputState, null, 0);
         }
@@ -309,9 +309,9 @@ public class EspressoW3CActionAdapter extends BaseW3CActionAdapter {
             List<Long> xList = Collections.singletonList(x);
             List<Long> yList = Collections.singletonList(y);
             AndroidMotionEvent androidMotionEvent = AndroidMotionEvent.getMotionEvent(sourceId, uiController);
-            androidMotionEvent.pointerUpOrDown(xList, yList,
+            androidMotionEvent.pointerUpOrDownOrCancel(xList, yList,
                     ACTION_POINTER_UP, button, pointerType, globalKeyInputState, null, 0);
-            androidMotionEvent.pointerUpOrDown(xList, yList,
+            androidMotionEvent.pointerUpOrDownOrCancel(xList, yList,
                     ACTION_UP, button, pointerType, globalKeyInputState, null, 0);
         }
     }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/espresso/MultiTouchState.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/espresso/MultiTouchState.java
@@ -14,6 +14,7 @@ import javax.annotation.Nullable;
 import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
 import io.appium.espressoserver.lib.helpers.w3c.state.KeyInputState;
 
+import static android.view.MotionEvent.ACTION_CANCEL;
 import static android.view.MotionEvent.ACTION_DOWN;
 import static android.view.MotionEvent.ACTION_POINTER_DOWN;
 import static android.view.MotionEvent.ACTION_POINTER_UP;
@@ -95,12 +96,12 @@ public class MultiTouchState {
         Long eventTime = SystemClock.uptimeMillis();
         List<Long> xCoords = getXCoords();
         List<Long> yCoords = getYCoords();
-        this.downEvent = androidMotionEvent.pointerUpOrDown(
+        this.downEvent = androidMotionEvent.pointerUpOrDownOrCancel(
                 xCoords, yCoords,
                 ACTION_DOWN, this.button, TOUCH, this.globalKeyInputState, null, eventTime);
 
         if (xCoords.size() > 1) {
-            androidMotionEvent.pointerUpOrDown(xCoords, yCoords,
+            androidMotionEvent.pointerUpOrDownOrCancel(xCoords, yCoords,
                     ACTION_POINTER_DOWN, this.button, TOUCH, this.globalKeyInputState, downEvent, eventTime);
         }
 
@@ -112,12 +113,12 @@ public class MultiTouchState {
         List<Long> xCoords = getXCoords();
         List<Long> yCoords = getYCoords();
         if (xCoords.size() > 1) {
-            androidMotionEvent.pointerUpOrDown(
+            androidMotionEvent.pointerUpOrDownOrCancel(
                     xCoords, yCoords,
                     ACTION_POINTER_UP, this.button, TOUCH, this.globalKeyInputState, downEvent, eventTime);
         }
 
-        androidMotionEvent.pointerUpOrDown(
+        androidMotionEvent.pointerUpOrDownOrCancel(
                 xCoords, yCoords,
                 ACTION_UP, this.button, TOUCH, this.globalKeyInputState, downEvent, eventTime);
 
@@ -127,7 +128,10 @@ public class MultiTouchState {
     public void pointerCancel(UiController uiController) throws AppiumException {
         List<Long> xCoords = getXCoords();
         List<Long> yCoords = getYCoords();
-        AndroidMotionEvent.getTouchMotionEvent(uiController).pointerCancel(xCoords, yCoords);
+        AndroidMotionEvent.getTouchMotionEvent(uiController).pointerUpOrDownOrCancel(
+                xCoords, yCoords,
+                ACTION_CANCEL, this.button, TOUCH, this.globalKeyInputState, downEvent, SystemClock.uptimeMillis()
+        );
         this.downEvent = null;
         touchPhase = NONE;
     }
@@ -157,6 +161,6 @@ public class MultiTouchState {
     public enum TouchPhase {
         DOWN,
         UP,
-        NONE;
+        NONE
     }
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/espresso/MultiTouchState.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/espresso/MultiTouchState.java
@@ -96,12 +96,12 @@ public class MultiTouchState {
         Long eventTime = SystemClock.uptimeMillis();
         List<Long> xCoords = getXCoords();
         List<Long> yCoords = getYCoords();
-        this.downEvent = androidMotionEvent.pointerUpOrDownOrCancel(
+        this.downEvent = androidMotionEvent.pointerEvent(
                 xCoords, yCoords,
                 ACTION_DOWN, this.button, TOUCH, this.globalKeyInputState, null, eventTime);
 
         if (xCoords.size() > 1) {
-            androidMotionEvent.pointerUpOrDownOrCancel(xCoords, yCoords,
+            androidMotionEvent.pointerEvent(xCoords, yCoords,
                     ACTION_POINTER_DOWN, this.button, TOUCH, this.globalKeyInputState, downEvent, eventTime);
         }
 
@@ -113,12 +113,12 @@ public class MultiTouchState {
         List<Long> xCoords = getXCoords();
         List<Long> yCoords = getYCoords();
         if (xCoords.size() > 1) {
-            androidMotionEvent.pointerUpOrDownOrCancel(
+            androidMotionEvent.pointerEvent(
                     xCoords, yCoords,
                     ACTION_POINTER_UP, this.button, TOUCH, this.globalKeyInputState, downEvent, eventTime);
         }
 
-        androidMotionEvent.pointerUpOrDownOrCancel(
+        androidMotionEvent.pointerEvent(
                 xCoords, yCoords,
                 ACTION_UP, this.button, TOUCH, this.globalKeyInputState, downEvent, eventTime);
 
@@ -128,7 +128,7 @@ public class MultiTouchState {
     public void pointerCancel(UiController uiController) throws AppiumException {
         List<Long> xCoords = getXCoords();
         List<Long> yCoords = getYCoords();
-        AndroidMotionEvent.getTouchMotionEvent(uiController).pointerUpOrDownOrCancel(
+        AndroidMotionEvent.getTouchMotionEvent(uiController).pointerEvent(
                 xCoords, yCoords,
                 ACTION_CANCEL, this.button, TOUCH, this.globalKeyInputState, downEvent, SystemClock.uptimeMillis()
         );

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/dispatcher/PointerDispatch.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/dispatcher/PointerDispatch.java
@@ -287,7 +287,7 @@ public class PointerDispatch {
 
                 // Sleep for a fixed period of time
                 if (duration > 0) {
-                    dispatcherAdapter.sleep(dispatcherAdapter.pointerMoveIntervalDuration());
+                    Thread.sleep(dispatcherAdapter.pointerMoveIntervalDuration());
                 }
 
                 if (!isLast) {

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/dispatcher/PointerDispatch.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/dispatcher/PointerDispatch.java
@@ -44,7 +44,6 @@ public class PointerDispatch {
         }
         Long x = pointerInputState.getX();
         Long y = pointerInputState.getY();
-        // TODO: Do cancel list stuff
         if (down) {
             pointerInputState.addPressed(button);
         } else {

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/dispatcher/PointerDispatch.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/dispatcher/PointerDispatch.java
@@ -168,7 +168,7 @@ public class PointerDispatch {
         if (originType == null) {
             originType = VIEWPORT;
         }
-        dispatcherAdapter.getLogger().info("Element type is: ", originType);
+        dispatcherAdapter.getLogger().info("Origin type is: ", originType);
         switch (origin.getType()) {
             case POINTER:
                 x = startX + xOffset;

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/models/ActionObject.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/models/ActionObject.java
@@ -139,6 +139,10 @@ public class ActionObject {
                         );
                         return null;
                     default:
+                        adapter.getLogger().info(String.format(
+                                "Dispatching pause event for %s milliseconds",
+                                getDuration()
+                        ));
                         break;
                 }
             }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/models/ActionSequence.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/models/ActionSequence.java
@@ -81,7 +81,7 @@ public class ActionSequence implements Iterator<Tick> {
             // 1. Dispatch all of the events
             adapter.getLogger().info(String.format(
                     "Dispatching tick #%s of %s",
-                    tickIndex, ticks.size()
+                    tickIndex + 1, ticks.size()
             ));
             List<Callable<BaseDispatchResult>> callables = tick.dispatchAll(adapter, inputStateTable, tickDuration);
             int callableCount = callables.size();
@@ -114,7 +114,9 @@ public class ActionSequence implements Iterator<Tick> {
             //  2.2 At least tick duration milliseconds have passed
             long timeSinceBeginningOfTick = System.currentTimeMillis() - timeAtBeginningOfTick;
             if (timeSinceBeginningOfTick < tickDuration) {
-                adapter.sleep(tickDuration - timeSinceBeginningOfTick);
+                long timeToSleep = tickDuration - timeSinceBeginningOfTick;
+                adapter.getLogger().info(String.format("Wait for tick to finish for %s ms", timeToSleep));
+                adapter.sleep(timeToSleep);
             }
 
             // 2.3 The UI thread is complete

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/models/Actions.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/models/Actions.java
@@ -74,7 +74,7 @@ public class Actions extends AppiumParams {
         InputStateTable inputStateTable = InputStateTable.getInputStateTableOfSession(sessionId);
 
         // Undo all actions
-        adapter.getLogger().info("Releasing actions performed during session %s");
+        adapter.getLogger().info(String.format("Releasing actions performed during session %s", sessionId));
         inputStateTable.undoAll(adapter, System.currentTimeMillis());
     }
 

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/models/InputSource.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/models/InputSource.java
@@ -311,6 +311,11 @@ public class InputSource {
             return this;
         }
 
+        public ActionBuilder withOrigin(Origin origin) {
+            this.origin = origin;
+            return this;
+        }
+
         public ActionBuilder withOrigin(String originType) {
             this.origin.setType(originType);
             return this;

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/models/InputSource.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/models/InputSource.java
@@ -316,6 +316,12 @@ public class InputSource {
             return this;
         }
 
+        public ActionBuilder withElementId(String elementId) {
+            this.origin.setType(InputSource.ELEMENT);
+            this.origin.setElementId(elementId);
+            return this;
+        }
+
         public Action build() {
             Action action = new Action();
             if (duration != null) {

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/processor/PointerProcessor.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/processor/PointerProcessor.java
@@ -131,12 +131,10 @@ public class PointerProcessor {
 
         // 8-10 Add the X coordinate
         Long x = action.getX();
-        assertNullOrPositive(index, id, "x", x);
         actionObject.setX(x);
 
         // 11-14 Add the Y coordinate
         Long y = action.getY();
-        assertNullOrPositive(index, id, "y", y);
         actionObject.setY(y);
 
         return actionObject;

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/state/InputStateTable.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/state/InputStateTable.java
@@ -88,10 +88,10 @@ public class InputStateTable {
         for (ActionObject actionObject:cancelList) {
             actionObject.dispatch(adapter, this, 0, timeAtBeginningOfTick);
         }
+        adapter.sychronousTickActionsComplete();
 
         // Clear the cancel list now that the Undo operations are all fulfilled
         cancelList.clear();
-        adapter.sychronousTickActionsComplete();
     }
 
 

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/state/InputStateTable.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/state/InputStateTable.java
@@ -91,6 +91,7 @@ public class InputStateTable {
 
         // Clear the cancel list now that the Undo operations are all fulfilled
         cancelList.clear();
+        adapter.sychronousTickActionsComplete();
     }
 
 

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.java
@@ -52,6 +52,8 @@ import io.appium.espressoserver.lib.handlers.GetSize;
 import io.appium.espressoserver.lib.handlers.GetWindowRect;
 import io.appium.espressoserver.lib.handlers.GetWindowSize;
 import io.appium.espressoserver.lib.handlers.Keys;
+import io.appium.espressoserver.lib.handlers.MultiTouchAction;
+import io.appium.espressoserver.lib.handlers.MultiTouchActionsParams;
 import io.appium.espressoserver.lib.handlers.NotYetImplemented;
 import io.appium.espressoserver.lib.handlers.PeformActions;
 import io.appium.espressoserver.lib.handlers.PointerEventHandler;
@@ -178,7 +180,7 @@ class Router {
         // Not implemented
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/touch/flick", new NotYetImplemented(), AppiumParams.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/touch/perform", new NotYetImplemented(), AppiumParams.class));
-        routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/touch/multi/perform", new NotYetImplemented(), AppiumParams.class));
+        routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/touch/multi/perform", new MultiTouchAction(), MultiTouchActionsParams.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/alert_text", new NotYetImplemented(), AppiumParams.class));
 
         // Probably will never implement

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.java
@@ -67,6 +67,8 @@ import io.appium.espressoserver.lib.handlers.Source;
 import io.appium.espressoserver.lib.handlers.StartActivity;
 import io.appium.espressoserver.lib.handlers.Status;
 import io.appium.espressoserver.lib.handlers.Text;
+import io.appium.espressoserver.lib.handlers.TouchAction;
+import io.appium.espressoserver.lib.handlers.TouchActionsParams;
 import io.appium.espressoserver.lib.handlers.exceptions.InvalidArgumentException;
 import io.appium.espressoserver.lib.handlers.exceptions.InvalidElementStateException;
 import io.appium.espressoserver.lib.handlers.exceptions.InvalidStrategyException;
@@ -94,18 +96,7 @@ import io.appium.espressoserver.lib.model.SessionParams;
 import io.appium.espressoserver.lib.model.StartActivityParams;
 import io.appium.espressoserver.lib.model.TextParams;
 
-import static io.appium.espressoserver.lib.handlers.PointerEventHandler.TouchType.CLICK;
-import static io.appium.espressoserver.lib.handlers.PointerEventHandler.TouchType.DOUBLE_CLICK;
-import static io.appium.espressoserver.lib.handlers.PointerEventHandler.TouchType.LONG_CLICK;
-import static io.appium.espressoserver.lib.handlers.PointerEventHandler.TouchType.MOUSE_CLICK;
-import static io.appium.espressoserver.lib.handlers.PointerEventHandler.TouchType.MOUSE_DOUBLECLICK;
-import static io.appium.espressoserver.lib.handlers.PointerEventHandler.TouchType.MOUSE_DOWN;
-import static io.appium.espressoserver.lib.handlers.PointerEventHandler.TouchType.MOUSE_MOVE;
-import static io.appium.espressoserver.lib.handlers.PointerEventHandler.TouchType.MOUSE_UP;
-import static io.appium.espressoserver.lib.handlers.PointerEventHandler.TouchType.TOUCH_DOWN;
-import static io.appium.espressoserver.lib.handlers.PointerEventHandler.TouchType.TOUCH_MOVE;
-import static io.appium.espressoserver.lib.handlers.PointerEventHandler.TouchType.TOUCH_SCROLL;
-import static io.appium.espressoserver.lib.handlers.PointerEventHandler.TouchType.TOUCH_UP;
+import static io.appium.espressoserver.lib.handlers.PointerEventHandler.TouchType.*;
 import static io.appium.espressoserver.lib.helpers.AndroidLogger.logger;
 import static io.appium.espressoserver.lib.helpers.StringHelpers.abbreviate;
 
@@ -176,11 +167,11 @@ class Router {
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/moveto", new PointerEventHandler(MOUSE_MOVE), MotionEventParams.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/click", new PointerEventHandler(MOUSE_CLICK), AppiumParams.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/doubleclick", new PointerEventHandler(MOUSE_DOUBLECLICK), AppiumParams.class));
+        routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/touch/perform", new TouchAction(), TouchActionsParams.class));
+        routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/touch/multi/perform", new MultiTouchAction(), MultiTouchActionsParams.class));
 
         // Not implemented
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/touch/flick", new NotYetImplemented(), AppiumParams.class));
-        routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/touch/perform", new NotYetImplemented(), AppiumParams.class));
-        routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/touch/multi/perform", new MultiTouchAction(), MultiTouchActionsParams.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/alert_text", new NotYetImplemented(), AppiumParams.class));
 
         // Probably will never implement

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/TouchAction.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/TouchAction.java
@@ -87,6 +87,11 @@ public class TouchAction {
         }
 
         // All touch actions map to 3 actions
+        // For multi-touch actions we need each event to happen synchronously with eachother
+
+        // e.g.) if one input calls press (which maps to move + down + wait) and another input is
+        // calling pause (which maps to wait) we need to add two no-ops to the wait event so that it
+        // doesn't prematurely advance to the next action before the 'press' event finishes
         return padActionsList(w3cActions);
     }
 

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/TouchAction.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/TouchAction.java
@@ -1,0 +1,225 @@
+package io.appium.espressoserver.lib.model;
+
+import android.view.ViewConfiguration;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
+import io.appium.espressoserver.lib.handlers.exceptions.InvalidArgumentException;
+import io.appium.espressoserver.lib.helpers.w3c.models.InputSource;
+import io.appium.espressoserver.lib.helpers.w3c.models.InputSource.Action;
+import io.appium.espressoserver.lib.helpers.w3c.models.InputSource.ActionBuilder;
+import io.appium.espressoserver.lib.helpers.w3c.models.InputSource.InputSourceBuilder;
+import io.appium.espressoserver.lib.helpers.w3c.models.InputSource.Parameters;
+
+import static io.appium.espressoserver.lib.helpers.w3c.models.InputSource.ActionType.PAUSE;
+import static io.appium.espressoserver.lib.helpers.w3c.models.InputSource.ActionType.POINTER_CANCEL;
+import static io.appium.espressoserver.lib.helpers.w3c.models.InputSource.ActionType.POINTER_DOWN;
+import static io.appium.espressoserver.lib.helpers.w3c.models.InputSource.ActionType.POINTER_MOVE;
+import static io.appium.espressoserver.lib.helpers.w3c.models.InputSource.ActionType.POINTER_UP;
+import static io.appium.espressoserver.lib.helpers.w3c.models.InputSource.InputSourceType.POINTER;
+import static io.appium.espressoserver.lib.helpers.w3c.models.InputSource.PointerType.TOUCH;
+
+public class TouchAction {
+
+    private final long TAP_TIMEOUT = ViewConfiguration.getTapTimeout();
+    private final long LONG_PRESS_TIMEOUT = ViewConfiguration.getLongPressTimeout();
+
+    // Make the standard press duration be between TAP and LONG_PRESS timeouts
+    private final long PRESS_DURATION = (TAP_TIMEOUT + LONG_PRESS_TIMEOUT) / 2;
+
+    // Number of ms to add or subtract to a timeout so that it isn't the exact number
+    private final long TIMEOUT_BUFFER = 10;
+
+    private ActionType action;
+    private TouchActionOptions options;
+
+    public ActionType getAction() {
+        return action;
+    }
+
+    public void setAction(ActionType action) {
+        this.action = action;
+    }
+
+    public TouchActionOptions getOptions() {
+        return options;
+    }
+
+    public void setOptions(TouchActionOptions options) {
+        this.options = options;
+    }
+
+    public List<Action> toW3CAction() {
+        switch (action) {
+            case MOVE_TO:
+                return Collections.singletonList(convertMoveTo());
+            case PRESS:
+                return convertPress(PRESS_DURATION);
+            case LONG_PRESS:
+                return convertPress(LONG_PRESS_TIMEOUT + TIMEOUT_BUFFER);
+            case TAP:
+                return convertPress(TAP_TIMEOUT - TIMEOUT_BUFFER);
+            case RELEASE:
+                return Collections.singletonList(convertRelease());
+            case WAIT:
+                return Collections.singletonList(convertWait());
+            case CANCEL:
+                return Collections.singletonList(convertCancel());
+            default:
+                break;
+        }
+
+        return null;
+    }
+
+    private Action convertCancel() {
+        return new ActionBuilder()
+                .withType(POINTER_CANCEL)
+                .build();
+    }
+
+    private Action convertWait() {
+        return new ActionBuilder()
+                .withType(PAUSE)
+                .build();
+    }
+
+    private Action convertRelease() {
+        return new ActionBuilder()
+                .withType(POINTER_UP)
+                .build();
+    }
+
+    private Action getMoveTo(Long duration) {
+        ActionBuilder actionBuilder = new ActionBuilder()
+                .withType(POINTER_MOVE)
+                .withDuration(duration)
+                .withX(options.getX())
+                .withY(options.getY());
+
+        if (options.getElementId() != null) {
+            actionBuilder.withElementId(options.getElementId());
+        } else {
+            actionBuilder.withOrigin(InputSource.VIEWPORT);
+        }
+
+        return actionBuilder.build();
+
+    }
+
+    private Action convertMoveTo() {
+        return getMoveTo(0L);
+    }
+
+    private List<Action> convertPress(Long pressDuration) {
+        Action moveAction = getMoveTo(pressDuration);
+
+        Action downAction = new ActionBuilder()
+                .withType(POINTER_DOWN)
+                .build();
+
+        Action upAction = new ActionBuilder()
+                .withType(POINTER_DOWN)
+                .build();
+
+        List<Action> ret = new ArrayList<>();
+        ret.add(moveAction);
+        ret.add(downAction);
+        ret.add(upAction);
+        return ret;
+    }
+
+    public static List<InputSource> toW3CInputSources(List<List<TouchAction>> touchActionsLists) throws AppiumException {
+        int touchInputIndex = 0;
+
+        // Not all actions lists are the same size so we need to know the max size at each step
+        boolean isMultiTouch = touchActionsLists.size() > 1;
+
+        List<InputSource> inputSources = new ArrayList<>();
+        for (List<TouchAction> touchActions: touchActionsLists) {
+            List<Action> w3cActions = new ArrayList<>();
+            for (TouchAction touchAction: touchActions) {
+                if (isMultiTouch) {
+                    // Don't accept TAP, PRESS or LONG_PRESS
+                    switch (touchAction.getAction()) {
+                        case TAP:
+                        case PRESS:
+                        case LONG_PRESS:
+                            throw new InvalidArgumentException("'tap', 'press', and 'long press' are not " +
+                                    "supported in multi touch events because they do not follow Android " +
+                                    "consistency guarantees " +
+                                    "(https://developer.android.com/reference/android/view/MotionEvent#consistency-guarantees)");
+                    }
+                }
+
+                w3cActions.addAll(touchAction.toW3CAction());
+            }
+
+            Parameters parameters = new Parameters();
+            parameters.setPointerType(TOUCH);
+
+            // Add a finger pointer
+            inputSources.add(new InputSourceBuilder()
+                    .withType(POINTER)
+                    .withParameters(parameters)
+                    .withId(String.format("finger%s", touchInputIndex))
+                    .withActions(w3cActions)
+                    .build());
+        }
+
+        return inputSources;
+    }
+
+    public enum ActionType {
+        @SerializedName("moveTo")
+        MOVE_TO,
+        @SerializedName("tap")
+        TAP,
+        @SerializedName("press")
+        PRESS,
+        @SerializedName("longPress")
+        LONG_PRESS,
+        @SerializedName("release")
+        RELEASE,
+        @SerializedName("wait")
+        WAIT,
+        @SerializedName("cancel")
+        CANCEL
+    }
+
+    public static class TouchActionOptions {
+        @SerializedName("element")
+        private String elementId;
+        private Long x;
+        private Long y;
+
+        public String getElementId() {
+            return elementId;
+        }
+
+        public void setElementId(String elementId) {
+            this.elementId = elementId;
+        }
+
+        public Long getX() {
+            return x;
+        }
+
+        public void setX(Long x) {
+            this.x = x;
+        }
+
+        public Long getY() {
+            return y;
+        }
+
+        public void setY(Long y) {
+            this.y = y;
+        }
+    }
+}

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/TouchAction.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/TouchAction.java
@@ -5,8 +5,11 @@ import android.view.ViewConfiguration;
 import com.google.gson.annotations.SerializedName;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
+import javax.annotation.Nullable;
 
 import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
 import io.appium.espressoserver.lib.handlers.exceptions.InvalidArgumentException;
@@ -144,12 +147,7 @@ public class TouchAction {
                 .withDuration(pressDuration)
                 .build();
 
-        List<Action> ret = new ArrayList<>();
-        ret.add(moveAction);
-        ret.add(downAction);
-        ret.add(waitAction);
-
-        return ret;
+        return Arrays.asList(moveAction, downAction, waitAction);
     }
 
     private Action getPause() {
@@ -223,6 +221,7 @@ public class TouchAction {
         private Long x;
         private Long y;
 
+        @Nullable
         public String getElementId() {
             return elementId;
         }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/TouchAction.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/TouchAction.java
@@ -192,7 +192,7 @@ public class TouchAction {
             inputSources.add(new InputSourceBuilder()
                     .withType(POINTER)
                     .withParameters(parameters)
-                    .withId(String.format("finger%s", touchInputIndex))
+                    .withId(String.format("finger%s", touchInputIndex++))
                     .withActions(w3cActions)
                     .build());
         }

--- a/espresso-server/app/src/test/java/io/appium/espressoserver/test/model/TouchActionTest.java
+++ b/espresso-server/app/src/test/java/io/appium/espressoserver/test/model/TouchActionTest.java
@@ -12,11 +12,13 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.List;
 
+import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
 import io.appium.espressoserver.lib.helpers.w3c.models.InputSource.Action;
 import io.appium.espressoserver.lib.model.TouchAction;
 import io.appium.espressoserver.lib.model.TouchAction.ActionType;
 import io.appium.espressoserver.lib.model.TouchAction.TouchActionOptions;
 
+import static io.appium.espressoserver.lib.helpers.w3c.models.InputSource.ActionType.PAUSE;
 import static io.appium.espressoserver.lib.helpers.w3c.models.InputSource.ActionType.POINTER_DOWN;
 import static io.appium.espressoserver.lib.helpers.w3c.models.InputSource.ActionType.POINTER_MOVE;
 import static io.appium.espressoserver.lib.model.TouchAction.ActionType.LONG_PRESS;
@@ -37,7 +39,7 @@ public class TouchActionTest {
     }
 
     @Test
-    public void shouldConvertMoveTo() {
+    public void shouldConvertMoveTo() throws AppiumException {
         TouchAction touchAction = new TouchAction();
         touchAction.setAction(MOVE_TO);
         TouchActionOptions options = new TouchActionOptions();
@@ -45,7 +47,9 @@ public class TouchActionTest {
         options.setY(200L);
         touchAction.setOptions(options);
         List<Action> actions = touchAction.toW3CAction();
-        Action action = actions.get(0);
+        assertEquals(actions.get(0).getType(), PAUSE);
+        assertEquals(actions.get(1).getType(), PAUSE);
+        Action action = actions.get(2);
         assertEquals(action.getX(), new Long(100));
         assertEquals(action.getY(), new Long(200));
         assertEquals(action.getType(), POINTER_MOVE);
@@ -53,7 +57,7 @@ public class TouchActionTest {
     }
 
     @Test
-    public void shouldConvertPress() {
+    public void shouldConvertPress() throws AppiumException {
 
         ActionType[] actionTypes = new ActionType[]{ TAP, PRESS, LONG_PRESS };
 
@@ -71,23 +75,21 @@ public class TouchActionTest {
             assertEquals(moveAction.getX(), new Long(100));
             assertEquals(moveAction.getY(), new Long(200));
 
-            if (actionType == PRESS) {
-                assertTrue(moveAction.getDuration() > ViewConfiguration.getTapTimeout());
-                assertTrue(moveAction.getDuration() < ViewConfiguration.getLongPressTimeout());
-            } else if (actionType == TAP) {
-                assertTrue(moveAction.getDuration() < ViewConfiguration.getTapTimeout());
-            } else if (actionType == LONG_PRESS) {
-                assertTrue(moveAction.getDuration() > ViewConfiguration.getLongPressTimeout());
-            }
-
-
-            Action downAction = actions.get(1);
-            assertEquals(downAction.getType(), POINTER_DOWN);
-            assertEquals(downAction.getButton(), 0);
-
-            Action upAction = actions.get(2);
+            Action upAction = actions.get(1);
             assertEquals(upAction.getType(), POINTER_DOWN);
             assertEquals(upAction.getButton(), 0);
+
+            Action waitAction = actions.get(2);
+            assertEquals(waitAction.getType(), PAUSE);
+
+            if (actionType == PRESS) {
+                assertTrue(waitAction.getDuration() > ViewConfiguration.getTapTimeout());
+                assertTrue(waitAction.getDuration() < ViewConfiguration.getLongPressTimeout());
+            } else if (actionType == TAP) {
+                assertTrue(waitAction.getDuration() < ViewConfiguration.getTapTimeout());
+            } else if (actionType == LONG_PRESS) {
+                assertTrue(waitAction.getDuration() > ViewConfiguration.getLongPressTimeout());
+            }
         }
     }
 }

--- a/espresso-server/app/src/test/java/io/appium/espressoserver/test/model/TouchActionTest.java
+++ b/espresso-server/app/src/test/java/io/appium/espressoserver/test/model/TouchActionTest.java
@@ -1,0 +1,93 @@
+package io.appium.espressoserver.test.model;
+
+import android.view.ViewConfiguration;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.BDDMockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.List;
+
+import io.appium.espressoserver.lib.helpers.w3c.models.InputSource.Action;
+import io.appium.espressoserver.lib.model.TouchAction;
+import io.appium.espressoserver.lib.model.TouchAction.ActionType;
+import io.appium.espressoserver.lib.model.TouchAction.TouchActionOptions;
+
+import static io.appium.espressoserver.lib.helpers.w3c.models.InputSource.ActionType.POINTER_DOWN;
+import static io.appium.espressoserver.lib.helpers.w3c.models.InputSource.ActionType.POINTER_MOVE;
+import static io.appium.espressoserver.lib.model.TouchAction.ActionType.LONG_PRESS;
+import static io.appium.espressoserver.lib.model.TouchAction.ActionType.MOVE_TO;
+import static io.appium.espressoserver.lib.model.TouchAction.ActionType.PRESS;
+import static io.appium.espressoserver.lib.model.TouchAction.ActionType.TAP;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(ViewConfiguration.class)
+public class TouchActionTest {
+    @Before
+    public void before() {
+        PowerMockito.mockStatic(ViewConfiguration.class);
+        BDDMockito.given(ViewConfiguration.getTapTimeout()).willReturn(10);
+        BDDMockito.given(ViewConfiguration.getLongPressTimeout()).willReturn(100);
+    }
+
+    @Test
+    public void shouldConvertMoveTo() {
+        TouchAction touchAction = new TouchAction();
+        touchAction.setAction(MOVE_TO);
+        TouchActionOptions options = new TouchActionOptions();
+        options.setX(100L);
+        options.setY(200L);
+        touchAction.setOptions(options);
+        List<Action> actions = touchAction.toW3CAction();
+        Action action = actions.get(0);
+        assertEquals(action.getX(), new Long(100));
+        assertEquals(action.getY(), new Long(200));
+        assertEquals(action.getType(), POINTER_MOVE);
+        assertTrue(action.isOriginViewport());
+    }
+
+    @Test
+    public void shouldConvertPress() {
+
+        ActionType[] actionTypes = new ActionType[]{ TAP, PRESS, LONG_PRESS };
+
+        for (ActionType actionType: actionTypes) {
+            TouchAction touchAction = new TouchAction();
+            touchAction.setAction(actionType);
+            TouchActionOptions options = new TouchActionOptions();
+            options.setX(100L);
+            options.setY(200L);
+            touchAction.setOptions(options);
+            List<Action> actions = touchAction.toW3CAction();
+
+            Action moveAction = actions.get(0);
+            assertEquals(moveAction.getType(), POINTER_MOVE);
+            assertEquals(moveAction.getX(), new Long(100));
+            assertEquals(moveAction.getY(), new Long(200));
+
+            if (actionType == PRESS) {
+                assertTrue(moveAction.getDuration() > ViewConfiguration.getTapTimeout());
+                assertTrue(moveAction.getDuration() < ViewConfiguration.getLongPressTimeout());
+            } else if (actionType == TAP) {
+                assertTrue(moveAction.getDuration() < ViewConfiguration.getTapTimeout());
+            } else if (actionType == LONG_PRESS) {
+                assertTrue(moveAction.getDuration() > ViewConfiguration.getLongPressTimeout());
+            }
+
+
+            Action downAction = actions.get(1);
+            assertEquals(downAction.getType(), POINTER_DOWN);
+            assertEquals(downAction.getButton(), 0);
+
+            Action upAction = actions.get(2);
+            assertEquals(upAction.getType(), POINTER_DOWN);
+            assertEquals(upAction.getButton(), 0);
+        }
+    }
+}

--- a/espresso-server/gradle/wrapper/gradle-wrapper.properties
+++ b/espresso-server/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Fri Aug 10 10:40:09 PDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-all.zip

--- a/test/functional/commands/touch-e2e-specs.js
+++ b/test/functional/commands/touch-e2e-specs.js
@@ -71,11 +71,11 @@ describe('elementByXPath', function () {
       let canvas = await driver.elementById("android:id/content");
       let {x, y} = await canvas.getLocation();
       const touchActions = [
-        {"type": "pointerMove", duration: 100, x: x + 10, y: y + 10},
+        {"type": "pointerMove", duration: 1000, x: x + 10, y: y + 10},
         {"type": "pointerDown", "button": 0},
-        {"type": "pointerMove", duration: 100,  x: x + 10, y: y + 1000},
-        {"type": "pause", duration: 100},
-        {"type": "pointerMove", duration: 100,  x: x + 1000, y: y + 1000},
+        {"type": "pointerMove", duration: 1000,  x: x + 10, y: y + 1000},
+        {"type": "pause", duration: 1000},
+        {"type": "pointerMove", duration: 1000,  x: x + 1000, y: y + 1000},
         {"type": "pointerCancel", "button": 0},
       ];
       await performTouchAction(touchActions);
@@ -149,7 +149,7 @@ describe('elementByXPath', function () {
         {"type": "pointerMove", "duration": 0, x: x + 30, y: y + 30},
         {"type": "pointerDown", "button": 0},
         {"type": "pointerMove", "duration": 100,  x: x + 10, y: y + 10},
-        {"type": "pointerUp", "button": 0}
+        {"type": "pointerUp", "button": 0},
       ];
       await performTouchAction(touchActions);
     });
@@ -158,9 +158,9 @@ describe('elementByXPath', function () {
       const el = await driver.elementByAccessibilityId("Accessibility");
       let {x, y} = await el.getLocation();
       const touchActions = [
-        {"type": "pointerMove", "duration": 0, x: x + 10, y: y + 10},
+        {"type": "pointerMove", "duration": 100, x: x + 10, y: y + 10},
         {"type": "pointerDown", "button": 0},
-        {"type": "pause", "duration": 100},
+        {"type": "pause", "duration": 3000},
         {"type": "pointerUp", "button": 0},
       ];
       await performTouchAction(touchActions);
@@ -327,38 +327,109 @@ describe('elementByXPath', function () {
     });
   });
 
-  describe('multi touch actions', function () {
-    it('should perform single tap/press/longPress actions', async function () {
-      for (let method of ['tap', 'press', 'longPress']) {
-        let action = new wd.TouchAction();
-        const el = await driver.elementByAccessibilityId("Accessibility");
-        let {x, y} = await el.getLocation();
-        action[method]({x: x + 10, y: y + 10});
-        action.release();
-        let multiAction = new wd.MultiAction(driver);
-        multiAction.add(action);
-        multiAction.perform();
-        await driver.elementByAccessibilityId("Accessibility Node Provider").should.eventually.exist;
-        await driver.back();
-      }
+  describe('mjsonwp touch actions', function () {
+    describe('multi touch actions', function () {
+      it('should perform single tap/press/longPress actions', async function () {
+        for (let method of ['tap', 'press', 'longPress']) {
+          let action = new wd.TouchAction();
+          const el = await driver.elementByAccessibilityId("Accessibility");
+          let {x, y} = await el.getLocation();
+          action[method]({x: x + 10, y: y + 10});
+          action.release();
+          let multiAction = new wd.MultiAction(driver);
+          multiAction.add(action);
+          multiAction.perform();
+          await driver.elementByAccessibilityId("Accessibility Node Provider").should.eventually.exist;
+          await driver.back();
+        }
+      });
+
+      it('should perform single tap/press/longPress actions on an element', async function () {
+        for (let method of ['tap', 'press', 'longPress']) {
+          let action = new wd.TouchAction();
+          const el = await driver.elementByAccessibilityId("Animation");
+          action[method]({el});
+          action.release();
+          let multiAction = new wd.MultiAction(driver);
+          multiAction.add(action);
+          multiAction.perform();
+          await driver.elementByAccessibilityId("Bouncing Balls").should.eventually.exist;
+          await driver.back();
+        }
+      });
     });
 
-    it('should perform single tap/press/longPress actions on an element', async function () {
-      for (let method of ['tap', 'press', 'longPress']) {
-        let action = new wd.TouchAction();
-        const {value:elementId} = await driver.elementByAccessibilityId("Accessibility");
-        action[method]({element: elementId});
-        action.release();
-        let multiAction = new wd.MultiAction(driver);
-        multiAction.add(action);
-        multiAction.perform();
-        await driver.elementByAccessibilityId("Accessibility Node Provider").should.eventually.exist;
-        await driver.back();
-      }
+    describe('touch actions', function () {
+      it('should perform single tap/press/longPress actions', async function () {
+        for (let method of ['tap', 'press', 'longPress']) {
+          let action = new wd.TouchAction(driver);
+          const el = await driver.elementByAccessibilityId("Accessibility");
+          let {x, y} = await el.getLocation();
+          action[method]({x: x + 10, y: y + 10});
+          action.release();
+          action.perform();
+          await driver.elementByAccessibilityId("Accessibility Node Provider").should.eventually.exist;
+          await driver.back();
+        }
+      });
+      it('should perform single tap/press/longPress actions on an element', async function () {
+        for (let method of ['tap', 'press', 'longPress']) {
+          let action = new wd.TouchAction(driver);
+          const el = await driver.elementByAccessibilityId("Animation");
+          action[method]({el});
+          action.release();
+          action.perform();
+          await driver.elementByAccessibilityId("Bouncing Balls").should.eventually.exist;
+          await driver.back();
+        }
+      });
+      /*it.skip('should touch down, move, touch up and cause a scroll event', async function () {
+        await (await driver.elementByAccessibilityId("Views")).click();
+
+        sessionId = await driver.getSessionId();
+        let el = await driver.elementByAccessibilityId("Gallery");
+        let {x:startX, y:startY} = await el.getLocation();
+        el = await driver.elementByAccessibilityId("Controls");
+        let {x:endX, y:endY} = await el.getLocation();
+        let action = new wd.TouchAction(driver);
+        action.press();
+        let options = {
+          method: 'POST',
+          uri: `http://${HOST}:${PORT}/wd/hub/session/${sessionId}/touch/down`,
+          body: {
+            x: startX + 1,
+            y: startY + 1,
+          },
+          json: true,
+        };
+        await request(options);
+        await B.delay(1000);
+
+        options = {
+          method: 'POST',
+          uri: `http://${HOST}:${PORT}/wd/hub/session/${sessionId}/touch/move`,
+          body: {
+            x: endX + 1,
+            y: endY + 1,
+          },
+          json: true,
+        };
+        await request(options);
+        await B.delay(1000);
+
+        options = {
+          method: 'POST',
+          uri: `http://${HOST}:${PORT}/wd/hub/session/${sessionId}/touch/up`,
+          body: {
+            x: endX + 1,
+            y: endY + 1,
+          },
+          json: true,
+        };
+        await request(options);
+        await driver.elementByAccessibilityId("Hover Events").should.eventually.exist;
+
+      });*/
     });
-  });
-
-  describe('touch actions', function () {
-
   });
 });

--- a/test/functional/commands/touch-e2e-specs.js
+++ b/test/functional/commands/touch-e2e-specs.js
@@ -326,4 +326,39 @@ describe('elementByXPath', function () {
       await B.delay(1000);
     });
   });
+
+  describe('multi touch actions', function () {
+    it('should perform single tap/press/longPress actions', async function () {
+      for (let method of ['tap', 'press', 'longPress']) {
+        let action = new wd.TouchAction();
+        const el = await driver.elementByAccessibilityId("Accessibility");
+        let {x, y} = await el.getLocation();
+        action[method]({x: x + 10, y: y + 10});
+        action.release();
+        let multiAction = new wd.MultiAction(driver);
+        multiAction.add(action);
+        multiAction.perform();
+        await driver.elementByAccessibilityId("Accessibility Node Provider").should.eventually.exist;
+        await driver.back();
+      }
+    });
+
+    it('should perform single tap/press/longPress actions on an element', async function () {
+      for (let method of ['tap', 'press', 'longPress']) {
+        let action = new wd.TouchAction();
+        const {value:elementId} = await driver.elementByAccessibilityId("Accessibility");
+        action[method]({element: elementId});
+        action.release();
+        let multiAction = new wd.MultiAction(driver);
+        multiAction.add(action);
+        multiAction.perform();
+        await driver.elementByAccessibilityId("Accessibility Node Provider").should.eventually.exist;
+        await driver.back();
+      }
+    });
+  });
+
+  describe('touch actions', function () {
+
+  });
 });


### PR DESCRIPTION
* Add touch and multi touch endpoints
  * The approach is to just deserialize the touch actions payload and then convert the TouchAction into a W3C action
  * Made it so that each TouchAction had three events (for press/tap/longpress it's `move -> down -> pause`).... `move`, `wait` and `cancel` have one corresponding but they're padded by `pause` with duration 0 (no-op) events so that multi touch actions are synchronized
* Other changes
    * Don't check that x,y is positive.... we can have negative x,y relative to element/pointer
    * Add tests for W3C multi touch (they work!)
    * Make the callable in pointer move use Thread.sleep and not SystemClock or the UiController sleep methods 
    * Changed sleep method to use `uiController.loopMainThreadForAtLeast` instead of `SystemClock.sleep`. `SystemClock.sleep` was blocking UI changes
    * Rename performActions and releaseActions to 'perform' and 'release'
    * Add more logging
    * Fixed cancel not working