### PR TITLE
Add mobile: endpoint to verify toast messages presence

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetToastVisibility.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetToastVisibility.java
@@ -37,11 +37,7 @@ public class GetToastVisibility implements RequestHandler<ToastLookupParams, Boo
             ViewInteraction viewInteraction = params.isRegexp()
                     ? onView(withRegexp(Pattern.compile(params.getText()))).inRoot(new ToastMatcher())
                     : onView(withText(params.getText())).inRoot(new ToastMatcher());
-            if (params.isRegexp()) {
-                viewInteraction.check(matches(isDisplayed()));
-            } else {
-                viewInteraction.check(matches(isDisplayed()));
-            }
+            viewInteraction.check(matches(isDisplayed()));
             return true;
         } catch (Exception e) {
             if (e instanceof EspressoException) {

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetToastVisibility.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetToastVisibility.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.espressoserver.lib.handlers;
+
+import java.util.regex.Pattern;
+
+import androidx.test.espresso.EspressoException;
+import androidx.test.espresso.ViewInteraction;
+import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
+import io.appium.espressoserver.lib.model.ToastLookupParams;
+import io.appium.espressoserver.lib.viewmatcher.ToastMatcher;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static io.appium.espressoserver.lib.viewmatcher.RegexpTextMatcher.withRegexp;
+
+public class GetToastVisibility implements RequestHandler<ToastLookupParams, Boolean> {
+    @Override
+    public Boolean handle(ToastLookupParams params) throws AppiumException {
+        try {
+            ViewInteraction viewInteraction = params.isRegexp()
+                    ? onView(withRegexp(Pattern.compile(params.getText()))).inRoot(new ToastMatcher())
+                    : onView(withText(params.getText())).inRoot(new ToastMatcher());
+            if (params.isRegexp()) {
+                viewInteraction.check(matches(isDisplayed()));
+            } else {
+                viewInteraction.check(matches(isDisplayed()));
+            }
+            return true;
+        } catch (Exception e) {
+            if (e instanceof EspressoException) {
+                return false;
+            }
+            throw e;
+        }
+    }
+}

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.java
@@ -50,6 +50,7 @@ import io.appium.espressoserver.lib.handlers.GetSelected;
 import io.appium.espressoserver.lib.handlers.GetSession;
 import io.appium.espressoserver.lib.handlers.GetSessions;
 import io.appium.espressoserver.lib.handlers.GetSize;
+import io.appium.espressoserver.lib.handlers.GetToastVisibility;
 import io.appium.espressoserver.lib.handlers.GetWindowRect;
 import io.appium.espressoserver.lib.handlers.GetWindowSize;
 import io.appium.espressoserver.lib.handlers.HideKeyboard;
@@ -101,6 +102,7 @@ import io.appium.espressoserver.lib.model.Session;
 import io.appium.espressoserver.lib.model.SessionParams;
 import io.appium.espressoserver.lib.model.StartActivityParams;
 import io.appium.espressoserver.lib.model.TextParams;
+import io.appium.espressoserver.lib.model.ToastLookupParams;
 
 import static io.appium.espressoserver.lib.handlers.PointerEventHandler.TouchType.CLICK;
 import static io.appium.espressoserver.lib.handlers.PointerEventHandler.TouchType.DOUBLE_CLICK;
@@ -192,6 +194,7 @@ class Router {
 
         // 'execute mobile' commands
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/appium/execute_mobile/:elementId/swipe", new MobileSwipe(), MobileSwipeParams.class));
+        routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/appium/execute_mobile/is_toast_displayed", new GetToastVisibility(), ToastLookupParams.class));
 
         // Not implemented
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/touch/flick", new NotYetImplemented(), AppiumParams.class));

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/ToastLookupParams.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/ToastLookupParams.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.espressoserver.lib.model;
+
+import javax.annotation.Nullable;
+
+@SuppressWarnings("unused")
+public class ToastLookupParams extends AppiumParams {
+    private String text;
+    private Boolean isRegexp;
+
+    @Nullable
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    public boolean isRegexp() {
+        return isRegexp == null ? false : isRegexp;
+    }
+
+    public void setIsRegexp(Boolean isRegexp) {
+        this.isRegexp = isRegexp;
+    }
+}

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/viewmatcher/RegexpTextMatcher.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/viewmatcher/RegexpTextMatcher.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.espressoserver.lib.viewmatcher;
+
+import android.view.View;
+import android.widget.TextView;
+
+import org.hamcrest.Description;
+
+import java.util.regex.Pattern;
+
+import androidx.test.espresso.matcher.BoundedMatcher;
+
+public class RegexpTextMatcher extends BoundedMatcher<View, TextView> {
+    public static RegexpTextMatcher withRegexp(Pattern pattern) {
+        return new RegexpTextMatcher(pattern);
+    }
+
+    private final Pattern pattern;
+
+    private RegexpTextMatcher(Pattern pattern) {
+        super(TextView.class);
+
+        this.pattern = pattern;
+    }
+
+    @Override
+    protected boolean matchesSafely(TextView item) {
+        CharSequence text = item.getText();
+        if (text == null) {
+            return false;
+        }
+        return pattern.matcher(text).find();
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("with regexp: ")
+                .appendValue(pattern.toString());
+    }
+}

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/viewmatcher/ToastMatcher.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/viewmatcher/ToastMatcher.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.espressoserver.lib.viewmatcher;
+
+import android.view.WindowManager;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+import androidx.test.espresso.Root;
+
+public class ToastMatcher extends TypeSafeMatcher<Root> {
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("is toast");
+    }
+
+    @Override
+    public boolean matchesSafely(Root root) {
+        if (root.getWindowLayoutParams().get().type != WindowManager.LayoutParams.TYPE_TOAST) {
+            return false;
+        }
+        return root.getDecorView().getWindowToken() == root.getDecorView().getApplicationWindowToken();
+    }
+}

--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -6,9 +6,14 @@ let extensions = {};
 extensions.executeMobile = async function (mobileCommand, opts = {}) {
   const mobileCommandsMapping = {
     shell: 'mobileShell',
+
     performEditorAction: 'mobilePerformEditorAction',
+
     swipe: 'mobileSwipe',
+
     deviceInfo: 'mobileGetDeviceInfo',
+
+    isToastVisible: 'mobileIsToastVisible',
   };
 
   if (!_.has(mobileCommandsMapping, mobileCommand)) {

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import { util } from 'appium-support';
+import logger from '../logger';
 
 let commands = {}, helpers = {}, extensions = {};
 
@@ -28,6 +29,17 @@ commands.mobileSwipe = async function (opts = {}) {
 
 commands.mobileGetDeviceInfo = async function () {
   return await this.espresso.jwproxy.command('/appium/device/info', 'GET');
+};
+
+commands.mobileIsToastVisible = async function (opts = {}) {
+  const {text, isRegexp} = opts;
+  if (!util.hasValue(text)) {
+    logger.errorAndThrow(`'text' argument is mandatory`);
+  }
+  return await this.espresso.jwproxy.command('/appium/execute_mobile/is_toast_displayed', 'POST', {
+    text,
+    isRegexp,
+  });
 };
 
 // Stop proxying to any Chromedriver and redirect to Espresso


### PR DESCRIPTION
`mobile: isToastVisible`

Arguments:
`text` - mandatory argument. Either exact toast text or a regular expression (depending on `isRegexp ` value)
`isRegexp` - optional argument. If set to `true` then `text` will be parsed as regular expression pattern. By default the matching by exact toast text is performed.