### PR TITLE
Make sure the settings helper is only installed once

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -229,8 +229,10 @@ class EspressoDriver extends BaseDriver {
     // and get it onto our 'opts' object so we use it from now on
     Object.assign(this.opts, appInfo);
 
+    // start an avd, set the language/locale, pick an emulator, etc...
+    // TODO with multiple devices we'll need to parameterize this
+    await helpers.initDevice(this.adb, this.opts);
     // https://github.com/appium/appium-espresso-driver/issues/72
-    await androidHelpers.pushSettingsApp(this.adb);
     if (await this.adb.isAnimationOn()) {
       try {
         await this.adb.setAnimationState(false);
@@ -246,9 +248,6 @@ class EspressoDriver extends BaseDriver {
 
     // set up the modified espresso server etc
     this.initEspressoServer();
-    // start an avd, set the language/locale, pick an emulator, etc...
-    // TODO with multiple devices we'll need to parameterize this
-    await helpers.initDevice(this.adb, this.opts);
     // Further prepare the device by forwarding the espresso port
     logger.debug(`Forwarding Espresso Server port ${DEVICE_PORT} to ${this.opts.systemPort}`);
     await this.adb.forwardPort(this.opts.systemPort, DEVICE_PORT);


### PR DESCRIPTION
`pushSettingsApp` was called twice in a row, since initDevice also contains this call. See https://gist.github.com/cosminstirbu/8f9e3b8c542b49e93626e31b9148cf58 for more details.

@KazuCocoa FYI