### PR TITLE
Uninstall if installed version is older or newer than new one

### DIFF
--- a/lib/espresso-runner.js
+++ b/lib/espresso-runner.js
@@ -236,5 +236,5 @@ class EspressoRunner {
   }
 }
 
-export { EspressoRunner, REQUIRED_PARAMS };
+export { EspressoRunner, REQUIRED_PARAMS, INSTRUMENTATION_TARGET };
 export default EspressoRunner;

--- a/lib/espresso-runner.js
+++ b/lib/espresso-runner.js
@@ -5,13 +5,14 @@ import path from 'path';
 import { fs, util, mkdirp } from 'appium-support';
 import { version } from '../../package.json'; // eslint-disable-line import/no-unresolved
 
-
 const TEST_APK_PATH = path.resolve(__dirname, '..', '..', 'espresso-server', 'app', 'build', 'outputs', 'apk', 'androidTest', 'debug', 'app-debug-androidTest.apk');
 const TEST_MANIFEST_PATH = path.resolve(__dirname, '..', '..', 'espresso-server', 'AndroidManifest-test.xml');
 const TEST_APK_PKG = 'io.appium.espressoserver.test';
 const REQUIRED_PARAMS = ['adb', 'tmpDir', 'host', 'systemPort', 'devicePort', 'appPackage', 'forceEspressoRebuild'];
 const ESPRESSO_SERVER_LAUNCH_TIMEOUT = 30000;
+const ESPRESSO_SERVER_INSTALL_RETRIES = 20;
 const TARGET_PACKAGE_CONTAINER = '/data/local/tmp/espresso.apppackage';
