### PR TITLE
Fix crash on /enabled and /selected

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetEnabled.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetEnabled.java
@@ -36,9 +36,7 @@ public class GetEnabled implements RequestHandler<AppiumParams, Boolean> {
         try {
             viewInteraction.check(matches(isEnabled()));
             return true;
-        } catch (NoMatchingViewException e) {
-            return false;
-        } catch (AssertionFailedError e) {
+        } catch (NoMatchingViewException | AssertionFailedError e) {
             return false;
         }
     }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetEnabled.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetEnabled.java
@@ -16,6 +16,8 @@
 
 package io.appium.espressoserver.lib.handlers;
 
+import junit.framework.AssertionFailedError;
+
 import androidx.test.espresso.NoMatchingViewException;
 import androidx.test.espresso.ViewInteraction;
 
@@ -35,6 +37,8 @@ public class GetEnabled implements RequestHandler<AppiumParams, Boolean> {
             viewInteraction.check(matches(isEnabled()));
             return true;
         } catch (NoMatchingViewException e) {
+            return false;
+        } catch (AssertionFailedError e) {
             return false;
         }
     }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetSelected.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetSelected.java
@@ -36,9 +36,7 @@ public class GetSelected implements RequestHandler<AppiumParams, Boolean> {
         try {
             viewInteraction.check(matches(isSelected()));
             return true;
-        } catch (NoMatchingViewException e) {
-            return false;
-        } catch (AssertionFailedError e) {
+        } catch (NoMatchingViewException | AssertionFailedError e) {
             return false;
         }
     }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetSelected.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetSelected.java
@@ -16,6 +16,8 @@
 
 package io.appium.espressoserver.lib.handlers;
 
+import junit.framework.AssertionFailedError;
+
 import androidx.test.espresso.NoMatchingViewException;
 import androidx.test.espresso.ViewInteraction;
 
@@ -35,6 +37,8 @@ public class GetSelected implements RequestHandler<AppiumParams, Boolean> {
             viewInteraction.check(matches(isSelected()));
             return true;
         } catch (NoMatchingViewException e) {
+            return false;
+        } catch (AssertionFailedError e) {
             return false;
         }
     }


### PR DESCRIPTION
Espresso server crashes on calling `/enabled` or `/selected` 
```
--------- beginning of crash
12-14 16:23:31.349 16968 17441 E AndroidRuntime: FATAL EXCEPTION: NanoHttpd Request Processor (#33)
12-14 16:23:31.349 16968 17441 E AndroidRuntime: Process: com.bumble.app, PID: 16968
12-14 16:23:31.349 16968 17441 E AndroidRuntime: androidx.test.espresso.base.DefaultFailureHandler$AssertionFailedWithCauseError: 'is enabled' doesn't match the selected view.
12-14 16:23:31.349 16968 17441 E AndroidRuntime: Expected: is enabled
12-14 16:23:31.349 16968 17441 E AndroidRuntime:      Got: "LoadingButton{id=2131363209, res-name=registration_continue, visibility=VISIBLE, width=468, height=90, has-focus=false, has-focusable=true, has-window-focus=true, is-clickable=false, is-enabled=false, is-focused=false, is-focusable=false, is-layout-requested=false, is-selected=false, layout-params=android.widget.LinearLayout$LayoutParams@767097a, tag=null, root-is-layout-requested=false, has-input-connection=false, x=36.0, y=405.0, child-count=2}"
12-14 16:23:31.349 16968 17441 E AndroidRuntime:
12-14 16:23:31.349 16968 17441 E AndroidRuntime: 	at dalvik.system.VMStack.getThreadStackTrace(Native Method)
12-14 16:23:31.349 16968 17441 E AndroidRuntime: 	at java.lang.Thread.getStackTrace(Thread.java:1536)
12-14 16:23:31.349 16968 17441 E AndroidRuntime: 	at androidx.test.espresso.base.DefaultFailureHandler.getUserFriendlyError(DefaultFailureHandler.java:88)
12-14 16:23:31.349 16968 17441 E AndroidRuntime: 	at androidx.test.espresso.base.DefaultFailureHandler.handle(DefaultFailureHandler.java:51)
12-14 16:23:31.349 16968 17441 E AndroidRuntime: 	at androidx.test.espresso.ViewInteraction.waitForAndHandleInteractionResults(ViewInteraction.java:314)
12-14 16:23:31.349 16968 17441 E AndroidRuntime: 	at androidx.test.espresso.ViewInteraction.check(ViewInteraction.java:297)
12-14 16:23:31.349 16968 17441 E AndroidRuntime: 	at io.appium.espressoserver.lib.handlers.GetEnabled.handle(GetEnabled.java:35)
12-14 16:23:31.349 16968 17441 E AndroidRuntime: 	at io.appium.espressoserver.lib.handlers.GetEnabled.handle(GetEnabled.java:29)
12-14 16:23:31.349 16968 17441 E AndroidRuntime: 	at io.appium.espressoserver.lib.http.Router.route(Router.java:299)
12-14 16:23:31.349 16968 17441 E AndroidRuntime: 	at io.appium.espressoserver.lib.http.Server.serve(Server.java:68)
12-14 16:23:31.349 16968 17441 E AndroidRuntime: 	at fi.iki.elonen.NanoHTTPD$HTTPSession.execute(NanoHTTPD.java:945)
12-14 16:23:31.349 16968 17441 E AndroidRuntime: 	at fi.iki.elonen.NanoHTTPD$ClientHandler.run(NanoHTTPD.java:192)
12-14 16:23:31.349 16968 17441 E AndroidRuntime: 	at java.lang.Thread.run(Thread.java:764)
12-14 16:23:31.349 16968 17441 E AndroidRuntime: Caused by: junit.framework.AssertionFailedError: 'is enabled' doesn't match the selected view.
12-14 16:23:31.349 16968 17441 E AndroidRuntime: Expected: is enabled
12-14 16:23:31.349 16968 17441 E AndroidRuntime:      Got: "LoadingButton{id=2131363209, res-name=registration_continue, visibility=VISIBLE, width=468, height=90, has-focus=false, has-focusable=true, has-window-focus=true, is-clickable=false, is-enabled=false, is-focused=false, is-focusable=false, is-layout-requested=false, is-selected=false, layout-params=android.widget.LinearLayout$LayoutParams@767097a, tag=null, root-is-layout-requested=false, has-input-connection=false, x=36.0, y=405.0, child-count=2}"
```