### PR TITLE
uninstall espresso server if the installed server version is newer

### DIFF
--- a/lib/espresso-runner.js
+++ b/lib/espresso-runner.js
@@ -41,6 +41,12 @@ class EspressoRunner {
   }
 
   async installServer () {
+    // this.adb.installOrUpgrade remains newer Espresso server
+    const appState = await this.adb.getApplicationInstallState(this.modServerPath, TEST_APK_PKG);
+    if (appState === this.adb.APP_INSTALL_STATE.NEWER_VERSION_INSTALLED) {
+      await this.adb.uninstallApk(TEST_APK_PKG);
+    }
+
     await this.adb.installOrUpgrade(this.modServerPath, TEST_APK_PKG);
     logger.info(`Installed Espresso Test Server apk '${this.modServerPath}' (pkg: '${TEST_APK_PKG}')`);
   }


### PR DESCRIPTION
https://github.com/appium/appium-uiautomator2-driver/pull/270 for Espresso.

`installOrUpgrade` includes the same, lower version and unknown cases. The only newer version does not exist in the method.

I considered implementing `uninstallApk` when installed app is `NEWER_VERSION_INSTALLED` in `installOrUpgrade`. But current behaviour is proper for the current method name. The cost of calling `getApplicationInstallState` is not considerable, I thought.

Thus, I add this way.