+const INSTRUMENTATION_TARGET = 'io.appium.espressoserver.test/androidx.test.runner.AndroidJUnitRunner';
 
 class EspressoRunner {
   constructor (opts = {}) {
@@ -40,9 +41,71 @@ class EspressoRunner {
     return previousAppPackage !== this.appPackage;
   }
 
-  async installServer () {
-    await this.adb.installOrUpgrade(this.modServerPath, TEST_APK_PKG);
+  /**
+   * Installs Espresso server apk on to the device or emulator.
+   *
+   * @param {number} installTimeout - Installation timeout
+   */
+  async installServer (installTimeout = ESPRESSO_SERVER_INSTALL_RETRIES * 1000) {
+    const appState = await this.adb.getApplicationInstallState(this.modServerPath, TEST_APK_PKG);
+
+    const shouldUninstallApp = [this.adb.APP_INSTALL_STATE.OLDER_VERSION_INSTALLED, this.adb.APP_INSTALL_STATE.NEWER_VERSION_INSTALLED].includes(appState);
+    const shouldInstallApp = shouldUninstallApp || [this.adb.APP_INSTALL_STATE.NOT_INSTALLED].includes(appState);
+
+    if (shouldUninstallApp) {
+      logger.info(`Uninstalling Espresso Test Server apk from the target device (pkg: '${TEST_APK_PKG}')`);
+      try {
+        await this.adb.uninstallApk(TEST_APK_PKG);
+      } catch (err) {
+        logger.warn(`Error uninstalling '${TEST_APK_PKG}': ${err.message}`);
+      }
+    }
+
+    if (shouldInstallApp) {
+      logger.info(`Installing Espresso Test Server apk from the target device (path: '${this.modServerPath}')`);
+      try {
+        await this.adb.install(this.modServerPath, {
+          replace: false,
+          timeout: installTimeout,
+        });
+      } catch (err) {
+        logger.warn(`Cannot install '${this.modServerPath}' because of '${err.message}'. Trying full reinstall`);
+      }
+    }
+
     logger.info(`Installed Espresso Test Server apk '${this.modServerPath}' (pkg: '${TEST_APK_PKG}')`);
+    await this.ensureInstrumentationEspresso();
+  }
+
+  /**
+   * Raise error if the target device has no espresso instrumentation package
+   * @param {number} installTimeout - Installation timeout
+   */
+  async ensureInstrumentationEspresso (retries = ESPRESSO_SERVER_INSTALL_RETRIES) {
+    logger.debug(`Waiting up to ${retries * 1000}ms for instrumentation '${INSTRUMENTATION_TARGET}' to be available`);
+
+    let output;
+    try {
+      await retryInterval(retries, 1000, async () => {
+        output = await this.adb.shell(['pm', 'list', 'instrumentation']);
+        if (output.includes('Could not access the Package Manager')) {
+          const err = new Error(`Problem running package manager: ${output}`);
+          output = null; // remove output, so it is not printed below
+          throw err;
+        } else if (!output.includes(INSTRUMENTATION_TARGET)) {
+          throw new Error('No instrumentation process found. Retrying...');
+        }
+        logger.debug(`Instrumentation '${INSTRUMENTATION_TARGET}' available`);
+      });
+    } catch (err) {
+      logger.error(`Unable to find instrumentation target '${INSTRUMENTATION_TARGET}': ${err.message}`);
+      if (output) {
+        logger.debug('Available targets:');
+        for (let line of output.split('\n')) {
+          logger.debug(`    ${line.replace('instrumentation:', '')}`);
+        }
+      }
+    }
   }
 
   async installTestApk () {

--- a/lib/espresso-runner.js
+++ b/lib/espresso-runner.js
@@ -12,7 +12,6 @@ const REQUIRED_PARAMS = ['adb', 'tmpDir', 'host', 'systemPort', 'devicePort', 'a
 const ESPRESSO_SERVER_LAUNCH_TIMEOUT = 30000;
 const ESPRESSO_SERVER_INSTALL_RETRIES = 20;
 const TARGET_PACKAGE_CONTAINER = '/data/local/tmp/espresso.apppackage';
-const INSTRUMENTATION_TARGET = 'io.appium.espressoserver.test/androidx.test.runner.AndroidJUnitRunner';
 
 class EspressoRunner {
   constructor (opts = {}) {
@@ -74,43 +73,11 @@ class EspressoRunner {
           timeout: installTimeout,
         });
       } catch (err) {
-        logger.warn(`Cannot install '${this.modServerPath}' because of '${err.message}'. Trying full reinstall`);
+        logger.errorAndThrow(`Cannot install '${this.modServerPath}' because of '${err.message}'`);
       }
     }
 
     logger.info(`Installed Espresso Test Server apk '${this.modServerPath}' (pkg: '${TEST_APK_PKG}')`);
-    await this.ensureInstrumentationEspresso();
-  }
-
-  /**
-   * Raise error if the target device has no espresso instrumentation package
-   * @param {number} installTimeout - Installation timeout
-   */
-  async ensureInstrumentationEspresso (retries = ESPRESSO_SERVER_INSTALL_RETRIES) {
-    logger.debug(`Waiting up to ${retries * 1000}ms for instrumentation '${INSTRUMENTATION_TARGET}' to be available`);
-
-    let output;
-    try {
-      await retryInterval(retries, 1000, async () => {
-        output = await this.adb.shell(['pm', 'list', 'instrumentation']);
-        if (output.includes('Could not access the Package Manager')) {
-          const err = new Error(`Problem running package manager: ${output}`);
-          output = null; // remove output, so it is not printed below
-          throw err;
-        } else if (!output.includes(INSTRUMENTATION_TARGET)) {
-          throw new Error('No instrumentation process found. Retrying...');
-        }
-        logger.debug(`Instrumentation '${INSTRUMENTATION_TARGET}' available`);
-      });
-    } catch (err) {
-      logger.error(`Unable to find instrumentation target '${INSTRUMENTATION_TARGET}': ${err.message}`);
-      if (output) {
-        logger.debug('Available targets:');
-        for (let line of output.split('\n')) {
-          logger.debug(`    ${line.replace('instrumentation:', '')}`);
-        }
-      }
-    }
   }
 
   async installTestApk () {
@@ -241,5 +208,5 @@ class EspressoRunner {
   }
 }
 
-export { EspressoRunner, REQUIRED_PARAMS, INSTRUMENTATION_TARGET };
+export { EspressoRunner, REQUIRED_PARAMS };
 export default EspressoRunner;

--- a/lib/espresso-runner.js
+++ b/lib/espresso-runner.js
@@ -5,6 +5,7 @@ import path from 'path';
 import { fs, util, mkdirp } from 'appium-support';
 import { version } from '../../package.json'; // eslint-disable-line import/no-unresolved
 
+
 const TEST_APK_PATH = path.resolve(__dirname, '..', '..', 'espresso-server', 'app', 'build', 'outputs', 'apk', 'androidTest', 'debug', 'app-debug-androidTest.apk');
 const TEST_MANIFEST_PATH = path.resolve(__dirname, '..', '..', 'espresso-server', 'AndroidManifest-test.xml');
 const TEST_APK_PKG = 'io.appium.espressoserver.test';

--- a/lib/espresso-runner.js
+++ b/lib/espresso-runner.js
@@ -49,8 +49,13 @@ class EspressoRunner {
   async installServer (installTimeout = ESPRESSO_SERVER_INSTALL_RETRIES * 1000) {
     const appState = await this.adb.getApplicationInstallState(this.modServerPath, TEST_APK_PKG);
 
-    const shouldUninstallApp = [this.adb.APP_INSTALL_STATE.OLDER_VERSION_INSTALLED, this.adb.APP_INSTALL_STATE.NEWER_VERSION_INSTALLED].includes(appState);
-    const shouldInstallApp = shouldUninstallApp || [this.adb.APP_INSTALL_STATE.NOT_INSTALLED].includes(appState);
+    const shouldUninstallApp = [
+      this.adb.APP_INSTALL_STATE.OLDER_VERSION_INSTALLED,
+      this.adb.APP_INSTALL_STATE.NEWER_VERSION_INSTALLED
+    ].includes(appState);
+    const shouldInstallApp = shouldUninstallApp || [
+      this.adb.APP_INSTALL_STATE.NOT_INSTALLED
+    ].includes(appState);
 
     if (shouldUninstallApp) {
       logger.info(`Uninstalling Espresso Test Server apk from the target device (pkg: '${TEST_APK_PKG}')`);

--- a/lib/espresso-runner.js
+++ b/lib/espresso-runner.js
@@ -11,7 +11,6 @@ const TEST_MANIFEST_PATH = path.resolve(__dirname, '..', '..', 'espresso-server'
 const TEST_APK_PKG = 'io.appium.espressoserver.test';
 const REQUIRED_PARAMS = ['adb', 'tmpDir', 'host', 'systemPort', 'devicePort', 'appPackage', 'forceEspressoRebuild'];
 const ESPRESSO_SERVER_LAUNCH_TIMEOUT = 30000;
-const ESPRESSO_SERVER_INSTALL_RETRIES = 20;
 const TARGET_PACKAGE_CONTAINER = '/data/local/tmp/espresso.apppackage';
 
 class EspressoRunner {
@@ -43,10 +42,9 @@ class EspressoRunner {
 
   /**
    * Installs Espresso server apk on to the device or emulator.
-   *
-   * @param {number} installTimeout - Installation timeout
+   * Each adb command uses default timeout by them.
    */
-  async installServer (installTimeout = ESPRESSO_SERVER_INSTALL_RETRIES * 1000) {
+  async installServer () {
     const appState = await this.adb.getApplicationInstallState(this.modServerPath, TEST_APK_PKG);
 
     const shouldUninstallApp = [
@@ -69,16 +67,12 @@ class EspressoRunner {
     if (shouldInstallApp) {
       logger.info(`Installing Espresso Test Server apk from the target device (path: '${this.modServerPath}')`);
       try {
-        await this.adb.install(this.modServerPath, {
-          replace: false,
-          timeout: installTimeout,
-        });
+        await this.adb.install(this.modServerPath, { replace: false });
+        logger.info(`Installed Espresso Test Server apk '${this.modServerPath}' (pkg: '${TEST_APK_PKG}')`);
       } catch (err) {
         logger.errorAndThrow(`Cannot install '${this.modServerPath}' because of '${err.message}'`);
       }
     }
-
-    logger.info(`Installed Espresso Test Server apk '${this.modServerPath}' (pkg: '${TEST_APK_PKG}')`);
   }
 
   async installTestApk () {

--- a/test/unit/espresso-runner-specs.js
+++ b/test/unit/espresso-runner-specs.js
@@ -1,11 +1,13 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { EspressoRunner, REQUIRED_PARAMS } from '../../lib/espresso-runner';
-
+import { EspressoRunner, REQUIRED_PARAMS, INSTRUMENTATION_TARGET } from '../../lib/espresso-runner';
+import { ADB } from 'appium-adb';
+import sinon from 'sinon';
 
 chai.should();
 chai.use(chaiAsPromised);
 const expect = chai.expect;
+let sandbox = sinon.createSandbox();
 
 describe('espresso-runner', function () {
   function getOpts (params) {
@@ -28,5 +30,103 @@ describe('espresso-runner', function () {
       let opts = getOpts(params);
       runConstructorTest(opts, REQUIRED_PARAMS[i]);
     }
+  });
+
+  describe('installServer', function () {
+    const adbCmd = new ADB();
+    let uninstallCount = -1;
+    let installCount = -1;
+    const commonStub = {
+      APP_INSTALL_STATE: {
+        NEWER_VERSION_INSTALLED: adbCmd.APP_INSTALL_STATE.NEWER_VERSION_INSTALLED,
+        OLDER_VERSION_INSTALLED: adbCmd.APP_INSTALL_STATE.OLDER_VERSION_INSTALLED,
+        NOT_INSTALLED: adbCmd.APP_INSTALL_STATE.NOT_INSTALLED,
+      },
+      uninstallApk: () => {
+        uninstallCount += 1;
+        return uninstallCount;
+      },
+      install: () => {
+        installCount += 1;
+        return installCount;
+      },
+      shell: () => `${INSTRUMENTATION_TARGET} (target=io.appium.android.apis)\n`,
+    };
+
+    afterEach(function () {
+      sandbox.restore();
+    });
+
+    it('should install newer server', async function () {
+      sandbox.stub(ADB, 'createADB').callsFake(function () {
+        uninstallCount = -1;
+        installCount = -1;
+        return Object.assign(
+          commonStub,
+          {
+            getApplicationInstallState: () => adbCmd.APP_INSTALL_STATE.NEWER_VERSION_INSTALLED,
+          }
+        );
+      });
+
+      const adb = ADB.createADB();
+      const espresso = new EspressoRunner({
+        adb, tmpDir: 'tmp', host: 'localhost',
+        systemPort: 4724, devicePort: 6790, appPackage: 'io.appium.example',
+        forceEspressoRebuild: false
+      });
+
+      await espresso.installServer();
+      espresso.adb.uninstallApk().should.eql(1);
+      espresso.adb.install().should.eql(1);
+    });
+
+    it('should install older server', async function () {
+      sandbox.stub(ADB, 'createADB').callsFake(function () {
+        uninstallCount = -1;
+        installCount = -1;
+        return Object.assign(
+          commonStub,
+          {
+            getApplicationInstallState: () => adbCmd.APP_INSTALL_STATE.OLDER_VERSION_INSTALLED,
+          }
+        );
+      });
+
+      const adb = ADB.createADB();
+      const espresso = new EspressoRunner({
+        adb, tmpDir: 'tmp', host: 'localhost',
+        systemPort: 4724, devicePort: 6790, appPackage: 'io.appium.example',
+        forceEspressoRebuild: false
+      });
+
+      await espresso.installServer();
+      espresso.adb.uninstallApk().should.eql(1);
+      espresso.adb.install().should.eql(1);
+    });
+
+    it('should install from no server', async function () {
+      sandbox.stub(ADB, 'createADB').callsFake(function () {
+        uninstallCount = -1;
+        installCount = -1;
+        return Object.assign(
+          commonStub,
+          {
+            getApplicationInstallState: () => adbCmd.APP_INSTALL_STATE.NOT_INSTALLED
+          }
+        );
+      });
+
+      const adb = ADB.createADB();
+      const espresso = new EspressoRunner({
+        adb, tmpDir: 'tmp', host: 'localhost',
+        systemPort: 4724, devicePort: 6790, appPackage: 'io.appium.example',
+        forceEspressoRebuild: false
+      });
+
+      await espresso.installServer();
+      espresso.adb.uninstallApk().should.eql(0);
+      espresso.adb.install().should.eql(1);
+    });
   });
 });


### PR DESCRIPTION
Alternative of https://github.com/appium/appium-espresso-driver/pull/357

- Uninstall if installed espresso server is older or newer than new espresso server
- Install new espresso server if uninstall happened or not installed it
- ~~Make sure the installation by checking `io.appium.espressoserver.test/androidx.test.runner.AndroidJUnitRunner`~~ <= early optimisation 
    - Current master has been updated to `androidx`