### PR TITLE
fix missing manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "lib",
     "build/index.js",
     "build/lib",
-    "espresso-server/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk"
+    "espresso-server/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk",
+    "espresso-server/AndroidManifest-test.xml"
   ],
   "dependencies": {
     "@babel/runtime": "^7.0.0",


### PR DESCRIPTION
Fix https://github.com/appium/appium/issues/11525#issuecomment-431633469

The cause is missing `espresso-server/AndroidManifest-test.xml` in npm package, it looks.
