### PR TITLE
add nativeWebScreenshot

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -447,6 +447,11 @@ class EspressoDriver extends BaseDriver {
   getProxyAvoidList (sessionId) {
     super.getProxyAvoidList(sessionId);
     this.jwpProxyAvoid = NO_PROXY;
+
+    if (this.opts.nativeWebScreenshot) {
+      this.jwpProxyAvoid = [...this.jwpProxyAvoid, ['GET', new RegExp('^/session/[^/]+/screenshot')]];
+    }
+
     return this.jwpProxyAvoid;
   }
 

--- a/test/unit/driver-specs.js
+++ b/test/unit/driver-specs.js
@@ -100,4 +100,32 @@ describe('driver', function () {
       driver.adb.setDefaultHiddenApiPolicy.calledOnce.should.be.false;
     });
   });
+
+  describe('#getProxyAvidList', function () {
+    let driver;
+    describe('nativeWebScreenshot', function () {
+      let proxyAvoidList;
+      let nativeWebScreenshotFilter = (item) => item[0] === 'GET' && item[1].test('/session/xxx/screenshot/');
+      beforeEach(function () {
+        driver = new EspressoDriver({}, false);
+        driver.caps = { appPackage: 'io.appium.package', appActivity: '.MainActivity'};
+        driver.opts = { autoLaunch: false, skipUnlock: true };
+        driver.chromedriver = true;
+        sandbox.stub(driver, 'initEspressoServer');
+        sandbox.stub(driver, 'initAUT');
+        sandbox.stub(driver, 'startEspressoSession');
+      });
+
+      it('should proxy screenshot if nativeWebScreenshot is off on chromedriver mode', async function () {
+        await driver.createSession({platformName: 'Android', deviceName: 'device', appPackage: driver.caps.appPackage, nativeWebScreenshot: false});
+        proxyAvoidList = driver.getProxyAvoidList().filter(nativeWebScreenshotFilter);
+        proxyAvoidList.should.be.empty;
+      });
+      it('should not proxy screenshot if nativeWebScreenshot is on on chromedriver mode', async function () {
+        await driver.createSession({platformName: 'Android', deviceName: 'device', appPackage: driver.caps.appPackage, nativeWebScreenshot: true});
+        proxyAvoidList = driver.getProxyAvoidList().filter(nativeWebScreenshotFilter);
+        proxyAvoidList.should.not.be.empty;
+      });
+    });
+  });
 });

--- a/test/unit/driver-specs.js
+++ b/test/unit/driver-specs.js
@@ -101,7 +101,7 @@ describe('driver', function () {
     });
   });
 
-  describe('#getProxyAvidList', function () {
+  describe('#getProxyAvoidList', function () {
     let driver;
     describe('nativeWebScreenshot', function () {
       let proxyAvoidList;


### PR DESCRIPTION
Just today, I noticed Espresso driver had no `nativeWebScreenshot`. We cannot get screenshot in webview context. uiautomator2 also cannot get screenshot in webview if `nativeWebScreenshot` is not enabled.

(I will add test code later.)


----

- Error when I tried to get screenshot in webview context

```
[HTTP] --> GET /wd/hub/session/1a3fc9a9-0684-40b4-9add-32a416e728e6/screenshot
[HTTP] {}
[W3C (1a3fc9a9)] Driver proxy active, passing request on via HTTP proxy
[debug] [WD Proxy] Matched '/wd/hub/session/1a3fc9a9-0684-40b4-9add-32a416e728e6/screenshot' to command name 'getScreenshot'
[debug] [WD Proxy] Proxying [GET /wd/hub/session/1a3fc9a9-0684-40b4-9add-32a416e728e6/screenshot] to [GET http://127.0.0.1:8000/wd/hub/session/1564e8c3fe4d676d33410f6d2c5d0e3f/screenshot] with body: {}
[WD Proxy] Got an unexpected response: {"code":"ESOCKETTIMEDOUT","connect":false}
[debug] [W3C (1a3fc9a9)] Encountered internal error running command: Error: Could not proxy. Proxy error: Could not proxy command to remote server. Original error: Error: ESOCKETTIMEDOUT
[debug] [W3C (1a3fc9a9)]     at doJwpProxy (/Users/kazuaki/GitHub/appium/node_modules/appium-base-driver/lib/protocol/protocol.js:547:13)
[HTTP] <-- GET /wd/hub/session/1a3fc9a9-0684-40b4-9add-32a416e728e6/screenshot 500 240023 ms - 705
[HTTP]
```

Then, I could not find error message in espresso server...