### PR TITLE
Make getViewById wait for main thread idle

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/DummyW3CActionAdapter.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/DummyW3CActionAdapter.java
@@ -107,7 +107,7 @@ public class DummyW3CActionAdapter extends BaseW3CActionAdapter {
     }
 
     public Point getElementCenterPoint(String elementId)
-            throws NoSuchElementException, StaleElementException, NotYetImplementedException {
+            throws AppiumException {
         if ("none".equals(elementId)) {
             throw new NoSuchElementException(String.format("Could not find element with id: %s", elementId));
         } else if ("stale".equals(elementId)) {

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/W3CActionAdapter.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/W3CActionAdapter.java
@@ -52,7 +52,7 @@ public interface W3CActionAdapter {
 
     void waitForUiThread();
 
-    Point getElementCenterPoint(String elementId) throws NoSuchElementException, StaleElementException, NotYetImplementedException;
+    Point getElementCenterPoint(String elementId) throws AppiumException;
 
     long getViewportWidth();
 

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/espresso/EspressoW3CActionAdapter.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/espresso/EspressoW3CActionAdapter.java
@@ -472,8 +472,8 @@ public class EspressoW3CActionAdapter extends BaseW3CActionAdapter {
     }
 
     public Point getElementCenterPoint(String elementId)
-            throws NoSuchElementException, StaleElementException, NotYetImplementedException {
-        View view = Element.getViewById(elementId);
+            throws AppiumException {
+        View view = Element.getViewById(elementId, true);
         int[] out = new int[2];
         view.getLocationInWindow(out);
         Point point = new Point();

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/Element.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/Element.java
@@ -37,7 +37,6 @@ import static io.appium.espressoserver.lib.viewmatcher.WithView.withView;
 @SuppressWarnings("unused")
 public class Element {
     private final String ELEMENT;
-    private final int WAIT_FOR_ELEMENT_LIMIT = 5000;
     private final static Map<String, View> cache = new ConcurrentHashMap<>();
 
     public Element (View view) {

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/Element.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/Element.java
@@ -16,6 +16,7 @@
 
 package io.appium.espressoserver.lib.model;
 
+import android.support.test.espresso.UiController;
 import android.support.test.espresso.ViewInteraction;
 import android.view.View;
 
@@ -24,7 +25,10 @@ import java.util.NoSuchElementException;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
+import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
 import io.appium.espressoserver.lib.handlers.exceptions.StaleElementException;
+import io.appium.espressoserver.lib.viewaction.UiControllerPerformer;
+import io.appium.espressoserver.lib.viewaction.UiControllerRunnable;
 
 import static android.support.test.espresso.Espresso.onView;
 import static io.appium.espressoserver.lib.viewmatcher.WithView.withView;
@@ -33,6 +37,7 @@ import static io.appium.espressoserver.lib.viewmatcher.WithView.withView;
 @SuppressWarnings("unused")
 public class Element {
     private final String ELEMENT;
+    private final int WAIT_FOR_ELEMENT_LIMIT = 5000;
     private final static Map<String, View> cache = new ConcurrentHashMap<>();
 
     public Element (View view) {
@@ -51,7 +56,7 @@ public class Element {
      * @throws NoSuchElementException
      * @throws StaleElementException
      */
-    public static ViewInteraction getViewInteractionById(String elementId) throws NoSuchElementException, StaleElementException {
+    public static ViewInteraction getViewInteractionById(String elementId) throws AppiumException {
         if (!exists(elementId)) {
             throw new NoSuchElementException(String.format("Invalid element ID %s", elementId));
         }
@@ -64,16 +69,43 @@ public class Element {
      * @param elementId
      * @return
      */
-    public static View getViewById(String elementId) throws NoSuchElementException, StaleElementException {
-        if (!exists(elementId)) {
-            throw new NoSuchElementException(String.format("Invalid element ID %s", elementId));
-        }
-        View view = cache.get(elementId);
+    public static View getViewById(final String elementId) throws AppiumException {
+        UiControllerRunnable<View> runnable = new UiControllerRunnable<View>() {
+            @Override
+            public View run(UiController uiController) throws NoSuchElementException, StaleElementException {
+                if (!exists(elementId)) {
+                    throw new NoSuchElementException(String.format("Invalid element ID %s", elementId));
+                }
 
-        if (!view.isShown()) {
-            throw new StaleElementException(elementId);
+                // Don't try accessing the View until the main thread is idle
+                uiController.loopMainThreadUntilIdle();
+
+                // Get the cached view
+                View view = cache.get(elementId);
+                if (!view.isShown()) {
+                    throw new StaleElementException(elementId);
+                }
+
+                return view;
+            }
+        };
+
+        return new UiControllerPerformer<>(runnable).run();
+    }
+
+    public static View getViewById(String elementId, boolean skipWaitForMainThreadIdle) throws AppiumException {
+        if (skipWaitForMainThreadIdle) {
+            if (!exists(elementId)) {
+                throw new NoSuchElementException(String.format("Invalid element ID %s", elementId));
+            }
+            View view = cache.get(elementId);
+
+            if (!view.isShown()) {
+                throw new StaleElementException(elementId);
+            }
+            return view;
         }
-        return view;
+        return getViewById(elementId);
     }
 
     public static boolean exists(String elementId) {

--- a/test/functional/commands/find-e2e-specs.js
+++ b/test/functional/commands/find-e2e-specs.js
@@ -1,5 +1,6 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
+import { retryInterval } from 'asyncbox';
 import { initSession, deleteSession, MOCHA_TIMEOUT } from '../helpers/session';
 import { APIDEMO_CAPS } from '../desired';
 
@@ -38,7 +39,7 @@ describe('elementByXPath', function () {
   it('should throw a stale element exception if clicking on element that does not exist', async function () {
     let el = await driver.elementByXPath("//*[@content-desc='Animation']");
     await el.click();
-    await el.click().should.eventually.be.rejectedWith(/no longer exists /);
+    await retryInterval(5, 1000, async () => await el.click().should.eventually.be.rejectedWith(/no longer exists /));
     await driver.back();
   });
   it('should get the isDisplayed attribute on the same element twice', async function () {

--- a/test/functional/desired.js
+++ b/test/functional/desired.js
@@ -1,4 +1,3 @@
-import path from 'path';
 import gpsdemoApp from 'gps-demo-app';
 const apidemosApp = require.resolve('android-apidemos');
 
@@ -21,8 +20,4 @@ const GPS_CAPS = Object.assign({}, GENERIC_CAPS, {
   app: gpsdemoApp,
 });
 
-const REACT_NATIVE_CAPS = Object.assign({}, GENERIC_CAPS, {
-  app: path.resolve(__dirname, '..', '..', 'assets', 'ReactNativeApp.apk'),
-});
-
-export { GENERIC_CAPS, APIDEMO_CAPS, GPS_CAPS, REACT_NATIVE_CAPS };
+export { GENERIC_CAPS, APIDEMO_CAPS, GPS_CAPS };


### PR DESCRIPTION
Espresso tests were flakey, and I suspect that the issue was that when retrieving cached Views (via `Element.getViewById(id)`, it wasn't waiting for the main thread to be idle and there was race conditions where it was finding `Views` that still were in the view hierarchy that were about to not be there.

Example:

```javascript
it('should throw a stale element exception if clicking on element that does not exist', async function () {
    let el = await driver.elementByXPath("//*[@content-desc='Animation']");
    await el.click();
    await el.click().should.eventually.be.rejectedWith(/no longer exists /);
    await driver.back();
  });
```

On the second call to `el.click()`, the element was still in the view hierarchy, because it didn't jump to the new activity yet. So what was happening is that it finds `el`, the "View" assocated with `el` is still present, but then when it tries clicking on it, the Espresso idling thread kicks in, waits for the UI thread to stop, and then the "View" isn't there any more because it's moved to a new activity by then.

This PR fixes this by waiting for the main thread to be idle when retrieving a View.

It makes one exception for 'Actions' though, because when an 'Action' retrieves a view, it's in the middle of a series of Actions, whereby the thread is not idle, and won't be idle.