### PR TITLE
Update appium-gulp-plugins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ android:
     - sys-img-armeabi-v7a-android-24
 env:
   global:
-    - NODE_VERSION=6
+    - NODE_VERSION=8
     - DEVICE=android
     - START_EMU=1
     - ANDROID_EMU_TARGET=android-21

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,12 +1,11 @@
 /* eslint-disable */
 "use strict";
 
-var gulp = require('gulp'),
-    boilerplate = require('appium-gulp-plugins').boilerplate.use(gulp);
+const gulp = require('gulp');
+const boilerplate = require('appium-gulp-plugins').boilerplate.use(gulp);
 
 boilerplate({
   build: 'appium-espresso-driver',
-  jscs: false,
   testTimeout: 120000,
   e2eTest: { android: true },
   eslint: true,

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -3,10 +3,10 @@ import generalCmds from "./general";
 
 let commands = {};
 Object.assign(
-    commands,
-    generalCmds,
-    executeCmds,
-    // add other command types here
-  );
+  commands,
+  generalCmds,
+  executeCmds,
+  // add other command types here
+);
 
 export default commands;

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -12,7 +12,7 @@ let espressoCapConstraints = {
     isString: true
   },
   launchTimeout: {
-    isNumber:true
+    isNumber: true
   },
   skipUnlock: {
     isBoolean: true

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -27,7 +27,7 @@ const DEVICE_PORT = 8080;
 // TODO: Need to segregate the paths better way using regular expressions wherever applicable.
 // (Not segregating right away because more paths to be added in the NO_PROXY list)
 const NO_PROXY = [
-  ['GET', new RegExp('^/session/(?!.*\/)')],
+  ['GET', new RegExp('^/session/(?!.*/)')],
   ['GET', new RegExp('^/session/[^/]+/alert/[^/]+')],
   ['GET', new RegExp('^/session/[^/]+/alert_[^/]+')],
   ['GET', new RegExp('^/session/[^/]+/appium/device/current_activity')],
@@ -182,7 +182,7 @@ class EspressoDriver extends BaseDriver {
   addWipeDataToAvdArgs () {
     if (!this.opts.avdArgs) {
       this.opts.avdArgs = '-wipe-data';
-    } else  if (this.opts.avdArgs.toLowerCase().indexOf("-wipe-data") === -1) {
+    } else if (this.opts.avdArgs.toLowerCase().indexOf("-wipe-data") === -1) {
       this.opts.avdArgs += ' -wipe-data';
     }
   }
@@ -229,7 +229,7 @@ class EspressoDriver extends BaseDriver {
     this.caps.deviceManufacturer = await this.adb.getManufacturer();
 
     // set up the modified espresso server etc
-    await this.initEspressoServer();
+    this.initEspressoServer();
     // start an avd, set the language/locale, pick an emulator, etc...
     // TODO with multiple devices we'll need to parameterize this
     await helpers.initDevice(this.adb, this.opts);
@@ -271,7 +271,7 @@ class EspressoDriver extends BaseDriver {
     this.jwpProxyActive = true;
   }
 
-  async initEspressoServer () {
+  initEspressoServer () {
     // now that we have package and activity, we can create an instance of
     // espresso with the appropriate data
     this.espresso = new EspressoRunner({

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -182,7 +182,7 @@ class EspressoDriver extends BaseDriver {
   addWipeDataToAvdArgs () {
     if (!this.opts.avdArgs) {
       this.opts.avdArgs = '-wipe-data';
-    } else if (this.opts.avdArgs.toLowerCase().indexOf("-wipe-data") === -1) {
+    } else if (!this.opts.avdArgs.toLowerCase().includes('-wipe-data')) {
       this.opts.avdArgs += ' -wipe-data';
     }
   }

--- a/package.json
+++ b/package.json
@@ -25,23 +25,30 @@
   "directories": {
     "lib": "lib"
   },
+  "files": [
+    "index.js",
+    "lib",
+    "build/index.js",
+    "build/lib",
+    "espresso-server/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk"
+  ],
   "dependencies": {
+    "@babel/runtime": "^7.0.0",
     "appium-adb": "^6.15.2",
     "appium-android-driver": "^4.0.0",
     "appium-base-driver": "^3.5.0",
     "appium-support": "^2.20.0",
     "asyncbox": "^2.3.1",
-    "babel-runtime": "=5.8.24",
     "bluebird": "^3.5.0",
     "lodash": "^4.17.11",
     "portscanner": "^2.1.1",
+    "request": "^2.88.0",
     "request-promise": "^4.2.1",
     "source-map-support": "^0.5.8",
-    "teen_process": "^1.13.0",
     "yargs": "^12.0.1"
   },
   "scripts": {
-    "clean": "rm -rf node_modules && rm -f package-locks.json && npm install",
+    "clean": "rm -rf node_modules && rm -f package-lock.json && npm install",
     "build": "gulp transpile && npm run build:server",
     "build:server": "cd espresso-server && ./gradlew clean assembleAndroidTest && cd ..",
     "mocha": "mocha",
@@ -49,7 +56,7 @@
     "e2e-test": "gulp e2e-test",
     "watch": "gulp watch",
     "coverage": "gulp coveralls",
-    "prepublish": "gulp prepublish && npm run build:server",
+    "prepare": "gulp prepublish && npm run build:server",
     "precommit-msg": "echo 'Pre-commit checks...' && exit 0",
     "precommit-test": "REPORTER=dot gulp once",
     "lint": "gulp eslint",
@@ -57,42 +64,29 @@
   },
   "pre-commit": [
     "precommit-msg",
-    "lint",
     "precommit-test"
   ],
   "devDependencies": {
+    "ajv": "^6.5.3",
     "android-apidemos": "^3.0.0",
-    "appium-gulp-plugins": "^2.4.1",
-    "appium-test-support": "^1.0.0",
-    "babel-eslint": "^7.1.1",
+    "appium-gulp-plugins": "^3.1.0",
+    "babel-eslint": "^10.0.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
-    "eslint": "^3.10.2",
-    "eslint-config-appium": "^2.0.1",
-    "eslint-plugin-babel": "^3.3.0",
-    "eslint-plugin-import": "^2.14.0",
-    "eslint-plugin-mocha": "^4.7.0",
-    "eslint-plugin-promise": "^3.8.0",
+    "eslint": "^5.2.0",
+    "eslint-config-appium": "^3.1.0",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-mocha": "^5.0.0",
+    "eslint-plugin-promise": "^4.0.0",
     "gps-demo-app": "^2.1.1",
-    "gulp": "^3.9.1",
+    "gulp": "^4.0.0",
     "mocha": "^5.1.1",
     "pre-commit": "^1.2.2",
-    "sinon": "^6.1.5",
     "wd": "^1.10.3",
     "xmldom": "^0.1.27",
     "xpath": "0.0.27"
   },
   "greenkeeper": {
-    "ignore": [
-      "babel-eslint",
-      "babel-preset-env",
-      "eslint",
-      "eslint-plugin-babel",
-      "eslint-plugin-import",
-      "eslint-plugin-mocha",
-      "eslint-plugin-promise",
-      "gulp",
-      "babel-runtime"
-    ]
+    "ignore": []
   }
 }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "ajv": "^6.5.3",
     "android-apidemos": "^3.0.0",
     "appium-gulp-plugins": "^3.1.0",
+    "appium-test-support": "^1.0.0",
     "babel-eslint": "^10.0.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",

--- a/test/functional/commands/touch-e2e-specs.js
+++ b/test/functional/commands/touch-e2e-specs.js
@@ -68,10 +68,10 @@ describe('touch actions -', function () {
     // the last element is the title of the view, and often the
     // second-to-last is actually off the screen
     const startEl = els[els.length - 3];
-    const {x:startX, y:startY} = await startEl.getLocation();
+    const {x: startX, y: startY} = await startEl.getLocation();
 
     const endEl = _.first(els);
-    const {x:endX, y:endY} = await endEl.getLocation();
+    const {x: endX, y: endY} = await endEl.getLocation();
 
     return {startX, startY, endX, endY, startEl, endEl};
   }
@@ -105,7 +105,7 @@ describe('touch actions -', function () {
     });
   };
 
-  describe('fingerpaint', async function () {
+  describe('fingerpaint', function () {
     beforeEach(startFingerPaintActivity);
 
     it('should draw the letter L on fingerpaint', async function () {
@@ -121,9 +121,9 @@ describe('touch actions -', function () {
       const touchActions = [
         {type: "pointerMove", duration: 1000, x: startX, y: startY},
         {type: "pointerDown", button: 0},
-        {type: "pointerMove", duration: 1000,  x: startX, y: endY},
+        {type: "pointerMove", duration: 1000, x: startX, y: endY},
         {type: "pause", duration: 1000},
-        {type: "pointerMove", duration: 1000,  x: endX, y: endY},
+        {type: "pointerMove", duration: 1000, x: endX, y: endY},
         {type: "pointerCancel", button: 0},
       ];
       await performTouchAction(touchActions);
@@ -138,7 +138,7 @@ describe('touch actions -', function () {
         touchActions.push([
           {type: "pointerMove", x: x + xOffset, y: y + 10},
           {type: "pointerDown", button: 0},
-          {type: "pointerMove", duration: 2000,  x: x + xOffset, y: y + Math.round(height / 2)},
+          {type: "pointerMove", duration: 2000, x: x + xOffset, y: y + Math.round(height / 2)},
           {type: "pointerUp", button: 0},
         ]);
         return touchActions;
@@ -147,7 +147,7 @@ describe('touch actions -', function () {
     });
   });
 
-  describe('scrolling/swiping', async function () {
+  describe('scrolling/swiping', function () {
     describe('single', function () {
       beforeEach(startListActivity);
 
@@ -157,7 +157,7 @@ describe('touch actions -', function () {
         const actions = [
           {type: "pointerMove", duration: 0, x: startX + 5, y: startY + 5},
           {type: "pointerDown", button: 0},
-          {type: "pointerMove", duration: 200,  x: endX + 5, y: endY + 5},
+          {type: "pointerMove", duration: 200, x: endX + 5, y: endY + 5},
           {type: "pointerUp", button: 0}
         ];
         await performTouchAction(actions);
@@ -169,9 +169,9 @@ describe('touch actions -', function () {
         const {startX, startY, endX, endY} = await getScrollData();
 
         const actions = [
-          {type: "pointerMove", duration: 0,  x: startX + 5, y: startY + 5},
+          {type: "pointerMove", duration: 0, x: startX + 5, y: startY + 5},
           {type: "pointerDown", button: 0},
-          {type: "pointerMove", duration: 100,  x: endX + 5, y: endY + 5},
+          {type: "pointerMove", duration: 100, x: endX + 5, y: endY + 5},
           {type: "pointerUp", button: 0}
         ];
         await performTouchAction(actions);
@@ -213,14 +213,14 @@ describe('touch actions -', function () {
       const touchActions = [
         {type: "pointerMove", duration: 0, x: x + 30, y: y + 30},
         {type: "pointerDown", button: 0},
-        {type: "pointerMove", duration: 100,  x: x + 10, y: y + 10},
+        {type: "pointerMove", duration: 100, x: x + 10, y: y + 10},
         {type: "pointerUp", button: 0},
       ];
       await performTouchAction(touchActions);
     });
   });
 
-  describe('touches', async function () {
+  describe('touches', function () {
     let nextEl;
 
     beforeEach(async function () {
@@ -272,7 +272,7 @@ describe('touch actions -', function () {
       });
 
       it('should do touch/click event', async function () {
-        const {value:elementId} = nextEl;
+        const {value: elementId} = nextEl;
         await request({
           method: 'POST',
           uri: `http://${HOST}:${PORT}/wd/hub/session/${sessionId}/touch/click`,
@@ -286,7 +286,7 @@ describe('touch actions -', function () {
       });
 
       it('should do touch/longclick event', async function () {
-        const {value:elementId} = nextEl;
+        const {value: elementId} = nextEl;
         await request({
           method: 'POST',
           uri: `http://${HOST}:${PORT}/wd/hub/session/${sessionId}/touch/longclick`,
@@ -302,7 +302,7 @@ describe('touch actions -', function () {
       it('should do touch/doubleclick event', async function () {
         await driver.elementByXPath("//*[@text='2']").should.eventually.be.rejectedWith(/NoSuchElement/);
 
-        const {value:elementId} = nextEl;
+        const {value: elementId} = nextEl;
         await request({
           method: 'POST',
           uri: `http://${HOST}:${PORT}/wd/hub/session/${sessionId}/touch/doubleclick`,


### PR DESCRIPTION
This PR does two main things:
1. Updates `eslint-config-appium` and fixes any linting errors.
1. Updated `appium-gulp-plugins` and moves to Babel 7 and Gulp 4.

See https://github.com/appium/appium-gulp-plugins/pull/35 for more details.