### PR TITLE
Scroll elements back into view when scrolled out

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/MobileSwipe.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/MobileSwipe.java
@@ -18,8 +18,6 @@ package io.appium.espressoserver.lib.handlers;
 
 import android.support.test.espresso.ViewInteraction;
 
-import javax.annotation.Nullable;
-
 import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
 import io.appium.espressoserver.lib.handlers.exceptions.InvalidArgumentException;
 import io.appium.espressoserver.lib.model.Element;

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/DummyW3CActionAdapter.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/DummyW3CActionAdapter.java
@@ -8,7 +8,6 @@ import java.util.Set;
 
 import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
 import io.appium.espressoserver.lib.handlers.exceptions.NoSuchElementException;
-import io.appium.espressoserver.lib.handlers.exceptions.NotYetImplementedException;
 import io.appium.espressoserver.lib.handlers.exceptions.StaleElementException;
 import io.appium.espressoserver.lib.helpers.Logger;
 import io.appium.espressoserver.lib.helpers.w3c.dispatcher.W3CKeyEvent;

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/W3CActionAdapter.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/W3CActionAdapter.java
@@ -5,9 +5,6 @@ import android.graphics.Point;
 import java.util.Set;
 
 import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
-import io.appium.espressoserver.lib.handlers.exceptions.NoSuchElementException;
-import io.appium.espressoserver.lib.handlers.exceptions.NotYetImplementedException;
-import io.appium.espressoserver.lib.handlers.exceptions.StaleElementException;
 import io.appium.espressoserver.lib.helpers.Logger;
 import io.appium.espressoserver.lib.helpers.w3c.dispatcher.W3CKeyEvent;
 import io.appium.espressoserver.lib.helpers.w3c.models.InputSource.PointerType;

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/espresso/EspressoW3CActionAdapter.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/espresso/EspressoW3CActionAdapter.java
@@ -19,9 +19,6 @@ import java.util.Set;
 
 import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
 import io.appium.espressoserver.lib.handlers.exceptions.InvalidArgumentException;
-import io.appium.espressoserver.lib.handlers.exceptions.NoSuchElementException;
-import io.appium.espressoserver.lib.handlers.exceptions.NotYetImplementedException;
-import io.appium.espressoserver.lib.handlers.exceptions.StaleElementException;
 import io.appium.espressoserver.lib.helpers.AndroidLogger;
 import io.appium.espressoserver.lib.helpers.Logger;
 import io.appium.espressoserver.lib.helpers.w3c.adapter.BaseW3CActionAdapter;
@@ -473,7 +470,7 @@ public class EspressoW3CActionAdapter extends BaseW3CActionAdapter {
 
     public Point getElementCenterPoint(String elementId)
             throws AppiumException {
-        View view = Element.getViewById(elementId, true);
+        View view = Element.getViewById(elementId);
         int[] out = new int[2];
         view.getLocationInWindow(out);
         Point point = new Point();

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.java
@@ -177,7 +177,7 @@ class Router {
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/touch/perform", new TouchAction(), TouchActionsParams.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/touch/multi/perform", new MultiTouchAction(), MultiTouchActionsParams.class));
 
-        // 'execute mobile commands'
+        // 'execute mobile' commands
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/appium/execute_mobile/:elementId/swipe", new MobileSwipe(), MobileSwipeParams.class));
 
         // Not implemented

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/Element.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/Element.java
@@ -17,6 +17,7 @@
 package io.appium.espressoserver.lib.model;
 
 import android.support.test.espresso.DataInteraction;
+import android.support.test.espresso.EspressoException;
 import android.support.test.espresso.ViewInteraction;
 import android.view.View;
 import android.view.ViewParent;
@@ -26,6 +27,7 @@ import org.hamcrest.Matchers;
 
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -119,7 +121,7 @@ public class Element {
         if (contentDescriptionCache.containsKey(elementId)) {
             String expectedContentDesc = contentDescriptionCache.get(elementId);
 
-            if (view.getContentDescription() != null && !view.getContentDescription().equals(expectedContentDesc)) {
+            if (!Objects.equals(view.getContentDescription(), expectedContentDesc)) {
 
                 // Look up the view hierarchy to find the closest ancestor AdapterView
                 ViewParent ancestorAdapter = view.getParent();
@@ -141,7 +143,10 @@ public class Element {
                     view = (new ViewGetter()).getView(onView(withContentDescription(expectedContentDesc)));
                     cache.put(elementId, view);
                 } catch (Exception e) {
-                    throw new StaleElementException(elementId);
+                    if (e instanceof EspressoException) {
+                        throw new StaleElementException(elementId);
+                    }
+                    throw e;
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -50,8 +50,9 @@
   },
   "scripts": {
     "clean": "rm -rf node_modules && rm -f package-lock.json && npm install",
-    "build": "gulp transpile && npm run build:server",
     "build:server": "cd espresso-server && ./gradlew clean assembleAndroidTest && cd ..",
+    "build:node": "gulp transpile",
+    "build": "npm run build:node && npm run build:server",
     "mocha": "mocha",
     "test": "gulp once",
     "e2e-test": "gulp transpile && mocha --timeout 600000 build/test/functional/",

--- a/test/functional/commands/find-e2e-specs.js
+++ b/test/functional/commands/find-e2e-specs.js
@@ -66,4 +66,16 @@ describe('elementByXPath', function () {
     await el.equals(elAgain).should.eventually.be.true;
     await el.equals(elNonMatch).should.eventually.be.false;
   });
+  it('should scroll element back into view if was scrolled out of view (regression test for https://github.com/appium/appium-espresso-driver/issues/276)', async function () {
+    // If we find an element by 'contentDescription', scroll out of view of that element, we should be able to scroll it back into view, as long
+    // as that element has a content description associated with an adapter item
+    let el = await driver.elementByAccessibilityId('Views');
+    await el.click();
+    el = await driver.elementByAccessibilityId('Custom');
+    await el.text().should.eventually.equal('Custom');
+    let {value: element} = await driver.elementById('android:id/list');
+    await driver.execute('mobile: swipe', {direction: 'up', element});
+    await el.text().should.eventually.equal('Custom');
+    await driver.back();
+  });
 });


### PR DESCRIPTION
* Views that are part of an AdapterView don't always have the same data (`value`, `contentDescription`, etc...) throughout their lifecycle. This is because AdapterView stores data about elements in memory and only render views that are on-screen. When views get scrolled away from, instead of re-creating new views, views are re-cycled with updated `contentDescription`, `text`, etc... (see https://stackoverflow.com/questions/11945563/how-listviews-recycling-mechanism-works for reference)
* This will cause unexpected element caching results. If you locate a view, `el`, that is inside a ListView, and then the  ListView is scrolled, for instance, the Views will have their data "re-shuffled" and `el` will have different data.
* For the most part, we can't do anything about this because we cache Views when we locate elements, and there's no definitive test that confirms that a View was part of an AdapterView and had its data modified
* In one special condition, though, where this type of View has a "contentDescription", and the View was scrolled away from, when we retrieve the cached view, we can check if 'contentDescription' for the cached view (`actualContentDescription`) matches what it was when it was originally cached as (`expectedContentDescription`). If `actualContentDescription != expectedContentDescription`, then we can try scrolling `expectedContentDescription` into View, and updating the cache.

Other change in this  PR
* I removed the "loopUntilMainIdle" thread on retrieving elements, because that blocks the test in the case that we try to find an element by content description and plus it didn't fix the original problem of Views still being present

(related to this issue: https://github.com/appium/appium-espresso-driver/issues/276)