### PR TITLE
respect element and elementId for mobile:swipe

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import util from 'appium-support';
 
 let commands = {}, helpers = {}, extensions = {};
 
@@ -22,8 +23,7 @@ commands.mobilePerformEditorAction = async function (opts = {}) {
 
 commands.mobileSwipe = async function (opts = {}) {
   const {direction, element} = assertRequiredOptions(opts, ['direction', 'element']);
-  let elementId = element.ELEMENT || element;
-  return await this.espresso.jwproxy.command(`/appium/execute_mobile/${elementId}/swipe`, 'POST', {direction});
+  return await this.espresso.jwproxy.command(`/appium/execute_mobile/${util.unwrapElement(element)}/swipe`, 'POST', {direction});
 };
 
 commands.mobileGetDeviceInfo = async function () {

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -22,7 +22,8 @@ commands.mobilePerformEditorAction = async function (opts = {}) {
 
 commands.mobileSwipe = async function (opts = {}) {
   const {direction, element} = assertRequiredOptions(opts, ['direction', 'element']);
-  return await this.espresso.jwproxy.command(`/appium/execute_mobile/${element}/swipe`, 'POST', {direction});
+  let elementId = element.ELEMENT || element;
+  return await this.espresso.jwproxy.command(`/appium/execute_mobile/${elementId}/swipe`, 'POST', {direction});
 };
 
 commands.mobileGetDeviceInfo = async function () {


### PR DESCRIPTION
XCUI-driver allows element and elementId. 

This PR allows espresso driver to accept both element and elementId to drivers consistent.

Related Issue: https://github.com/appium/appium-espresso-driver/issues/259

