### PR TITLE
add a route of element screenshot for converted request as MJSONWP

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.java
@@ -224,6 +224,9 @@ class Router {
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/appium/execute_mobile/backdoor", new MobileBackdoor(), MobileBackdoorParams.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/appium/execute_mobile/:elementId/flash", new MobileViewFlash(), ViewFlashParams.class));
 
+        // Compatibility for https://github.com/appium/appium-base-driver/blob/master/lib/jsonwp-proxy/protocol-converter.js
+        routeMap.addRoute(new RouteDefinition(Method.GET, "/session/:sessionId/screenshot/:elementId", new ElementScreenshot(), AppiumParams.class));
+
         // Not implemented
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/touch/flick", new NotYetImplemented(), AppiumParams.class));
         routeMap.addRoute(new RouteDefinition(Method.POST, "/session/:sessionId/alert_text", new NotYetImplemented(), AppiumParams.class));


### PR DESCRIPTION
https://github.com/appium/appium/issues/11988
A converted in base driver converts getting element screenshot from W3C to MJSONWP. The converted request sends to Espresso server.

The converted checked if it converts a request with response status. I think adding this URL is reasonable to change the converter's logic for v1.11.0 release.

cc @dpgraham 
Can you take a look and include this into 1.11.0 if this way is approval?
This will fix failing taking element screenshot in Appium 1.9.?, 1.10.0 and comming 1.11.0