### PR TITLE
Remove alert endpoints from NO_PROXY list

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -28,8 +28,6 @@ const DEVICE_PORT = 8080;
 // (Not segregating right away because more paths to be added in the NO_PROXY list)
 const NO_PROXY = [
   ['GET', new RegExp('^/session/(?!.*/)')],
-  ['GET', new RegExp('^/session/[^/]+/alert/[^/]+')],
-  ['GET', new RegExp('^/session/[^/]+/alert_[^/]+')],
   ['GET', new RegExp('^/session/[^/]+/appium/device/current_activity')],
   ['GET', new RegExp('^/session/[^/]+/appium/device/current_package')],
   ['GET', new RegExp('^/session/[^/]+/appium/device/display_density')],
@@ -41,7 +39,6 @@ const NO_PROXY = [
   ['GET', new RegExp('^/session/[^/]+/log/types')],
   ['GET', new RegExp('^/session/[^/]+/network_connection')],
   ['GET', new RegExp('^/session/[^/]+/url')],
-  ['POST', new RegExp('^/session/[^/]+/alert/[^/]+')],
   ['POST', new RegExp('^/session/[^/]+/appium/app/background')],
   ['POST', new RegExp('^/session/[^/]+/appium/app/close')],
   ['POST', new RegExp('^/session/[^/]+/appium/app/launch')],


### PR DESCRIPTION
These endpoints are implemented in the downstream server, so they should be proxied.
Addresses https://github.com/appium/appium-espresso-driver/issues/260