### PR TITLE
Make "Actions" accept floats for "x", "y" and "duration" properties

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/exceptions/MoveTargetOutOfBoundsException.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/exceptions/MoveTargetOutOfBoundsException.java
@@ -5,7 +5,7 @@ import io.appium.espressoserver.lib.helpers.Rect;
 
 public class MoveTargetOutOfBoundsException extends AppiumException {
 
-    public MoveTargetOutOfBoundsException(long targetX, long targetY, final Rect boundingRect) {
+    public MoveTargetOutOfBoundsException(float targetX, float targetY, final Rect boundingRect) {
         super(String.format(
             "The target [%s, %s] for pointer interaction is not in the viewport %s and cannot be brought into the viewport",
             targetX, targetY, boundingRect.toShortString()

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/AndroidLogger.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/AndroidLogger.java
@@ -47,5 +47,9 @@ public class AndroidLogger implements Logger {
         android.util.Log.d(TAG, toString(messages));
     }
 
+    public void warn(Object... messages) {
+        android.util.Log.w(TAG, toString(messages));
+    }
+
     public static Logger logger = new AndroidLogger();
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/Logger.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/Logger.java
@@ -21,4 +21,5 @@ public interface Logger {
     void error(String message, Throwable throwable);
     void info(Object... messages);
     void debug(Object... messages);
+    void warn(Object... messages);
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/BaseW3CActionAdapter.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/BaseW3CActionAdapter.java
@@ -52,9 +52,9 @@ public abstract class BaseW3CActionAdapter implements W3CActionAdapter {
         return 5;
     }
 
-    public void sleep(long duration) throws AppiumException {
+    public void sleep(float duration) throws AppiumException {
         try {
-            Thread.sleep(duration);
+            Thread.sleep(Math.round(duration));
         } catch (InterruptedException ie) {
             throw new AppiumException(String.format("Could not run 'sleep' method: %s", ie.getCause()));
         }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/DummyW3CActionAdapter.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/DummyW3CActionAdapter.java
@@ -24,10 +24,10 @@ public class DummyW3CActionAdapter extends BaseW3CActionAdapter {
     public static class PointerMoveEvent {
         public String sourceId;
         public PointerType pointerType;
-        public long currentX;
-        public long currentY;
-        public long x;
-        public long y;
+        public float currentX;
+        public float currentY;
+        public float x;
+        public float y;
         public Set<Integer> buttons;
         public KeyInputState globalKeyInputState;
     }
@@ -45,6 +45,9 @@ public class DummyW3CActionAdapter extends BaseW3CActionAdapter {
         public void debug(Object... messages) {
             // No-op
         }
+        public void warn(Object... messages) {
+            // No-op
+        }
     }
 
     public void keyDown(W3CKeyEvent keyEvent) {
@@ -56,18 +59,18 @@ public class DummyW3CActionAdapter extends BaseW3CActionAdapter {
     }
 
     public void pointerUp(int button, String sourceId, PointerType pointerType,
-                            Long x, Long y, Set<Integer> depressedButtons,
+                            Float x, Float y, Set<Integer> depressedButtons,
                             KeyInputState globalKeyInputState) throws AppiumException {
         // No-op
     }
 
     public void pointerDown(int button, String sourceId, PointerType pointerType,
-                     Long x, Long y, Set<Integer> depressedButtons,
+                            Float x, Float y, Set<Integer> depressedButtons,
                      KeyInputState globalKeyInputState) throws AppiumException {
         // No-op
     }
 
-    public void pointerCancel(String sourceId, PointerType pointerType) throws AppiumException {
+    public void pointerCancel(String sourceId, PointerType pointerType) {
         // No-op
     }
 
@@ -85,7 +88,7 @@ public class DummyW3CActionAdapter extends BaseW3CActionAdapter {
     }
 
     public void pointerMove(String sourceId, PointerType pointerType,
-                            long currentX, long currentY, long x, long y,
+                            float currentX, float currentY, float x, float y,
                             Set<Integer> buttons, KeyInputState globalKeyInputState) throws AppiumException {
         // Add the pointer move event to the logs
         PointerMoveEvent pointerMoveEvent = new PointerMoveEvent();

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/W3CActionAdapter.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/W3CActionAdapter.java
@@ -18,15 +18,15 @@ public interface W3CActionAdapter {
     void keyUp(W3CKeyEvent keyUpEvent) throws AppiumException;
 
     void pointerDown(int button, String sourceId, PointerType pointerType,
-                     Long x, Long y, Set<Integer> depressedButtons,
+                     Float x, Float y, Set<Integer> depressedButtons,
                      KeyInputState globalKeyInputState) throws AppiumException;
 
     void pointerUp(int button, String sourceId, PointerType pointerType,
-                     Long x, Long y, Set<Integer> depressedButtons,
+                   Float x, Float y, Set<Integer> depressedButtons,
                      KeyInputState globalKeyInputState) throws AppiumException;
 
     void pointerMove(String sourceId, PointerType pointerType,
-                     long currentX, long currentY, long x, long y,
+                     float currentX, float currentY, float x, float y,
                      Set<Integer> buttons, KeyInputState globalKeyInputState) throws AppiumException;
 
     void pointerCancel(String sourceId, PointerType pointerType) throws AppiumException;
@@ -45,7 +45,7 @@ public interface W3CActionAdapter {
 
     int pointerMoveIntervalDuration();
 
-    void sleep(long duration) throws AppiumException;
+    void sleep(float duration) throws AppiumException;
 
     void waitForUiThread();
 

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/espresso/EspressoW3CActionAdapter.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/espresso/EspressoW3CActionAdapter.java
@@ -278,7 +278,7 @@ public class EspressoW3CActionAdapter extends BaseW3CActionAdapter {
                             Float x, Float y, Set<Integer> depressedButtons,
                      KeyInputState globalKeyInputState) throws AppiumException {
         this.getLogger().info(String.format("Running pointer down at coordinates: %s %s %s", x, y, pointerType));
-        final Point roundedCoords = getRoundedCoordinates(x, y);
+        final Point roundedCoords = toCoordinates(x, y);
 
         if (isTouch(pointerType)) {
             // touch down actions need to be grouped together
@@ -301,7 +301,7 @@ public class EspressoW3CActionAdapter extends BaseW3CActionAdapter {
                           Float x, Float y, Set<Integer> depressedButtons,
                    KeyInputState globalKeyInputState) throws AppiumException {
         this.getLogger().info(String.format("Running pointer up at coordinates: %s %s %s", x, y, pointerType));
-        final Point roundedCoords = getRoundedCoordinates(x, y);
+        final Point roundedCoords = toCoordinates(x, y);
         if (isTouch(pointerType)) {
             // touch up actions need to be grouped together
             multiTouchState.updateTouchState(ACTION_UP, sourceId, (long) roundedCoords.x, (long) roundedCoords.y, globalKeyInputState, button);
@@ -320,7 +320,7 @@ public class EspressoW3CActionAdapter extends BaseW3CActionAdapter {
                             float currentX, float currentY, float x, float y,
                             Set<Integer> buttons, KeyInputState globalKeyInputState) throws AppiumException {
         this.getLogger().info(String.format("Running pointer move at coordinates: %s %s %s", x, y, pointerType));
-        final Point roundedCoords = getRoundedCoordinates(x, y);
+        final Point roundedCoords = toCoordinates(x, y);
         if (isTouch(pointerType)) {
             multiTouchState.updateTouchState(ACTION_MOVE, sourceId, (long) roundedCoords.x, (long) roundedCoords.y,  globalKeyInputState, null);
             multiTouchState.pointerMove(uiController);
@@ -512,7 +512,7 @@ public class EspressoW3CActionAdapter extends BaseW3CActionAdapter {
      * @param y Y coordinate
      * @return Rounded x and y coordinates
      */
-    private Point getRoundedCoordinates(float x, float y) {
+    private Point toCoordinates(float x, float y) {
         int roundedX = Math.round(x);
         int roundedY = Math.round(y);
         if (x != roundedX || y != roundedY) {

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/dispatcher/DispatchPointerMoveResult.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/dispatcher/DispatchPointerMoveResult.java
@@ -12,18 +12,18 @@ public class DispatchPointerMoveResult extends BaseDispatchResult {
     private W3CActionAdapter dispatcherAdapter;
     private String sourceId;
     private InputSource.PointerType pointerType;
-    private long currentX;
-    private long currentY;
-    private long x;
-    private long y;
+    private float currentX;
+    private float currentY;
+    private float x;
+    private float y;
     private Set<Integer> buttons;
     private KeyInputState globalKeyInputState;
 
     public DispatchPointerMoveResult(final W3CActionAdapter dispatcherAdapter,
                                      final String sourceId,
                                      final InputSource.PointerType pointerType,
-                                     final long currentX, final long currentY,
-                                     final long x, final long y,
+                                     final float currentX, final float currentY,
+                                     final float x, final float y,
                                      final Set<Integer> buttons,
                                      final KeyInputState globalKeyInputState) {
         this.dispatcherAdapter = dispatcherAdapter;

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/dispatcher/KeyDispatch.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/dispatcher/KeyDispatch.java
@@ -23,7 +23,7 @@ public class KeyDispatch {
                                                 ActionObject actionObject,
                                                 KeyInputState inputState,
                                                 InputStateTable inputStateTable,
-                                                long tickDuration, boolean down) throws AppiumException {
+                                                float tickDuration, boolean down) throws AppiumException {
         // Get the base Key Event
         W3CKeyEvent keyEvent = getKeyEvent(dispatcherAdapter, actionObject);
         String key = keyEvent.getKey();
@@ -109,7 +109,7 @@ public class KeyDispatch {
     @Nullable
     public static W3CKeyEvent dispatchKeyDown(W3CActionAdapter dispatcherAdapter,
                                               ActionObject actionObject, KeyInputState inputState,
-                                              InputStateTable inputStateTable, long tickDuration) throws AppiumException {
+                                              InputStateTable inputStateTable, float tickDuration) throws AppiumException {
 
         return dispatchKeyEvent(dispatcherAdapter, actionObject, inputState, inputStateTable ,tickDuration, true);
     }
@@ -134,7 +134,7 @@ public class KeyDispatch {
     @Nullable
     public static W3CKeyEvent dispatchKeyUp(W3CActionAdapter dispatcherAdapter,
                                             ActionObject actionObject, KeyInputState inputState,
-                                            InputStateTable inputStateTable, long tickDuration) throws AppiumException {
+                                            InputStateTable inputStateTable, float tickDuration) throws AppiumException {
         return dispatchKeyEvent(dispatcherAdapter, actionObject, inputState, inputStateTable, tickDuration, false);
     }
 

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/dispatcher/PointerDispatch.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/dispatcher/PointerDispatch.java
@@ -43,8 +43,8 @@ public class PointerDispatch {
                 return;
             }
         }
-        Long x = pointerInputState.getX();
-        Long y = pointerInputState.getY();
+        Float x = pointerInputState.getX();
+        Float y = pointerInputState.getY();
         if (down) {
             pointerInputState.addPressed(button);
         } else {
@@ -145,14 +145,14 @@ public class PointerDispatch {
                                                      final String sourceId,
                                                      final ActionObject actionObject,
                                                      final PointerInputState pointerInputState,
-                                                     final long tickDuration,
+                                                     final float tickDuration,
                                                      final long timeAtBeginningOfTick,
                                                      final KeyInputState globalKeyInputState) throws AppiumException {
         // 1.5 Variable definitions
-        long xOffset = actionObject.getX();
-        long yOffset = actionObject.getY();
-        long startX = pointerInputState.getX();
-        long startY = pointerInputState.getY();
+        float xOffset = actionObject.getX();
+        float yOffset = actionObject.getY();
+        float startX = pointerInputState.getX();
+        float startY = pointerInputState.getY();
         Origin origin = actionObject.getOrigin();
         
         dispatcherAdapter.getLogger().info(String.format(
@@ -160,8 +160,8 @@ public class PointerDispatch {
             pointerInputState.getType(), sourceId, origin, xOffset, yOffset
         ));
 
-        long x;
-        long y;
+        float x;
+        float y;
 
         // 6. Run the substeps of the first matching value of origin
         String originType = origin.getType();
@@ -199,7 +199,7 @@ public class PointerDispatch {
         }
 
         // 9. Let duration be equal to action object's duration property if it is not undefined, or tick duration otherwise
-        Long duration = actionObject.getDuration();
+        Float duration = actionObject.getDuration();
         if (duration == null) {
             duration = tickDuration;
         }
@@ -239,9 +239,9 @@ public class PointerDispatch {
     public static Callable<BaseDispatchResult> performPointerMove(final W3CActionAdapter dispatcherAdapter,
                                                     final String sourceId,
                                                     final PointerInputState pointerInputState,
-                                                    final long duration,
-                                                    final long startX, final long startY,
-                                                    final long targetX, final long targetY,
+                                                    final float duration,
+                                                    final float startX, final float startY,
+                                                    final float targetX, final float targetY,
                                                     final long timeAtBeginningOfTick,
                                                     final KeyInputState globalKeyInputState) {
         return new Callable<BaseDispatchResult>() {
@@ -253,7 +253,7 @@ public class PointerDispatch {
                 long timeDelta = System.currentTimeMillis() - timeAtBeginningOfTick;
 
                 // 3. Let duration ratio be the ratio of time delta and duration, if duration is greater than 0, or 1 otherwise
-                float durationRatio = duration > 0 ? timeDelta / ((float) duration) : 1;
+                float durationRatio = duration > 0 ? timeDelta / duration : 1;
 
                 // 4. If duration ratio is 1, or close enough to 1 that the implementation will not further subdivide the move action,
                 //    let last be true. Otherwise let last be false
@@ -261,12 +261,12 @@ public class PointerDispatch {
 
                 // 5. If last is true, let x equal target x and y equal target y
                 // 6. Otherwise let x equal an approximation to duration ratio × (target x - start x) + start x,, ...
-                final long x = isLast ? targetX : Math.round(durationRatio * (targetX - startX)) + startX;
-                final long y = isLast ? targetY : Math.round(durationRatio * (targetY - startY)) + startY;
+                final float x = isLast ? targetX : Math.round(durationRatio * (targetX - startX)) + startX;
+                final float y = isLast ? targetY : Math.round(durationRatio * (targetY - startY)) + startY;
 
                 // 7-8: Let currentX and currentY be pointer input state
-                final long currentX = pointerInputState.getX();
-                final long currentY = pointerInputState.getY();
+                final float currentX = pointerInputState.getX();
+                final float currentY = pointerInputState.getY();
 
                 // Prepare the result
                 DispatchPointerMoveResult dispatchResult = new DispatchPointerMoveResult(

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/models/ActionObject.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/models/ActionObject.java
@@ -30,9 +30,9 @@ public class ActionObject {
     private InputSourceType type;
     private ActionType subType;
     private String id;
-    private Long duration;
-    private Long x;
-    private Long y;
+    private Float duration;
+    private Float x;
+    private Float y;
     private int button;
     private String value;
     private PointerType pointer;
@@ -76,7 +76,7 @@ public class ActionObject {
     @Nullable
     public Callable<BaseDispatchResult> dispatch(W3CActionAdapter adapter,
                                                  InputStateTable inputStateTable,
-                                                 long tickDuration, long timeAtBeginningOfTick) throws AppiumException {
+                                                 float tickDuration, long timeAtBeginningOfTick) throws AppiumException {
         InputSourceType inputSourceType = this.getType();
         ActionType actionType = this.getSubType();
         adapter.getLogger().info(String.format(
@@ -172,11 +172,11 @@ public class ActionObject {
     }
 
     @Nullable
-    public Long getDuration() {
+    public Float getDuration() {
         return duration;
     }
 
-    public void setDuration(Long duration) {
+    public void setDuration(Float duration) {
         this.duration = duration;
     }
 
@@ -189,19 +189,19 @@ public class ActionObject {
         this.origin = origin;
     }
 
-    public long getX() {
+    public float getX() {
         return x == null ? 0 : x;
     }
 
-    public void setX(Long x) {
+    public void setX(Float x) {
         this.x = x;
     }
 
-    public long getY() {
+    public float getY() {
         return y == null ? 0 : y;
     }
 
-    public void setY(Long y) {
+    public void setY(Float y) {
         this.y = y;
     }
 

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/models/ActionSequence.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/models/ActionSequence.java
@@ -76,7 +76,7 @@ public class ActionSequence implements Iterator<Tick> {
         int tickIndex = 0;
         for(Tick tick: ticks) {
             long timeAtBeginningOfTick = System.currentTimeMillis();
-            long tickDuration = tick.calculateTickDuration();
+            float tickDuration = tick.calculateTickDuration();
 
             // 1. Dispatch all of the events
             adapter.getLogger().info(String.format(
@@ -112,9 +112,9 @@ public class ActionSequence implements Iterator<Tick> {
             }
 
             //  2.2 At least tick duration milliseconds have passed
-            long timeSinceBeginningOfTick = System.currentTimeMillis() - timeAtBeginningOfTick;
+            float timeSinceBeginningOfTick = System.currentTimeMillis() - timeAtBeginningOfTick;
             if (timeSinceBeginningOfTick < tickDuration) {
-                long timeToSleep = tickDuration - timeSinceBeginningOfTick;
+                float timeToSleep = tickDuration - timeSinceBeginningOfTick;
                 adapter.getLogger().info(String.format("Wait for tick to finish for %s ms", timeToSleep));
                 adapter.sleep(timeToSleep);
             }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/models/InputSource.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/models/InputSource.java
@@ -110,10 +110,10 @@ public class InputSource {
 
     public static class Action {
         private ActionType type; // type of action
-        private Long duration; // time in milliseconds
+        private Float duration; // time in milliseconds
         private Integer button; // Button that is being pressed. Defaults to 0.
-        private Long x; // x coordinate of pointer
-        private Long y; // y coordinate of pointer
+        private Float x; // x coordinate of pointer
+        private Float y; // y coordinate of pointer
         private String value; // a string containing a single Unicode code point or a number
         private Origin origin = new Origin(); // origin; could be viewport, pointer or <{element-6066-11e4-a52e-4f735466cecf: <element-uuid>}>
 
@@ -131,11 +131,11 @@ public class InputSource {
         }
 
         @Nullable
-        public Long getDuration(){
+        public Float getDuration(){
             return duration;
         }
 
-        public void setDuration(long duration){
+        public void setDuration(float duration){
             this.duration = duration;
         }
 
@@ -162,19 +162,19 @@ public class InputSource {
             return origin.getType().equalsIgnoreCase(ELEMENT_CODE);
         }
 
-        public Long getX(){
+        public Float getX(){
             return x;
         }
 
-        public void setX(long x){
+        public void setX(float x){
             this.x = x;
         }
 
-        public Long getY(){
+        public Float getY(){
             return y;
         }
 
-        public void setY(long y){
+        public void setY(float y){
             this.y = y;
         }
 

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/models/Tick.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/models/Tick.java
@@ -39,19 +39,17 @@ public class Tick implements Iterator<ActionObject> {
      * Get max tick duration for a tick
      * @return Max tick duration
      */
-    public long calculateTickDuration(){
-        long maxDuration = 0;
+    public float calculateTickDuration(){
+        float maxDuration = 0;
         for(ActionObject actionObject: tickActions) {
-            long currDuration = 0;
+            float currDuration = 0.0F;
 
             InputSourceType type = actionObject.getType();
-            Long duration = actionObject.getDuration();
+            Float duration = actionObject.getDuration();
             ActionType subType = actionObject.getSubType();
 
             if (duration != null) {
-                if (type == POINTER && subType == POINTER_MOVE) {
-                    currDuration = duration;
-                } else if (subType == PAUSE) {
+                if ((type == POINTER && subType == POINTER_MOVE) || subType == PAUSE) {
                     currDuration = duration;
                 }
             }
@@ -63,7 +61,7 @@ public class Tick implements Iterator<ActionObject> {
         return maxDuration;
     }
 
-    public List<Callable<BaseDispatchResult>> dispatchAll(W3CActionAdapter adapter, InputStateTable inputStateTable, long tickDuration)
+    public List<Callable<BaseDispatchResult>> dispatchAll(W3CActionAdapter adapter, InputStateTable inputStateTable, float tickDuration)
             throws AppiumException {
         long timeAtBeginningOfTick = System.currentTimeMillis();
         List<Callable<BaseDispatchResult>> asyncOperations = new ArrayList<>();

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/models/Tick.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/models/Tick.java
@@ -48,10 +48,8 @@ public class Tick implements Iterator<ActionObject> {
             Float duration = actionObject.getDuration();
             ActionType subType = actionObject.getSubType();
 
-            if (duration != null) {
-                if ((type == POINTER && subType == POINTER_MOVE) || subType == PAUSE) {
-                    currDuration = duration;
-                }
+            if (duration != null && (type == POINTER && subType == POINTER_MOVE) || subType == PAUSE) {
+                currDuration = duration;
             }
 
             if (currDuration > maxDuration) {

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/processor/PauseProcessor.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/processor/PauseProcessor.java
@@ -54,7 +54,7 @@ public class PauseProcessor {
      * @throws InvalidArgumentException If failed to process, throw this. Means that args are bad.
      */
     public static ActionObject processPauseAction(Action action, InputSourceType inputSourceType, String id, int index) throws InvalidArgumentException {
-        Long duration = action.getDuration();
+        Float duration = action.getDuration();
         assertNullOrPositive(index, id, "duration", duration);
         ActionObject actionObject = new ActionObject(id, inputSourceType, PAUSE, index);
         actionObject.setDuration(duration);

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/processor/PointerProcessor.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/processor/PointerProcessor.java
@@ -19,7 +19,6 @@ package io.appium.espressoserver.lib.helpers.w3c.processor;
 import java.util.Arrays;
 
 import io.appium.espressoserver.lib.handlers.exceptions.InvalidArgumentException;
-import io.appium.espressoserver.lib.handlers.exceptions.NotYetImplementedException;
 import io.appium.espressoserver.lib.helpers.w3c.models.ActionObject;
 import io.appium.espressoserver.lib.helpers.w3c.models.InputSource;
 import io.appium.espressoserver.lib.helpers.w3c.models.InputSource.Action;
@@ -48,7 +47,7 @@ public class PointerProcessor {
      * @throws InvalidArgumentException If failed to process, throw this. Means that args are bad.
      */
     public static ActionObject processPointerAction(Action action, InputSource inputSource, String id, int index)
-            throws InvalidArgumentException, NotYetImplementedException {
+            throws InvalidArgumentException {
 
         // 1 -2 get and validate the type
         ActionType subType = action.getType();
@@ -105,7 +104,7 @@ public class PointerProcessor {
         return actionObject;
     }
 
-    public static ActionObject processPointerCancelAction(Action action, InputSourceType inputSourceType, String id, int index) throws InvalidArgumentException {
+    public static ActionObject processPointerCancelAction(Action action, InputSourceType inputSourceType, String id, int index) {
         return new ActionObject(id, inputSourceType, action.getType(), index);
     }
 
@@ -122,7 +121,7 @@ public class PointerProcessor {
         ActionObject actionObject = new ActionObject(id, inputSourceType, action.getType(), index);
 
         // 1-3 Add the duration
-        Long duration = action.getDuration();
+        Float duration = action.getDuration();
         assertNullOrPositive(index, id, "duration", duration);
         actionObject.setDuration(duration);
 
@@ -130,11 +129,11 @@ public class PointerProcessor {
         actionObject.setOrigin(action.getOrigin());
 
         // 8-10 Add the X coordinate
-        Long x = action.getX();
+        Float x = action.getX();
         actionObject.setX(x);
 
         // 11-14 Add the Y coordinate
-        Long y = action.getY();
+        Float y = action.getY();
         actionObject.setY(y);
 
         return actionObject;

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/processor/ProcessorHelpers.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/processor/ProcessorHelpers.java
@@ -21,6 +21,10 @@ import io.appium.espressoserver.lib.handlers.exceptions.InvalidArgumentException
 @SuppressWarnings("unused")
 public class ProcessorHelpers {
     public static boolean isNullOrPositive(Long num) {
+        return isNullOrPositive((float) num);
+    }
+
+    public static boolean isNullOrPositive(Float num) {
         return num == null || num >= 0;
     }
 
@@ -30,6 +34,10 @@ public class ProcessorHelpers {
     }
 
     public static void assertNullOrPositive(int index, String id, String propertyName, Long propertyValue) throws InvalidArgumentException {
+        assertNullOrPositive(index, id, propertyName, (float) propertyValue);
+    }
+
+    public static void assertNullOrPositive(int index, String id, String propertyName, Float propertyValue) throws InvalidArgumentException {
         if (!isNullOrPositive(propertyValue)) {
             throwArgException(index, id, String.format(
                     "must have property '%s' be greater than or equal to 0 or undefined. Found %s", propertyName, propertyValue)

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/state/PointerInputState.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/state/PointerInputState.java
@@ -13,8 +13,8 @@ import io.appium.espressoserver.lib.helpers.w3c.models.InputSource.PointerType;
 public class PointerInputState implements InputState {
     private Set<Integer> pressed = new HashSet<>();
     private PointerType type;
-    private long x = 0;
-    private long y = 0;
+    private float x = 0;
+    private float y = 0;
 
     public PointerInputState(PointerType pointerType) {
         this.type = pointerType;
@@ -40,19 +40,19 @@ public class PointerInputState implements InputState {
         return !pressed.isEmpty();
     }
 
-    public long getX() {
+    public float getX() {
         return x;
     }
 
-    public void setX(long x) {
+    public void setX(float x) {
         this.x = x;
     }
 
-    public long getY() {
+    public float getY() {
         return y;
     }
 
-    public void setY(long y) {
+    public void setY(float y) {
         this.y = y;
     }
 

--- a/espresso-server/app/src/test/java/io/appium/espressoserver/test/helpers/w3c/ActionSequenceTest.java
+++ b/espresso-server/app/src/test/java/io/appium/espressoserver/test/helpers/w3c/ActionSequenceTest.java
@@ -48,17 +48,17 @@ public class ActionSequenceTest {
         assertEquals(action.getId(), "finger1");
         assertEquals(action.getType(), POINTER);
         assertEquals(action.getSubType(), POINTER_MOVE);
-        assertEquals(action.getDuration(), new Long(0));
-        assertEquals(action.getX(), 100);
-        assertEquals(action.getY(), 100);
+        assertEquals(action.getDuration(), new Float(0));
+        assertEquals(action.getX(), 100, 1e-15);
+        assertEquals(action.getY(), 100, 1e-15);
 
         action = tick.next();
         assertEquals(action.getId(), "finger2");
         assertEquals(action.getType(), POINTER);
         assertEquals(action.getSubType(), POINTER_MOVE);
-        assertEquals(action.getDuration(), new Long(10));
-        assertEquals(action.getX(), 200);
-        assertEquals(action.getY(), 400);
+        assertEquals(action.getDuration(), new Float(10));
+        assertEquals(action.getX(), 200, 1e-15);
+        assertEquals(action.getY(), 400, 1e-15);
 
         assertFalse(tick.hasNext());
 
@@ -98,19 +98,19 @@ public class ActionSequenceTest {
         assertEquals(action.getId(), "finger1");
         assertEquals(action.getType(), POINTER);
         assertEquals(action.getSubType(), POINTER_MOVE);
-        assertEquals(action.getDuration(), new Long(1000));
+        assertEquals(action.getDuration(), new Float(1000));
         assertTrue(action.getPointer().equals(PointerType.TOUCH));
-        assertEquals(action.getX(), 20);
-        assertEquals(action.getY(), 0);
+        assertEquals(action.getX(), 20, 1e-15);
+        assertEquals(action.getY(), 0, 1e-15);
 
         action = tick.next();
         assertEquals(action.getId(), "finger2");
         assertEquals(action.getType(), POINTER);
         assertEquals(action.getSubType(), POINTER_MOVE);
-        assertEquals(action.getDuration(), new Long(1000));
+        assertEquals(action.getDuration(), new Float(1000));
         assertEquals(action.getOrigin().getType(), InputSource.POINTER);
-        assertEquals(action.getX(), 50);
-        assertEquals(action.getY(), 0);
+        assertEquals(action.getX(), 50, 1e-15);
+        assertEquals(action.getY(), 0, 1e-15);
 
         assertFalse(tick.hasNext());
 
@@ -136,7 +136,7 @@ public class ActionSequenceTest {
         assertEquals(action.getId(), "finger2");
         assertEquals(action.getType(), POINTER);
         assertEquals(action.getSubType(), PAUSE);
-        assertEquals(action.getDuration(), new Long(0));
+        assertEquals(action.getDuration(), new Float(0));
 
         assertFalse(tick.hasNext());
         assertFalse(actionSequence.hasNext());
@@ -204,10 +204,10 @@ public class ActionSequenceTest {
         PointerInputState finger1State = (PointerInputState) inputStateTable.getInputState("finger1");
         PointerInputState finger2State = (PointerInputState) inputStateTable.getInputState("finger2");
 
-        assertEquals(finger1State.getX(), 120);
-        assertEquals(finger1State.getY(), 100);
-        assertEquals(finger2State.getX(), 250);
-        assertEquals(finger2State.getY(), 400);
+        assertEquals(finger1State.getX(), 120, 1e-15);
+        assertEquals(finger1State.getY(), 100, 1e-15);
+        assertEquals(finger2State.getX(), 250, 1e-15);
+        assertEquals(finger2State.getY(), 400, 1e-15);
     }
 
     @Test

--- a/espresso-server/app/src/test/java/io/appium/espressoserver/test/helpers/w3c/ActionSequenceTest.java
+++ b/espresso-server/app/src/test/java/io/appium/espressoserver/test/helpers/w3c/ActionSequenceTest.java
@@ -49,16 +49,16 @@ public class ActionSequenceTest {
         assertEquals(action.getType(), POINTER);
         assertEquals(action.getSubType(), POINTER_MOVE);
         assertEquals(action.getDuration(), new Float(0));
-        assertEquals(action.getX(), 100, 1e-15);
-        assertEquals(action.getY(), 100, 1e-15);
+        assertEquals(action.getX(), 100, Math.ulp(1.0));
+        assertEquals(action.getY(), 100, Math.ulp(1.0));
 
         action = tick.next();
         assertEquals(action.getId(), "finger2");
         assertEquals(action.getType(), POINTER);
         assertEquals(action.getSubType(), POINTER_MOVE);
         assertEquals(action.getDuration(), new Float(10));
-        assertEquals(action.getX(), 200, 1e-15);
-        assertEquals(action.getY(), 400, 1e-15);
+        assertEquals(action.getX(), 200, Math.ulp(1.0));
+        assertEquals(action.getY(), 400, Math.ulp(1.0));
 
         assertFalse(tick.hasNext());
 
@@ -100,8 +100,8 @@ public class ActionSequenceTest {
         assertEquals(action.getSubType(), POINTER_MOVE);
         assertEquals(action.getDuration(), new Float(1000));
         assertTrue(action.getPointer().equals(PointerType.TOUCH));
-        assertEquals(action.getX(), 20, 1e-15);
-        assertEquals(action.getY(), 0, 1e-15);
+        assertEquals(action.getX(), 20, Math.ulp(1.0));
+        assertEquals(action.getY(), 0, Math.ulp(1.0));
 
         action = tick.next();
         assertEquals(action.getId(), "finger2");
@@ -109,8 +109,8 @@ public class ActionSequenceTest {
         assertEquals(action.getSubType(), POINTER_MOVE);
         assertEquals(action.getDuration(), new Float(1000));
         assertEquals(action.getOrigin().getType(), InputSource.POINTER);
-        assertEquals(action.getX(), 50, 1e-15);
-        assertEquals(action.getY(), 0, 1e-15);
+        assertEquals(action.getX(), 50, Math.ulp(1.0));
+        assertEquals(action.getY(), 0, Math.ulp(1.0));
 
         assertFalse(tick.hasNext());
 
@@ -204,10 +204,10 @@ public class ActionSequenceTest {
         PointerInputState finger1State = (PointerInputState) inputStateTable.getInputState("finger1");
         PointerInputState finger2State = (PointerInputState) inputStateTable.getInputState("finger2");
 
-        assertEquals(finger1State.getX(), 120, 1e-15);
-        assertEquals(finger1State.getY(), 100, 1e-15);
-        assertEquals(finger2State.getX(), 250, 1e-15);
-        assertEquals(finger2State.getY(), 400, 1e-15);
+        assertEquals(finger1State.getX(), 120, Math.ulp(1.0));
+        assertEquals(finger1State.getY(), 100, Math.ulp(1.0));
+        assertEquals(finger2State.getX(), 250, Math.ulp(1.0));
+        assertEquals(finger2State.getY(), 400, Math.ulp(1.0));
     }
 
     @Test

--- a/espresso-server/app/src/test/java/io/appium/espressoserver/test/helpers/w3c/ActionsTest.java
+++ b/espresso-server/app/src/test/java/io/appium/espressoserver/test/helpers/w3c/ActionsTest.java
@@ -37,7 +37,7 @@ public class ActionsTest {
     }
 
     @Test
-    public void shouldThrowIfAdapterNotSet() throws IOException, AppiumException {
+    public void shouldThrowIfAdapterNotSet() throws IOException {
         String multiTouchJson = Helpers.readAssetFile("multi-touch-actions.json");
         Actions actions = Actions.class.cast((new Gson()).fromJson(multiTouchJson, Actions.class));
 
@@ -62,10 +62,10 @@ public class ActionsTest {
         PointerInputState finger2 = (PointerInputState) inputStateTable.getInputState("finger2");
 
         // Check the state
-        assertEquals(finger1.getX(), 120);
-        assertEquals(finger1.getY(), 100);
-        assertEquals(finger2.getX(), 250);
-        assertEquals(finger2.getY(), 400);
+        assertEquals(finger1.getX(), 120, 1e-15);
+        assertEquals(finger1.getY(), 100, 1e-15);
+        assertEquals(finger2.getX(), 250, 1e-15);
+        assertEquals(finger2.getY(), 400, 1e-15);
 
         // Sanity check that it's recording pointer move events
         List<PointerMoveEvent> pointerMoveEvents = ((DummyW3CActionAdapter) actions.getAdapter()).getPointerMoveEvents();

--- a/espresso-server/app/src/test/java/io/appium/espressoserver/test/helpers/w3c/ActionsTest.java
+++ b/espresso-server/app/src/test/java/io/appium/espressoserver/test/helpers/w3c/ActionsTest.java
@@ -62,10 +62,10 @@ public class ActionsTest {
         PointerInputState finger2 = (PointerInputState) inputStateTable.getInputState("finger2");
 
         // Check the state
-        assertEquals(finger1.getX(), 120, 1e-15);
-        assertEquals(finger1.getY(), 100, 1e-15);
-        assertEquals(finger2.getX(), 250, 1e-15);
-        assertEquals(finger2.getY(), 400, 1e-15);
+        assertEquals(finger1.getX(), 120, Math.ulp(1.0));
+        assertEquals(finger1.getY(), 100, Math.ulp(1.0));
+        assertEquals(finger2.getX(), 250, Math.ulp(1.0));
+        assertEquals(finger2.getY(), 400, Math.ulp(1.0));
 
         // Sanity check that it's recording pointer move events
         List<PointerMoveEvent> pointerMoveEvents = ((DummyW3CActionAdapter) actions.getAdapter()).getPointerMoveEvents();

--- a/espresso-server/app/src/test/java/io/appium/espressoserver/test/helpers/w3c/InputSourceTest.java
+++ b/espresso-server/app/src/test/java/io/appium/espressoserver/test/helpers/w3c/InputSourceTest.java
@@ -63,9 +63,9 @@ public class InputSourceTest {
         List<Action> actions = inputSource.getActions();
         Action actionOne = actions.get(0);
         assertEquals(actionOne.getType(), ActionType.POINTER_MOVE);
-        assertEquals(actionOne.getDuration(), 0.0, 1e-15);
-        assertEquals(actionOne.getX(), 100.0, 1e-15);
-        assertEquals(actionOne.getY(), 200.0, 1e-15);
+        assertEquals(actionOne.getDuration(), 0.0, Math.ulp(1.0));
+        assertEquals(actionOne.getX(), 100.0, Math.ulp(1.0));
+        assertEquals(actionOne.getY(), 200.0, Math.ulp(1.0));
 
         Action actionTwo = actions.get(1);
         assertEquals(actionTwo.getType(), ActionType.POINTER_DOWN);
@@ -73,15 +73,15 @@ public class InputSourceTest {
 
         Action actionThree = actions.get(2);
         assertEquals(actionThree.getType(), ActionType.PAUSE);
-        assertEquals(actionThree.getDuration(), 500.0, 1e-15);
+        assertEquals(actionThree.getDuration(), 500.0, Math.ulp(1.0));
 
         Action actionFour = actions.get(3);
         assertEquals(actionFour.getType(), ActionType.POINTER_MOVE);
-        assertEquals(actionFour.getDuration(), 1000.0, 1e-15);
+        assertEquals(actionFour.getDuration(), 1000.0, Math.ulp(1.0));
         assertEquals(actionFour.getOrigin().getType(), "pointer");
         assertTrue(actionFour.isOriginPointer());
-        assertEquals(actionFour.getX(), 50.0, 1e-15);
-        assertEquals(actionFour.getY(), 10.0, 1e-15);
+        assertEquals(actionFour.getX(), 50.0, Math.ulp(1.0));
+        assertEquals(actionFour.getY(), 10.0, Math.ulp(1.0));
 
         Action actionFive = actions.get(4);
         assertEquals(actionFive.getType(), ActionType.POINTER_UP);

--- a/espresso-server/app/src/test/java/io/appium/espressoserver/test/helpers/w3c/InputSourceTest.java
+++ b/espresso-server/app/src/test/java/io/appium/espressoserver/test/helpers/w3c/InputSourceTest.java
@@ -63,9 +63,9 @@ public class InputSourceTest {
         List<Action> actions = inputSource.getActions();
         Action actionOne = actions.get(0);
         assertEquals(actionOne.getType(), ActionType.POINTER_MOVE);
-        assertEquals(actionOne.getDuration(), new Long(0));
-        assertEquals(actionOne.getX(), new Long(100));
-        assertEquals(actionOne.getY(), new Long(200));
+        assertEquals(actionOne.getDuration(), 0.0, 1e-15);
+        assertEquals(actionOne.getX(), 100.0, 1e-15);
+        assertEquals(actionOne.getY(), 200.0, 1e-15);
 
         Action actionTwo = actions.get(1);
         assertEquals(actionTwo.getType(), ActionType.POINTER_DOWN);
@@ -73,15 +73,15 @@ public class InputSourceTest {
 
         Action actionThree = actions.get(2);
         assertEquals(actionThree.getType(), ActionType.PAUSE);
-        assertEquals(actionThree.getDuration(), new Long(500));
+        assertEquals(actionThree.getDuration(), 500.0, 1e-15);
 
         Action actionFour = actions.get(3);
         assertEquals(actionFour.getType(), ActionType.POINTER_MOVE);
-        assertEquals(actionFour.getDuration(), new Long(1000));
+        assertEquals(actionFour.getDuration(), 1000.0, 1e-15);
         assertEquals(actionFour.getOrigin().getType(), "pointer");
         assertTrue(actionFour.isOriginPointer());
-        assertEquals(actionFour.getX(), new Long(50));
-        assertEquals(actionFour.getY(), new Long(10));
+        assertEquals(actionFour.getX(), 50.0, 1e-15);
+        assertEquals(actionFour.getY(), 10.0, 1e-15);
 
         Action actionFive = actions.get(4);
         assertEquals(actionFive.getType(), ActionType.POINTER_UP);

--- a/espresso-server/app/src/test/java/io/appium/espressoserver/test/helpers/w3c/PointerDispatchTest.java
+++ b/espresso-server/app/src/test/java/io/appium/espressoserver/test/helpers/w3c/PointerDispatchTest.java
@@ -86,8 +86,8 @@ public class PointerDispatchTest {
 
         List<PointerMoveEvent> pointerMoveEvents = dummyW3CActionAdapter.getPointerMoveEvents();
         assertEquals(dummyW3CActionAdapter.getPointerMoveEvents().size(), 1);
-        assertEquals(pointerMoveEvents.get(pointerMoveEvents.size() - 1).x, 30);
-        assertEquals(pointerMoveEvents.get(pointerMoveEvents.size() - 1).y, 40);
+        assertEquals(pointerMoveEvents.get(pointerMoveEvents.size() - 1).x, 30, 1e-15);
+        assertEquals(pointerMoveEvents.get(pointerMoveEvents.size() - 1).y, 40, 1e-15);
     }
 
     @Test
@@ -116,15 +116,15 @@ public class PointerDispatchTest {
 
         List<PointerMoveEvent> pointerMoveEvents = dummyW3CActionAdapter.getPointerMoveEvents();
         assertTrue(Math.abs(pointerMoveEvents.size() - 20) <= 2); // Should be 20 moves per the 1 second (give or take 1)
-        assertEquals(pointerMoveEvents.get(0).currentX, 10);
-        assertEquals(pointerMoveEvents.get(0).currentY, 20);
-        assertEquals(pointerMoveEvents.get(pointerMoveEvents.size() - 1).x, 30);
-        assertEquals(pointerMoveEvents.get(pointerMoveEvents.size() - 1).y, 40);
+        assertEquals(pointerMoveEvents.get(0).currentX, 10, 1e-15);
+        assertEquals(pointerMoveEvents.get(0).currentY, 20, 1e-15);
+        assertEquals(pointerMoveEvents.get(pointerMoveEvents.size() - 1).x, 30, 1e-15);
+        assertEquals(pointerMoveEvents.get(pointerMoveEvents.size() - 1).y, 40, 1e-15);
 
-        long prevX = 10;
-        long prevY = 10;
-        long currX;
-        long currY;
+        float prevX = 10;
+        float prevY = 10;
+        float currX;
+        float currY;
         for(PointerMoveEvent pointerMoveEvent:pointerMoveEvents) {
             currX = pointerMoveEvent.x;
             currY = pointerMoveEvent.y;
@@ -134,8 +134,8 @@ public class PointerDispatchTest {
             prevY = currY;
         }
 
-        assertEquals(pointerInputSource.getX(), 30);
-        assertEquals(pointerInputSource.getY(), 40);
+        assertEquals(pointerInputSource.getX(), 30, 1e-15);
+        assertEquals(pointerInputSource.getY(), 40, 1e-15);
     }
 
     @Test
@@ -223,8 +223,8 @@ public class PointerDispatchTest {
             ActionObject actionObject = new ActionObject(
                     "id", InputSourceType.POINTER, POINTER_MOVE, 0
             );
-            actionObject.setX(badX[i]);
-            actionObject.setY(badY[i]);
+            actionObject.setX((float) badX[i]);
+            actionObject.setY((float) badY[i]);
             actionObject.setOrigin(new Origin(badOrigin[i]));
 
             try {
@@ -261,8 +261,8 @@ public class PointerDispatchTest {
             ActionObject actionObject = new ActionObject(
                     "id", InputSourceType.POINTER, POINTER_MOVE, 0
             );
-            actionObject.setX(xCoords[i]);
-            actionObject.setY(yCoords[i]);
+            actionObject.setX((float) xCoords[i]);
+            actionObject.setY((float) yCoords[i]);
             actionObject.setOrigin(new Origin(origins[i]));
 
             ExecutorService executorService = Executors.newSingleThreadExecutor();
@@ -271,8 +271,8 @@ public class PointerDispatchTest {
             executorService.submit(callable).get();
             executorService.shutdown();
 
-            assertEquals(pointerInputState.getX(), expectedX[i]);
-            assertEquals(pointerInputState.getY(), expectedY[i]);
+            assertEquals(pointerInputState.getX(), expectedX[i], 1e-15);
+            assertEquals(pointerInputState.getY(), expectedY[i], 1e-15);
         }
     }
 
@@ -303,7 +303,7 @@ public class PointerDispatchTest {
         class TempDummyAdapter extends DummyW3CActionAdapter {
             @Override
             public void pointerDown(int button, String sourceId, PointerType pointerType,
-                                    Long x, Long y, Set<Integer> depressedButtons,
+                                    Float x, Float y, Set<Integer> depressedButtons,
                                     KeyInputState globalKeyInputState) throws AppiumException {
                 throw new AppiumException("Should not reach this point. Button already pressed.");
             }
@@ -347,7 +347,7 @@ public class PointerDispatchTest {
         class TempDummyAdapter extends DummyW3CActionAdapter {
             @Override
             public void pointerUp(int button, String sourceId, PointerType pointerType,
-                                  Long x, Long y, Set<Integer> depressedButtons,
+                                  Float x, Float y, Set<Integer> depressedButtons,
                                   KeyInputState globalKeyInputState) throws AppiumException {
                 throw new AppiumException("Should not reach this point. Button already pressed.");
             }

--- a/espresso-server/app/src/test/java/io/appium/espressoserver/test/helpers/w3c/PointerDispatchTest.java
+++ b/espresso-server/app/src/test/java/io/appium/espressoserver/test/helpers/w3c/PointerDispatchTest.java
@@ -86,8 +86,8 @@ public class PointerDispatchTest {
 
         List<PointerMoveEvent> pointerMoveEvents = dummyW3CActionAdapter.getPointerMoveEvents();
         assertEquals(dummyW3CActionAdapter.getPointerMoveEvents().size(), 1);
-        assertEquals(pointerMoveEvents.get(pointerMoveEvents.size() - 1).x, 30, 1e-15);
-        assertEquals(pointerMoveEvents.get(pointerMoveEvents.size() - 1).y, 40, 1e-15);
+        assertEquals(pointerMoveEvents.get(pointerMoveEvents.size() - 1).x, 30, Math.ulp(1.0));
+        assertEquals(pointerMoveEvents.get(pointerMoveEvents.size() - 1).y, 40, Math.ulp(1.0));
     }
 
     @Test
@@ -116,10 +116,10 @@ public class PointerDispatchTest {
 
         List<PointerMoveEvent> pointerMoveEvents = dummyW3CActionAdapter.getPointerMoveEvents();
         assertTrue(Math.abs(pointerMoveEvents.size() - 20) <= 2); // Should be 20 moves per the 1 second (give or take 1)
-        assertEquals(pointerMoveEvents.get(0).currentX, 10, 1e-15);
-        assertEquals(pointerMoveEvents.get(0).currentY, 20, 1e-15);
-        assertEquals(pointerMoveEvents.get(pointerMoveEvents.size() - 1).x, 30, 1e-15);
-        assertEquals(pointerMoveEvents.get(pointerMoveEvents.size() - 1).y, 40, 1e-15);
+        assertEquals(pointerMoveEvents.get(0).currentX, 10, Math.ulp(1.0));
+        assertEquals(pointerMoveEvents.get(0).currentY, 20, Math.ulp(1.0));
+        assertEquals(pointerMoveEvents.get(pointerMoveEvents.size() - 1).x, 30, Math.ulp(1.0));
+        assertEquals(pointerMoveEvents.get(pointerMoveEvents.size() - 1).y, 40, Math.ulp(1.0));
 
         float prevX = 10;
         float prevY = 10;
@@ -134,8 +134,8 @@ public class PointerDispatchTest {
             prevY = currY;
         }
 
-        assertEquals(pointerInputSource.getX(), 30, 1e-15);
-        assertEquals(pointerInputSource.getY(), 40, 1e-15);
+        assertEquals(pointerInputSource.getX(), 30, Math.ulp(1.0));
+        assertEquals(pointerInputSource.getY(), 40, Math.ulp(1.0));
     }
 
     @Test
@@ -271,8 +271,8 @@ public class PointerDispatchTest {
             executorService.submit(callable).get();
             executorService.shutdown();
 
-            assertEquals(pointerInputState.getX(), expectedX[i], 1e-15);
-            assertEquals(pointerInputState.getY(), expectedY[i], 1e-15);
+            assertEquals(pointerInputState.getX(), expectedX[i], Math.ulp(1.0));
+            assertEquals(pointerInputState.getY(), expectedY[i], Math.ulp(1.0));
         }
     }
 

--- a/espresso-server/app/src/test/java/io/appium/espressoserver/test/helpers/w3c/ProcessorTest.java
+++ b/espresso-server/app/src/test/java/io/appium/espressoserver/test/helpers/w3c/ProcessorTest.java
@@ -88,11 +88,11 @@ public class ProcessorTest {
         Action action = new Action();
         action.setDuration(10L);
         ActionObject actionObject = processPauseAction(action, InputSourceType.NONE, "any", 0);
-        assertEquals(actionObject.getDuration(), new Long(10));
+        assertEquals(actionObject.getDuration(), new Float(10));
     }
 
     @Test
-    public void shouldRejectNullIfTypeNotPause() throws InvalidArgumentException {
+    public void shouldRejectNullIfTypeNotPause() {
         Action action = new Action();
         try {
             processPauseAction(action, InputSourceType.NONE, "any", 0);
@@ -107,11 +107,11 @@ public class ProcessorTest {
         action.setDuration(100);
         action.setType(ActionType.PAUSE);
         processPauseAction(action, InputSourceType.NONE, "any", 0);
-        assertEquals(action.getDuration(), new Long(100));
+        assertEquals(action.getDuration(), new Float(100));
     }
 
     @Test
-    public void shouldRejectPointerMoveIfNegativeDuration() throws InvalidArgumentException {
+    public void shouldRejectPointerMoveIfNegativeDuration() {
         Action action = new Action();
         action.setDuration(-1);
         try {
@@ -129,13 +129,13 @@ public class ProcessorTest {
         action.setY(200);
         action.setDuration(300);
         ActionObject actionObject = processPointerMoveAction(action, InputSourceType.POINTER, "any", 0);
-        assertEquals(actionObject.getX(), 100);
-        assertEquals(actionObject.getY(), 200);
-        assertEquals(actionObject.getDuration(), new Long(300));
+        assertEquals(actionObject.getX(), 100, 1e-15);
+        assertEquals(actionObject.getY(), 200, 1e-15);
+        assertEquals(actionObject.getDuration(), new Float(300));
     }
 
     @Test
-    public void shouldRejectPointerUpOrDownIfButtonNegative() throws InvalidArgumentException {
+    public void shouldRejectPointerUpOrDownIfButtonNegative() {
         Action action = new Action();
         action.setButton(-100);
         try {
@@ -164,13 +164,13 @@ public class ProcessorTest {
         action.setType(ActionType.PAUSE);
         action.setDuration(300);
         ActionObject actionObject = processKeyAction(action, InputSourceType.KEY, "any", 0);
-        assertEquals(actionObject.getDuration(), new Long(300));
+        assertEquals(actionObject.getDuration(), new Float(300));
         assertEquals(actionObject.getSubType(), ActionType.PAUSE);
         assertEquals(actionObject.getType(), InputSourceType.KEY);
     }
 
     @Test
-    public void shouldRejectKeyIfNotUnicode() throws InvalidArgumentException {
+    public void shouldRejectKeyIfNotUnicode() {
         Action action = new Action();
         action.setType(ActionType.KEY_DOWN);
         action.setValue("asdfafsd");
@@ -211,7 +211,7 @@ public class ProcessorTest {
         action.setType(ActionType.PAUSE);
         action.setDuration(300);
         ActionObject actionObject = processPointerAction(action, pointerInputSource, "any", 0);
-        assertEquals(actionObject.getDuration(), new Long(300));
+        assertEquals(actionObject.getDuration(), new Float(300));
         assertEquals(actionObject.getSubType(), ActionType.PAUSE);
         assertEquals(actionObject.getType(), InputSourceType.POINTER);
     }
@@ -244,7 +244,7 @@ public class ProcessorTest {
     }
 
     @Test
-    public void shouldNotPassProcessorIfNoType() throws InvalidArgumentException, NotYetImplementedException {
+    public void shouldNotPassProcessorIfNoType() throws NotYetImplementedException {
         InputSource inputSource = new InputSource();
         try {
             processSourceActionSequence(inputSource, new ActiveInputSources(), new InputStateTable());
@@ -254,7 +254,7 @@ public class ProcessorTest {
     }
 
     @Test
-    public void shouldNotPassProcessorIfNoId() throws InvalidArgumentException, NotYetImplementedException {
+    public void shouldNotPassProcessorIfNoId() throws NotYetImplementedException {
         InputSource inputSource = new InputSource();
         inputSource.setType(InputSourceType.KEY);
         try {

--- a/espresso-server/app/src/test/java/io/appium/espressoserver/test/helpers/w3c/ProcessorTest.java
+++ b/espresso-server/app/src/test/java/io/appium/espressoserver/test/helpers/w3c/ProcessorTest.java
@@ -129,8 +129,8 @@ public class ProcessorTest {
         action.setY(200);
         action.setDuration(300);
         ActionObject actionObject = processPointerMoveAction(action, InputSourceType.POINTER, "any", 0);
-        assertEquals(actionObject.getX(), 100, 1e-15);
-        assertEquals(actionObject.getY(), 200, 1e-15);
+        assertEquals(actionObject.getX(), 100, Math.ulp(1.0));
+        assertEquals(actionObject.getY(), 200, Math.ulp(1.0));
         assertEquals(actionObject.getDuration(), new Float(300));
     }
 

--- a/espresso-server/app/src/test/java/io/appium/espressoserver/test/helpers/w3c/TickTest.java
+++ b/espresso-server/app/src/test/java/io/appium/espressoserver/test/helpers/w3c/TickTest.java
@@ -44,10 +44,10 @@ import static org.junit.Assert.fail;
 public class TickTest {
 
     @Test
-    public void shouldCalculateMaxDurationZeroIfNoDurations() throws ExecutionException, InterruptedException {
+    public void shouldCalculateMaxDurationZeroIfNoDurations() {
         Tick tick = new Tick();
         tick.addAction(new ActionObject());
-        assertEquals(tick.calculateTickDuration(), 0);
+        assertEquals(tick.calculateTickDuration(), 0, 1e-15);
     }
 
     @Test
@@ -62,12 +62,12 @@ public class TickTest {
             ActionObject actionObjectOne = new ActionObject();
             actionObjectOne.setType(NONE);
             actionObjectOne.setSubType(PAUSE);
-            actionObjectOne.setDuration(valueOne[i]);
+            actionObjectOne.setDuration((float) valueOne[i]);
 
             ActionObject actionObjectTwo = new ActionObject();
             actionObjectTwo.setType(POINTER);
             actionObjectTwo.setSubType(POINTER_MOVE);
-            actionObjectTwo.setDuration(valueTwo[i]);
+            actionObjectTwo.setDuration((float) valueTwo[i]);
 
             ActionObject actionObjectThree = new ActionObject();
             actionObjectTwo.setType(POINTER);
@@ -77,7 +77,7 @@ public class TickTest {
             tick.addAction(actionObjectTwo);
             tick.addAction(actionObjectThree);
 
-            assertEquals(tick.calculateTickDuration(), expectedMax[i]);
+            assertEquals(tick.calculateTickDuration(), expectedMax[i], 1e-15);
         }
     }
 
@@ -188,16 +188,16 @@ public class TickTest {
         ActionObject actionObjectOne = new ActionObject(sourceId, POINTER, null, 0);
         actionObjectOne.setSubType(POINTER_MOVE);
         actionObjectOne.setPointer(TOUCH);
-        actionObjectOne.setX(10L);
-        actionObjectOne.setY(20L);
+        actionObjectOne.setX(10.0F);
+        actionObjectOne.setY(20.0F);
         actionObjectOne.setOrigin(new Origin(VIEWPORT));
 
         // Construct another pointer move event
         ActionObject actionObjectTwo = new ActionObject(sourceId2, POINTER, null, 0);
         actionObjectTwo.setSubType(POINTER_MOVE);
         actionObjectTwo.setPointer(TOUCH);
-        actionObjectTwo.setX(10L);
-        actionObjectTwo.setY(20L);
+        actionObjectTwo.setX(10.0F);
+        actionObjectTwo.setY(20.0F);
         actionObjectTwo.setOrigin(new Origin(VIEWPORT));
 
         // Add two pointer move actions to verify that they can run on multiple threads separately
@@ -208,10 +208,10 @@ public class TickTest {
             @Override
             public void pointerMove(String sourceIdCalled,
                                     PointerType pointerType,
-                                    long currentX, long currentY,
-                                    long x, long y,
+                                    float currentX, float currentY,
+                                    float x, float y,
                                     Set<Integer> buttons,
-                                    KeyInputState globalKeyInputState) throws AppiumException {
+                                    KeyInputState globalKeyInputState) {
                 assertEquals(pointerType, TOUCH);
                 assertEquals(currentX, 5L);
                 assertEquals(currentY, 6L);
@@ -221,7 +221,7 @@ public class TickTest {
                 assertTrue(buttons.contains(1));
                 assertTrue(globalKeyInputState.isShift());
             }
-        };
+        }
 
         final W3CActionAdapter dummyAdapter = new ExtendedDummyW3CActionAdapter();
 

--- a/espresso-server/app/src/test/java/io/appium/espressoserver/test/helpers/w3c/TickTest.java
+++ b/espresso-server/app/src/test/java/io/appium/espressoserver/test/helpers/w3c/TickTest.java
@@ -47,7 +47,7 @@ public class TickTest {
     public void shouldCalculateMaxDurationZeroIfNoDurations() {
         Tick tick = new Tick();
         tick.addAction(new ActionObject());
-        assertEquals(tick.calculateTickDuration(), 0, 1e-15);
+        assertEquals(tick.calculateTickDuration(), 0, Math.ulp(1.0));
     }
 
     @Test
@@ -77,7 +77,7 @@ public class TickTest {
             tick.addAction(actionObjectTwo);
             tick.addAction(actionObjectThree);
 
-            assertEquals(tick.calculateTickDuration(), expectedMax[i], 1e-15);
+            assertEquals(tick.calculateTickDuration(), expectedMax[i], Math.ulp(1.0));
         }
     }
 

--- a/espresso-server/app/src/test/java/io/appium/espressoserver/test/model/TouchActionTest.java
+++ b/espresso-server/app/src/test/java/io/appium/espressoserver/test/model/TouchActionTest.java
@@ -54,8 +54,8 @@ public class TouchActionTest {
         assertEquals(actions.get(0).getType(), PAUSE);
         assertEquals(actions.get(1).getType(), PAUSE);
         Action action = actions.get(2);
-        assertEquals(action.getX(), new Long(100));
-        assertEquals(action.getY(), new Long(200));
+        assertEquals(action.getX(), 100.0, 1e-15);
+        assertEquals(action.getY(), 200.0, 1e-15);
         assertEquals(action.getType(), POINTER_MOVE);
         assertTrue(action.isOriginViewport());
     }
@@ -76,8 +76,8 @@ public class TouchActionTest {
 
             Action moveAction = actions.get(0);
             assertEquals(moveAction.getType(), POINTER_MOVE);
-            assertEquals(moveAction.getX(), new Long(100));
-            assertEquals(moveAction.getY(), new Long(200));
+            assertEquals(moveAction.getX(), 100.0, 1e-15);
+            assertEquals(moveAction.getY(), 200.0, 1e-15);
 
             Action upAction = actions.get(1);
             assertEquals(upAction.getType(), POINTER_DOWN);

--- a/espresso-server/app/src/test/java/io/appium/espressoserver/test/model/TouchActionTest.java
+++ b/espresso-server/app/src/test/java/io/appium/espressoserver/test/model/TouchActionTest.java
@@ -54,8 +54,8 @@ public class TouchActionTest {
         assertEquals(actions.get(0).getType(), PAUSE);
         assertEquals(actions.get(1).getType(), PAUSE);
         Action action = actions.get(2);
-        assertEquals(action.getX(), 100.0, 1e-15);
-        assertEquals(action.getY(), 200.0, 1e-15);
+        assertEquals(action.getX(), 100.0, Math.ulp(1.0));
+        assertEquals(action.getY(), 200.0, Math.ulp(1.0));
         assertEquals(action.getType(), POINTER_MOVE);
         assertTrue(action.isOriginViewport());
     }
@@ -76,8 +76,8 @@ public class TouchActionTest {
 
             Action moveAction = actions.get(0);
             assertEquals(moveAction.getType(), POINTER_MOVE);
-            assertEquals(moveAction.getX(), 100.0, 1e-15);
-            assertEquals(moveAction.getY(), 200.0, 1e-15);
+            assertEquals(moveAction.getX(), 100.0, Math.ulp(1.0));
+            assertEquals(moveAction.getY(), 200.0, Math.ulp(1.0));
 
             Action upAction = actions.get(1);
             assertEquals(upAction.getType(), POINTER_DOWN);


### PR DESCRIPTION
* Use floats as type for `x`, `y` and `duration` so that it doesn't break when a float is provided in Actions JSON
* When floats are provided in Actions JSON, round the values and provide warning to user if rounded value is different from provided value
* Also, add 'warn' as a log type (along with 'info', 'debug' and 'error')