### PR TITLE
Return null if resource id is unset

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/ViewElement.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/ViewElement.java
@@ -49,10 +49,8 @@ public class ViewElement {
         if (this.activity == null) {
             Activity result = getActivity(view.getContext());
             if (result == null && (view instanceof ViewGroup)) {
-                ViewGroup v = (ViewGroup) view;
-                int c = v.getChildCount();
-                for (int i = 0; i < c && result == null; ++i) {
-                    result = getActivity(v.getChildAt(i).getContext());
+                for (int i = 0; i < ((ViewGroup) view).getChildCount() && result == null; ++i) {
+                    result = getActivity(((ViewGroup) view).getChildAt(i).getContext());
                 }
             }
             this.activity = result;
@@ -73,14 +71,10 @@ public class ViewElement {
     }
 
     private static boolean isPasswordInputType(int inputType) {
-        final int variation =
-                inputType & (EditorInfo.TYPE_MASK_CLASS | EditorInfo.TYPE_MASK_VARIATION);
-        return variation
-                == (EditorInfo.TYPE_CLASS_TEXT | EditorInfo.TYPE_TEXT_VARIATION_PASSWORD)
-                || variation
-                == (EditorInfo.TYPE_CLASS_TEXT | EditorInfo.TYPE_TEXT_VARIATION_WEB_PASSWORD)
-                || variation
-                == (EditorInfo.TYPE_CLASS_NUMBER | EditorInfo.TYPE_NUMBER_VARIATION_PASSWORD);
+        final int variation = inputType & (EditorInfo.TYPE_MASK_CLASS | EditorInfo.TYPE_MASK_VARIATION);
+        return variation == (EditorInfo.TYPE_CLASS_TEXT | EditorInfo.TYPE_TEXT_VARIATION_PASSWORD)
+                || variation == (EditorInfo.TYPE_CLASS_TEXT | EditorInfo.TYPE_TEXT_VARIATION_WEB_PASSWORD)
+                || variation == (EditorInfo.TYPE_CLASS_NUMBER | EditorInfo.TYPE_NUMBER_VARIATION_PASSWORD);
     }
 
     @Nullable
@@ -122,6 +116,7 @@ public class ViewElement {
         return view.getId();
     }
 
+    @Nullable
     public String getResourceId() {
         final int id = getId();
         if (id != NO_ID) {
@@ -147,7 +142,7 @@ public class ViewElement {
                 }
             }
         }
-        return "";
+        return null;
     }
 
     public String getClassName() {
@@ -210,8 +205,7 @@ public class ViewElement {
     }
 
     public boolean isPassword() {
-        return (view instanceof TextView) &&
-                isPasswordInputType(((TextView) view).getInputType());
+        return (view instanceof TextView) && isPasswordInputType(((TextView) view).getInputType());
     }
 
     public boolean isSelected() {


### PR DESCRIPTION
Now we return an empty string for missing resource ids, which clutters the output XML page source