### PR TITLE
Speed up session startup

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetDeviceInfo.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetDeviceInfo.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.espressoserver.lib.handlers;
+
+import android.app.Instrumentation;
+import android.support.test.InstrumentationRegistry;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
+import io.appium.espressoserver.lib.helpers.DeviceInfoHelper;
+import io.appium.espressoserver.lib.model.AppiumParams;
+
+public class GetDeviceInfo implements RequestHandler<AppiumParams, Map<String, Object>> {
+    private final Instrumentation mInstrumentation = InstrumentationRegistry.getInstrumentation();
+
+    @Override
+    public Map<String, Object> handle(AppiumParams params) throws AppiumException {
+        final DeviceInfoHelper deviceInfoHelper = new DeviceInfoHelper(mInstrumentation.getTargetContext());
+        final Map<String, Object> result = new HashMap<>();
+        result.put("androidId", deviceInfoHelper.getAndroidId());
+        result.put("manufacturer", deviceInfoHelper.getManufacturer());
+        result.put("model", deviceInfoHelper.getModelName());
+        result.put("brand", deviceInfoHelper.getBrand());
+        result.put("apiVersion", deviceInfoHelper.getApiVersion());
+        result.put("platformVersion", deviceInfoHelper.getPlatformVersion());
+        result.put("carrierName", deviceInfoHelper.getCarrierName());
+        result.put("realDisplaySize", deviceInfoHelper.getRealDisplaySize());
+        result.put("displayDensity", deviceInfoHelper.getDisplayDensity());
+        return result;
+    }
+}

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/DeviceInfoHelper.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/DeviceInfoHelper.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.espressoserver.lib.helpers;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.os.Build;
+import android.provider.Settings.Secure;
+import android.support.annotation.Nullable;
+import android.telephony.TelephonyManager;
+import android.util.DisplayMetrics;
+import android.view.Display;
+import android.view.WindowManager;
+
+public class DeviceInfoHelper {
+    private final Context context;
+
+    public DeviceInfoHelper(Context context) {
+        this.context = context;
+    }
+
+    @Nullable
+    private Display getDefaultDisplay() {
+        Object windowManager = context.getSystemService(Context.WINDOW_SERVICE);
+        return windowManager == null ? null : ((WindowManager) windowManager).getDefaultDisplay();
+    }
+
+    /**
+     * A unique serial number identifying a device, if a device has multiple users,  each user appears as a
+     * completely separate device, so the ANDROID_ID value is unique to each user.
+     * See https://developer.android.com/reference/android/provider/Settings.Secure.html#ANDROID_ID
+     * for more info.
+     *
+     * @return ANDROID_ID A 64-bit number (as a hex string) that is uniquely generated when the user
+     * first sets up the device and should remain constant for the lifetime of the user's device. The value
+     * may change if a factory reset is performed on the device.
+     */
+    @SuppressLint("HardwareIds")
+    public String getAndroidId() {
+        return Secure.getString(context.getContentResolver(), Secure.ANDROID_ID);
+    }
+
+    /**
+     * @return Build.MANUFACTURER value
+     */
+    public String getManufacturer() {
+        return Build.MANUFACTURER;
+    }
+
+    /**
+     * @return Build.MODEL value
+     */
+    public String getModelName() {
+        return Build.MODEL;
+    }
+
+    /**
+     * @return Build.BRAND value
+     */
+    public String getBrand() {
+        return Build.BRAND;
+    }
+
+    /**
+     * Current running OS's API VERSION
+     *
+     * @return the os version as String
+     */
+    public String getApiVersion() {
+        return Integer.toString(Build.VERSION.SDK_INT);
+    }
+
+    /**
+     * @return The current version string, for example "1.0" or "3.4b5"
+     */
+    public String getPlatformVersion() {
+        return Build.VERSION.RELEASE;
+    }
+
+    /**
+     * @return The logical density of the display in Density Independent Pixel units.
+     */
+    @Nullable
+    public Integer getDisplayDensity() {
+        Display display = getDefaultDisplay();
+        if (display == null) {
+            return null;
+        }
+        DisplayMetrics metrics = new DisplayMetrics();
+        display.getRealMetrics(metrics);
+        return (int) (metrics.density * 160);
+    }
+
+    /**
+     * Retrievs the name of the current celluar network carrier
+     *
+     * @return carrier name or null if it cannot be retrieved
+     */
+    @Nullable
+    public String getCarrierName() {
+        TelephonyManager telephonyManager = (TelephonyManager) context
+                .getSystemService(Context.TELEPHONY_SERVICE);
+        try {
+            return telephonyManager == null ? null : telephonyManager.getNetworkOperatorName();
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    /**
+     * Retrieves the real size of the default display
+     *
+     * @return The display size in 'WxH' format
+     */
+    @Nullable
+    public String getRealDisplaySize() {
+        Display display = getDefaultDisplay();
+        if (display == null) {
+            return null;
+        }
+        android.graphics.Point p = new android.graphics.Point();
+        display.getRealSize(p);
+        return String.format("%sx%s", p.x, p.y);
+    }
+}

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.java
@@ -38,6 +38,7 @@ import io.appium.espressoserver.lib.handlers.FindElement;
 import io.appium.espressoserver.lib.handlers.FindElements;
 import io.appium.espressoserver.lib.handlers.GetAlertText;
 import io.appium.espressoserver.lib.handlers.GetAttribute;
+import io.appium.espressoserver.lib.handlers.GetDeviceInfo;
 import io.appium.espressoserver.lib.handlers.GetDisplayed;
 import io.appium.espressoserver.lib.handlers.GetEnabled;
 import io.appium.espressoserver.lib.handlers.GetLocation;
@@ -149,6 +150,7 @@ class Router {
         routeMap.addRoute(new RouteDefinition(Method.GET, "/session/:sessionId/window/rect", new GetWindowRect(), AppiumParams.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/elements", new FindElements(), Locator.class));
         routeMap.addRoute(new RouteDefinition(Method.GET, "/sessions", new GetSessions(), AppiumParams.class));
+        routeMap.addRoute(new RouteDefinition(Method.GET, "/session/:sessionId/appium/device/info", new GetDeviceInfo(), AppiumParams.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/appium/device/start_activity", new StartActivity(), StartActivityParams.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/appium/device/press_keycode", new PressKeyCode(false), KeyEventParams.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/appium/device/long_press_keycode", new PressKeyCode(true), KeyEventParams.class));

--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -8,6 +8,7 @@ extensions.executeMobile = async function (mobileCommand, opts = {}) {
     shell: 'mobileShell',
     performEditorAction: 'mobilePerformEditorAction',
     swipe: 'mobileSwipe',
+    deviceInfo: 'mobileGetDeviceInfo',
   };
 
   if (!_.has(mobileCommandsMapping, mobileCommand)) {

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -1,6 +1,61 @@
 import _ from 'lodash';
+import { fs, tempDir } from 'appium-support';
+import log from '../logger';
 
 let commands = {}, helpers = {}, extensions = {};
+
+
+commands.getStrings = async function (language) {
+  if (!language) {
+    language = await this.adb.getDeviceLanguage();
+    log.info(`No language specified, returning strings for: ${language}`);
+  }
+
+  // Clients require the resulting mapping to have both keys
+  // and values of type string
+  const preprocessStringsMap = function (mapping) {
+    const result = {};
+    for (const [key, value] of _.toPairs(mapping)) {
+      result[key] = _.isString(value) ? value : JSON.stringify(value);
+    }
+    return result;
+  };
+
+  if (this.apkStrings[language]) {
+    // Return cached strings
+    return preprocessStringsMap(this.apkStrings[language]);
+  }
+
+  if (!this.opts.app && !this.opts.appPackage) {
+    log.errorAndThrow("One of 'app' or 'appPackage' capabilities should must be specified");
+  }
+
+  let app = this.opts.app;
+  const tmpRoot = await tempDir.openDir();
+  try {
+    if (!app) {
+      try {
+        app = await this.adb.pullApk(this.opts.appPackage, tmpRoot);
+      } catch (err) {
+        log.errorAndThrow(`Failed to pull an apk from '${this.opts.appPackage}'. Original error: ${err.message}`);
+      }
+    }
+
+    if (!await fs.exists(app)) {
+      log.errorAndThrow(`The app at '${app}' does not exist`);
+    }
+
+    try {
+      const {apkStrings} = await this.adb.extractStringsFromApk(app, language, tmpRoot);
+      this.apkStrings[language] = apkStrings;
+      return preprocessStringsMap(apkStrings);
+    } catch (err) {
+      log.errorAndThrow(`Cannot extract strings from '${app}'. Original error: ${err.message}`);
+    }
+  } finally {
+    await fs.rimraf(tmpRoot);
+  }
+};
 
 function assertRequiredOptions (options, requiredOptionNames) {
   if (!_.isArray(requiredOptionNames)) {
@@ -23,6 +78,10 @@ commands.mobilePerformEditorAction = async function (opts = {}) {
 commands.mobileSwipe = async function (opts = {}) {
   const {direction, element} = assertRequiredOptions(opts, ['direction', 'element']);
   return await this.espresso.jwproxy.command(`/appium/execute_mobile/${element}/swipe`, 'POST', {direction});
+};
+
+commands.mobileGetDeviceInfo = async function () {
+  return await this.espresso.jwproxy.command('/appium/device/info', 'GET');
 };
 
 Object.assign(extensions, commands, helpers);

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -218,13 +218,9 @@ class EspressoDriver extends BaseDriver {
       }
     }
 
-    // set actual device name, udid, platform version, screen size, model and manufacturer details
+    // set actual device name, udid
     this.caps.deviceName = this.adb.curDeviceId;
     this.caps.deviceUDID = this.opts.udid;
-    this.caps.platformVersion = await this.adb.getPlatformVersion();
-    this.caps.deviceScreenSize = await this.adb.getScreenSize();
-    this.caps.deviceModel = await this.adb.getModel();
-    this.caps.deviceManufacturer = await this.adb.getManufacturer();
 
     // set up the modified espresso server etc
     this.initEspressoServer();
@@ -267,6 +263,25 @@ class EspressoDriver extends BaseDriver {
     // now that everything has started successfully, turn on proxying so all
     // subsequent session requests go straight to/from espresso
     this.jwpProxyActive = true;
+
+    await this.addDeviceInfoToCaps();
+  }
+
+  async addDeviceInfoToCaps () {
+    const {
+      apiVersion,
+      platformVersion,
+      manufacturer,
+      model,
+      realDisplaySize,
+      displayDensity,
+    } = await this.mobileGetDeviceInfo();
+    this.caps.deviceApiLevel = parseInt(apiVersion, 10);
+    this.caps.platformVersion = platformVersion;
+    this.caps.deviceScreenSize = realDisplaySize;
+    this.caps.deviceScreenDensity = displayDensity;
+    this.caps.deviceModel = model;
+    this.caps.deviceManufacturer = manufacturer;
   }
 
   initEspressoServer () {


### PR DESCRIPTION
Executing adb commands requires a lot of time. Getting the device information directly from the server is much more effective