### PR TITLE
Properly refresh the server package if the actual package is changed

### DIFF
--- a/lib/espresso-runner.js
+++ b/lib/espresso-runner.js
@@ -2,7 +2,7 @@ import { JWProxy } from 'appium-base-driver';
 import { retryInterval } from 'asyncbox';
 import logger from './logger';
 import path from 'path';
-import { fs, util, mkdirp } from 'appium-support';
+import { fs, util, mkdirp, tempDir } from 'appium-support';
 import { version } from '../../package.json'; // eslint-disable-line import/no-unresolved
 
 
@@ -11,6 +11,7 @@ const TEST_MANIFEST_PATH = path.resolve(__dirname, '..', '..', 'espresso-server'
 const TEST_APK_PKG = 'io.appium.espressoserver.test';
 const REQUIRED_PARAMS = ['adb', 'tmpDir', 'host', 'systemPort', 'devicePort', 'appPackage', 'forceEspressoRebuild'];
 const ESPRESSO_SERVER_LAUNCH_TIMEOUT = 30000;
+const TARGET_PACKAGE_CONTAINER = '/data/local/tmp/espresso.apppackage';
 
 class EspressoRunner {
   constructor (opts = {}) {
@@ -28,6 +29,39 @@ class EspressoRunner {
     this.serverLaunchTimeout = opts.serverLaunchTimeout || ESPRESSO_SERVER_LAUNCH_TIMEOUT;
   }
 
+  async shouldUninstallServer () {
+    if (this.forceEspressoRebuild || !await this.adb.fileExists(TARGET_PACKAGE_CONTAINER)) {
+      return true;
+    }
+
+    const tmpRoot = await tempDir.openDir();
+    try {
+      const dstPath = path.resolve(tmpRoot, path.posix.basename(TARGET_PACKAGE_CONTAINER));
+      await this.adb.pull(TARGET_PACKAGE_CONTAINER, dstPath);
+      const previousAppPackage = await fs.readFile(dstPath, 'utf8');
+      logger.debug(`The previous target application package was '${previousAppPackage}'. ` +
+        `The current package is '${this.appPackage}'.`);
+      return previousAppPackage !== this.appPackage;
+    } finally {
+      await fs.rimraf(tmpRoot);
+    }
+  }
+
+  async installServer () {
+    await this.adb.installOrUpgrade(this.modServerPath, TEST_APK_PKG);
+
+    const tmpRoot = await tempDir.openDir();
+    try {
+      const srcPath = path.resolve(tmpRoot, path.posix.basename(TARGET_PACKAGE_CONTAINER));
+      await fs.writeFile(srcPath, this.appPackage, 'utf8');
+      await this.adb.push(srcPath, TARGET_PACKAGE_CONTAINER);
+      logger.info(`Recorded the target application package '${this.appPackage}' to ${TARGET_PACKAGE_CONTAINER}`);
+    } finally {
+      await fs.rimraf(tmpRoot);
+    }
+    logger.info(`Installed Espresso Test Server apk '${this.modServerPath}' (pkg: '${TEST_APK_PKG}')`);
+  }
+
   async installTestApk () {
     if (this.forceEspressoRebuild && await fs.exists(this.modServerPath)) {
       logger.debug(`Capability 'forceEspressoRebuild' on. Deleting file '${this.modServerPath}'`);
@@ -38,13 +72,12 @@ class EspressoRunner {
       await this.buildNewModServer();
     }
     await this.checkAndSignCert(this.modServerPath);
-    if (this.forceEspressoRebuild) {
-      logger.info("New server was built, uninstalling any instances of it");
+    if (await this.adb.isAppInstalled(TEST_APK_PKG) && await this.shouldUninstallServer()) {
+      logger.info('Uninstalling the obsolete Espresso server package from the device under test');
       await this.adb.uninstallApk(TEST_APK_PKG);
     }
 
-    await this.adb.installOrUpgrade(this.modServerPath, TEST_APK_PKG);
-    logger.info(`Installed Espresso Test Server apk '${this.modServerPath}' (pkg: '${TEST_APK_PKG}')`);
+    await this.installServer();
   }
 
   async buildNewModServer () {


### PR DESCRIPTION
It might be that the target package is changed, so then we need to properly refresh the server apk. Unfortunately dumpsys says nothing about the target package, so we need to keep the target package value elsewhere to know when the server reinstall is needed

Addresses https://github.com/appium/appium-espresso-driver/issues/258