### PR TITLE
Test source document

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ env:
     - RECURSIVE=""
     - CC=gcc-6 CXX=g++-6
     - START_XVFB=0
+    - TERM=dumb # Suppresses Gradlew progress output
   matrix:
     - TEST=unit START_EMU=0 RECURSIVE="--recursive"
     - TEST=functional

--- a/espresso-server/app/build.gradle
+++ b/espresso-server/app/build.gradle
@@ -54,3 +54,7 @@ dependencies {
     androidTestImplementation 'javax.ws.rs:jsr311-api:1.1.1'
     androidTestImplementation 'org.nanohttpd:nanohttpd-webserver:2.3.1'
 }
+
+tasks.withType(Test) {
+    systemProperty "skipespressoserver", "true"
+}

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/EspressoServerRunnerTest.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/EspressoServerRunnerTest.java
@@ -16,6 +16,7 @@
 
 package io.appium.espressoserver;
 
+import org.junit.Assume;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -37,6 +38,10 @@ public class EspressoServerRunnerTest {
 
     @Test
     public void startEspressoServer() throws InterruptedException, IOException, DuplicateRouteException {
+        if (System.getProperty("skipespressoserver") != null) {
+            Assume.assumeTrue(true);
+            return;
+        }
         try {
             espressoServer.start();
 

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/SourceDocument.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/SourceDocument.java
@@ -67,7 +67,7 @@ public class SourceDocument {
     private static final String VIEW_INDEX = "viewIndex";
     private static final String NAMESPACE = "";
     private static final String DEFAULT_VIEW_CLASS_NAME = "android.view.View";
-    private static final int MAX_TRAVERSAL_DEPTH = 70;
+    private static int MAX_TRAVERSAL_DEPTH = 70;
     private static final int MAX_XML_VALUE_LENGTH = 64 * 1024;
     private static final String XML_ENCODING = "UTF-8";
     private final Semaphore RESOURCES_GUARD = new Semaphore(1);
@@ -87,7 +87,7 @@ public class SourceDocument {
         this(root, new SparseArray<View>());
     }
 
-    private SourceDocument(@Nullable View root, @Nullable SparseArray<View> viewMap) {
+    public SourceDocument(@Nullable View root, @Nullable SparseArray<View> viewMap) {
         this.root = root;
         this.viewMap = viewMap;
     }
@@ -316,5 +316,9 @@ public class SourceDocument {
         } catch (XPathExpressionException xe) {
             throw new XPathLookupException(xpathSelector, xe.getMessage());
         }
+    }
+
+    public static void $setMaxTraverseDepth(int maxTraverseDepth) {
+        SourceDocument.MAX_TRAVERSAL_DEPTH = maxTraverseDepth;
     }
 }

--- a/espresso-server/app/src/test/java/io/appium/espressoserver/test/model/SourceDocumentTest.java
+++ b/espresso-server/app/src/test/java/io/appium/espressoserver/test/model/SourceDocumentTest.java
@@ -3,7 +3,6 @@ package io.appium.espressoserver.test.model;
 import android.content.Context;
 import android.widget.LinearLayout;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;

--- a/espresso-server/app/src/test/java/io/appium/espressoserver/test/model/SourceDocumentTest.java
+++ b/espresso-server/app/src/test/java/io/appium/espressoserver/test/model/SourceDocumentTest.java
@@ -1,0 +1,38 @@
+package io.appium.espressoserver.test.model;
+
+import android.content.Context;
+import android.widget.LinearLayout;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import io.appium.espressoserver.lib.handlers.exceptions.AppiumException;
+import io.appium.espressoserver.lib.model.SourceDocument;
+
+import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(RobolectricTestRunner.class)
+public class SourceDocumentTest {
+
+    @Test
+    public void shouldHandleLargeMemoryHierarchies() throws AppiumException {
+        Context context = getApplicationContext();
+        LinearLayout listView = new LinearLayout(context);
+        LinearLayout currView = listView;
+
+        for (int i=0; i<50; i++) {
+            LinearLayout nextView = new LinearLayout(context);
+            currView.addView(nextView);
+            currView = nextView;
+        }
+
+        // Set the max traverse depth low. JVM runs out of heap space quicker than Android.
+        SourceDocument.$setMaxTraverseDepth(3);
+        SourceDocument sourceDoc = new SourceDocument(listView, null);
+        String xml = sourceDoc.toXMLString();
+        assertTrue(xml.startsWith("<?xml"));
+    }
+}

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "mocha": "mocha",
     "test": "npm run test:server && npm run test:node",
     "test:node": "gulp once",
-    "test:server": "echo 'TODO: Add gradle unit tests'",
+    "test:server": "cd espresso-server && ./gradlew test && cd ..",
     "e2e-test": "gulp transpile && mocha --timeout 600000 build/test/functional/",
     "watch": "gulp watch",
     "coverage": "gulp coveralls",


### PR DESCRIPTION
* Add a test that would cause a Java heap error, if not for the XML traversal depth limit introduced by: https://github.com/appium/appium-espresso-driver/pull/341
* Runs the tests on Travis CI now. Skips the Espresso Server test by adding a property that tells the test to be skipped.