### PR TITLE
Fix: Add 'pointerType' (touch, mouse, stylus) to inputState

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/PerformAction.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/PerformAction.java
@@ -9,7 +9,7 @@ import io.appium.espressoserver.lib.viewaction.UiControllerPerformer;
 import io.appium.espressoserver.lib.viewaction.UiControllerRunnable;
 
 
-public class PeformActions implements RequestHandler<Actions, Void>  {
+public class PerformAction implements RequestHandler<Actions, Void>  {
 
     @Override
     public Void handle(final Actions actions) throws AppiumException {

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/dispatcher/PointerDispatch.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/dispatcher/PointerDispatch.java
@@ -153,7 +153,7 @@ public class PointerDispatch {
         long startX = pointerInputState.getX();
         long startY = pointerInputState.getY();
         Origin origin = actionObject.getOrigin();
-
+        
         dispatcherAdapter.getLogger().info(String.format(
             "Dispatching pointer move '%s' on input source with id '%s' with origin '%s' and coordinates [%s, %s]",
             pointerInputState.getType(), sourceId, origin, xOffset, yOffset

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/models/InputSource.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/models/InputSource.java
@@ -74,7 +74,7 @@ public class InputSource {
     public InputState getDefaultState() {
         switch (getType()) {
             case POINTER:
-                return new PointerInputState();
+                return new PointerInputState(getPointerType());
             case KEY:
                 return new KeyInputState();
             default:

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/state/InputStateTable.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/state/InputStateTable.java
@@ -38,7 +38,7 @@ public class InputStateTable {
                     newInputState = new KeyInputState();
                     break;
                 case POINTER:
-                    newInputState = new PointerInputState();
+                    newInputState = new PointerInputState(actionObject.getPointer());
                     break;
                 // Don't need to track state of null input types
                 case NONE:

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/state/PointerInputState.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/state/PointerInputState.java
@@ -16,6 +16,10 @@ public class PointerInputState implements InputState {
     private long x = 0;
     private long y = 0;
 
+    public PointerInputState(PointerType pointerType) {
+        this.type = pointerType;
+    }
+
     public boolean isPressed(int num) {
         return pressed.contains(num);
     }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.java
@@ -55,7 +55,7 @@ import io.appium.espressoserver.lib.handlers.Keys;
 import io.appium.espressoserver.lib.handlers.MultiTouchAction;
 import io.appium.espressoserver.lib.handlers.MultiTouchActionsParams;
 import io.appium.espressoserver.lib.handlers.NotYetImplemented;
-import io.appium.espressoserver.lib.handlers.PeformActions;
+import io.appium.espressoserver.lib.handlers.PerformAction;
 import io.appium.espressoserver.lib.handlers.PointerEventHandler;
 import io.appium.espressoserver.lib.handlers.PressKeyCode;
 import io.appium.espressoserver.lib.handlers.ReleaseActions;
@@ -110,7 +110,7 @@ class Router {
         routeMap.addRoute(new RouteDefinition(Method.GET, "/status", new Status(), AppiumParams.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session", new CreateSession(), SessionParams.class));
         routeMap.addRoute(new RouteDefinition(Method.GET, "/session/:sessionId", new GetSession(), AppiumParams.class));
-        routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/actions", new PeformActions(), Actions.class));
+        routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/actions", new PerformAction(), Actions.class));
         routeMap.addRoute(new RouteDefinition(Method.DELETE, "/session/:sessionId/actions", new ReleaseActions(), Actions.class));
         routeMap.addRoute(new RouteDefinition(Method.DELETE, "/session/:sessionId", new DeleteSession(), AppiumParams.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/back", new Back(), AppiumParams.class));

--- a/espresso-server/app/src/test/java/io/appium/espressoserver/test/helpers/w3c/PointerDispatchTest.java
+++ b/espresso-server/app/src/test/java/io/appium/espressoserver/test/helpers/w3c/PointerDispatchTest.java
@@ -35,6 +35,7 @@ import static io.appium.espressoserver.lib.helpers.w3c.dispatcher.PointerDispatc
 import static io.appium.espressoserver.lib.helpers.w3c.models.InputSource.ActionType.POINTER_MOVE;
 import static io.appium.espressoserver.lib.helpers.w3c.models.InputSource.ActionType.POINTER_UP;
 import static io.appium.espressoserver.lib.helpers.w3c.models.InputSource.POINTER;
+import static io.appium.espressoserver.lib.helpers.w3c.models.InputSource.PointerType.TOUCH;
 import static io.appium.espressoserver.lib.helpers.w3c.models.InputSource.VIEWPORT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -48,7 +49,7 @@ public class PointerDispatchTest {
     @Test
     public void shouldNoopPointerMoveIfNoButtons() throws ExecutionException, InterruptedException, AppiumException {
         DummyW3CActionAdapter dummyW3CActionAdapter = new DummyW3CActionAdapter();
-        pointerInputSource = new PointerInputState();
+        pointerInputSource = new PointerInputState(TOUCH);
         pointerInputSource.setType(PointerType.TOUCH);
 
         ExecutorService executorService = Executors.newSingleThreadExecutor();
@@ -67,7 +68,7 @@ public class PointerDispatchTest {
     public void shouldDoOneMoveIfDurationZero()
             throws ExecutionException, InterruptedException, AppiumException {
         DummyW3CActionAdapter dummyW3CActionAdapter = new DummyW3CActionAdapter();
-        pointerInputSource = new PointerInputState();
+        pointerInputSource = new PointerInputState(TOUCH);
         pointerInputSource.setType(PointerType.TOUCH);
         pointerInputSource.setX(10);
         pointerInputSource.setY(20);
@@ -92,7 +93,7 @@ public class PointerDispatchTest {
     @Test
     public void shouldMovePointerInIntervals() throws ExecutionException, InterruptedException, AppiumException {
         DummyW3CActionAdapter dummyW3CActionAdapter = new DummyW3CActionAdapter();
-        pointerInputSource = new PointerInputState();
+        pointerInputSource = new PointerInputState(TOUCH);
         pointerInputSource.setType(PointerType.TOUCH);
         pointerInputSource.setX(10);
         pointerInputSource.setY(20);
@@ -140,13 +141,13 @@ public class PointerDispatchTest {
     @Test
     public void shouldRunMultiplePointerMoves() throws InterruptedException, ExecutionException, AppiumException{
         DummyW3CActionAdapter dummyW3CActionAdapter = new DummyW3CActionAdapter();
-        pointerInputSource = new PointerInputState();
+        pointerInputSource = new PointerInputState(TOUCH);
         pointerInputSource.setType(PointerType.TOUCH);
         pointerInputSource.setX(10);
         pointerInputSource.setY(20);
         pointerInputSource.addPressed(0);
 
-        PointerInputState pointerInputSourceTwo = new PointerInputState();
+        PointerInputState pointerInputSourceTwo = new PointerInputState(TOUCH);
         pointerInputSourceTwo.setType(PointerType.TOUCH);
         pointerInputSourceTwo.setX(10);
         pointerInputSourceTwo.setY(20);
@@ -215,7 +216,7 @@ public class PointerDispatchTest {
 
         for (int i=0; i<badX.length; i++) {
             DummyW3CActionAdapter dummyW3CActionAdapter = new DummyW3CActionAdapter();
-            PointerInputState pointerInputState = new PointerInputState();
+            PointerInputState pointerInputState = new PointerInputState(TOUCH);
 
             pointerInputState.setX(10);
             pointerInputState.setY(10);
@@ -253,7 +254,7 @@ public class PointerDispatchTest {
 
         for (int i=0; i<xCoords.length; i++) {
             DummyW3CActionAdapter dummyW3CActionAdapter = new DummyW3CActionAdapter();
-            PointerInputState pointerInputState = new PointerInputState();
+            PointerInputState pointerInputState = new PointerInputState(TOUCH);
 
             pointerInputState.setX(50);
             pointerInputState.setY(70);
@@ -279,7 +280,7 @@ public class PointerDispatchTest {
     public void shouldAddButtonToDepressedOnDispatchDown() throws AppiumException {
         DummyW3CActionAdapter dummyW3CActionAdapter = new DummyW3CActionAdapter();
         InputStateTable inputStateTable = new InputStateTable();
-        PointerInputState pointerInputState = new PointerInputState();
+        PointerInputState pointerInputState = new PointerInputState(TOUCH);
 
         ActionObject actionObject = new ActionObject(
                 "id", InputSourceType.POINTER, POINTER_MOVE, 0
@@ -309,7 +310,7 @@ public class PointerDispatchTest {
 
         }
         W3CActionAdapter dummyW3CActionAdapter = new TempDummyAdapter();
-        PointerInputState pointerInputState = new PointerInputState();
+        PointerInputState pointerInputState = new PointerInputState(TOUCH);
         pointerInputState.addPressed(1);
         ActionObject actionObject = new ActionObject(
                 "id", InputSourceType.POINTER, POINTER_MOVE, 0
@@ -326,7 +327,7 @@ public class PointerDispatchTest {
     @Test
     public void shouldRemoveButtonFromDepressedOnDispatchUp() throws AppiumException {
         DummyW3CActionAdapter dummyW3CActionAdapter = new DummyW3CActionAdapter();
-        PointerInputState pointerInputState = new PointerInputState();
+        PointerInputState pointerInputState = new PointerInputState(TOUCH);
         pointerInputState.addPressed(1);
 
         ActionObject actionObject = new ActionObject(
@@ -353,7 +354,7 @@ public class PointerDispatchTest {
 
         }
         W3CActionAdapter dummyW3CActionAdapter = new TempDummyAdapter();
-        PointerInputState pointerInputState = new PointerInputState();
+        PointerInputState pointerInputState = new PointerInputState(TOUCH);
         ActionObject actionObject = new ActionObject(
                 "id", InputSourceType.POINTER, POINTER_MOVE, 0
         );

--- a/espresso-server/app/src/test/java/io/appium/espressoserver/test/helpers/w3c/ProcessorTest.java
+++ b/espresso-server/app/src/test/java/io/appium/espressoserver/test/helpers/w3c/ProcessorTest.java
@@ -123,30 +123,6 @@ public class ProcessorTest {
     }
 
     @Test
-    public void shouldRejectPointerMoveIfNegativeX() throws InvalidArgumentException {
-        Action action = new Action();
-        action.setX(-100);
-        try {
-            processPointerMoveAction(action, InputSourceType.POINTER, "any", 0);
-            fail("expected exception was not occured.");
-        } catch (InvalidArgumentException ie) {
-            assertTrue(ie.getMessage().contains("'x' be greater than or equal to 0"));
-        }
-    }
-
-    @Test
-    public void shouldRejectPointerMoveIfNegativeY() throws InvalidArgumentException {
-        Action action = new Action();
-        action.setY(-100);
-        try {
-            processPointerMoveAction(action, InputSourceType.POINTER, "any", 0);
-            fail("expected exception was not occured.");
-        } catch (InvalidArgumentException ie) {
-            assertTrue(ie.getMessage().contains("'y' be greater than or equal to 0"));
-        }
-    }
-
-    @Test
     public void shouldPassValidPointerMove() throws InvalidArgumentException {
         Action action = new Action();
         action.setX(100);

--- a/espresso-server/app/src/test/java/io/appium/espressoserver/test/helpers/w3c/TickTest.java
+++ b/espresso-server/app/src/test/java/io/appium/espressoserver/test/helpers/w3c/TickTest.java
@@ -175,7 +175,7 @@ public class TickTest {
 
         final String sourceId = "something4";
         final String sourceId2 = "something5";
-        PointerInputState pointerInputState = new PointerInputState();
+        PointerInputState pointerInputState = new PointerInputState(TOUCH);
         pointerInputState.setType(TOUCH);
         pointerInputState.setX(5L);
         pointerInputState.setY(6L);
@@ -245,7 +245,7 @@ public class TickTest {
         InputStateTable inputStateTable = new InputStateTable();
         Tick tick = new Tick();
         final String sourceId = "something4";
-        PointerInputState pointerInputState = new PointerInputState();
+        PointerInputState pointerInputState = new PointerInputState(TOUCH);
         inputStateTable.addInputState(sourceId, pointerInputState);
 
         // Depress the shift key


### PR DESCRIPTION
* input state didn't have a type before so it was maintaining the state by touch only
* This was causing wrong events to be dispatched
* Also
  * Fixed typo 'peformActions'
  * Removed test that checks that exception thrown if negative x,y actions... negative x, y is fine because it might be relative to a pointer or element