### PR TITLE
Add `installTimeout` and add Kotlin

### DIFF
--- a/espresso-server/app/build.gradle
+++ b/espresso-server/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.application'
+apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 28
@@ -14,8 +15,7 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            minifyEnabled true
         }
     }
 
@@ -44,6 +44,8 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:2.8.9'
     testImplementation 'org.nanohttpd:nanohttpd-webserver:2.3.1'
     testImplementation 'org.robolectric:robolectric:4.0.2'
+    testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
+    testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
 
     androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.1.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
@@ -53,8 +55,13 @@ dependencies {
     androidTestImplementation 'com.google.code.gson:gson:2.8.5'
     androidTestImplementation 'javax.ws.rs:jsr311-api:1.1.1'
     androidTestImplementation 'org.nanohttpd:nanohttpd-webserver:2.3.1'
+    androidTestImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    androidTestImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 }
 
 tasks.withType(Test) {
     systemProperty "skipespressoserver", "true"
+}
+repositories {
+    mavenCentral()
 }

--- a/espresso-server/build.gradle
+++ b/espresso-server/build.gradle
@@ -1,6 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
+    ext.kotlin_version = '1.3.11'
 
     repositories {
         maven {
@@ -10,6 +11,7 @@ buildscript {
         google()
     }
     dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.android.tools.build:gradle:3.2.1'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -327,6 +327,7 @@ class EspressoDriver extends BaseDriver {
       appActivity: this.opts.appActivity,
       forceEspressoRebuild: !!this.opts.forceEspressoRebuild,
       serverLaunchTimeout: this.opts.espressoServerLaunchTimeout,
+      installTimeout: this.opts.androidInstallTimeout,
     });
     this.proxyReqRes = this.espresso.proxyReqRes.bind(this.espresso);
   }

--- a/lib/espresso-runner.js
+++ b/lib/espresso-runner.js
@@ -27,6 +27,7 @@ class EspressoRunner {
     this.modServerPath = path.resolve(this.tmpDir, `${TEST_APK_PKG}_${version}_${this.appPackage}.apk`);
 
     this.serverLaunchTimeout = opts.serverLaunchTimeout || ESPRESSO_SERVER_LAUNCH_TIMEOUT;
+    this.androidInstallTimeout = opts.androidInstallTimeout;
   }
 
   async isAppPackageChanged () {
@@ -67,7 +68,7 @@ class EspressoRunner {
     if (shouldInstallApp) {
       logger.info(`Installing Espresso Test Server apk from the target device (path: '${this.modServerPath}')`);
       try {
-        await this.adb.install(this.modServerPath, { replace: false });
+        await this.adb.install(this.modServerPath, { replace: false, timeout: this.androidInstallTimeout });
         logger.info(`Installed Espresso Test Server apk '${this.modServerPath}' (pkg: '${TEST_APK_PKG}')`);
       } catch (err) {
         logger.errorAndThrow(`Cannot install '${this.modServerPath}' because of '${err.message}'`);

--- a/test/functional/desired.js
+++ b/test/functional/desired.js
@@ -3,7 +3,7 @@ const apidemosApp = require.resolve('android-apidemos');
 
 
 const GENERIC_CAPS = {
-  androidInstallTimeout: 90000,
+  androidInstallTimeout: process.env.CI ? 120000 : 90000,
   deviceName: 'Android',
   platformName: 'Android',
   forceEspressoRebuild: true,


### PR DESCRIPTION
* `androidInstallTimeout` was being ignored in `appium-espresso-driver`. Update it to include `androidInstallTimeout` as a paramter in `this.adb.install` and as a member variable in `EspressoRunner
* Update gradle to use Kotlin