### PR TITLE
Fix for remoteAdbHost capability

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -317,7 +317,7 @@ class EspressoDriver extends BaseDriver {
     // now that we have package and activity, we can create an instance of
     // espresso with the appropriate data
     this.espresso = new EspressoRunner({
-      host: this.opts.host || 'localhost',
+      host: this.opts.remoteAdbHost || this.opts.host || 'localhost',
       systemPort: this.opts.systemPort,
       devicePort: DEVICE_PORT,
       adb: this.adb,


### PR DESCRIPTION
Currently, we can't run tests on remote machines due to this bug because espresso-driver is not recognizing the capability 'remoteAdbHost'