### PR TITLE
Handle no elementId

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/SetOrientation.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/SetOrientation.java
@@ -18,6 +18,9 @@ package io.appium.espressoserver.lib.handlers;
 
 import androidx.test.espresso.ViewInteraction;
 
+import static androidx.test.espresso.matcher.ViewMatchers.isRoot;
+import static androidx.test.espresso.Espresso.onView;
+
 import java.util.Arrays;
 
 import javax.annotation.Nullable;
@@ -32,7 +35,10 @@ public class SetOrientation implements RequestHandler<OrientationParams, Void> {
     @Override
     @Nullable
     public Void handle(OrientationParams params) throws AppiumException {
-        final ViewInteraction viewInteraction = Element.getViewInteractionById(params.getElementId());
+        final String elementId = params.getElementId();
+        final ViewInteraction viewInteraction = elementId == null
+                ? onView(isRoot())
+                : Element.getViewInteractionById(elementId);
         final String orientation = params.getOrientation();
         if (orientation == null ||
                 !Arrays.asList(new String[] {"LANDSCAPE", "PORTRAIT"}).


### PR DESCRIPTION
The `elementId` parameter is not specified in the Set Orientation definition:

http://appium.io/docs/en/commands/session/orientation/set-orientation/

Since the SetOrientation handler in espresso server requires an `elementId` parameter, the java-client's `device.rotate(ScreeOrientation.LANDSCAPE)` method produces errors like this...

```
org.openqa.selenium.WebDriverException: An unknown server-side error occurred while processing the command. Original error: java.lang.NullPointerException: Attempt to invoke virtual method 'int java.lang.Object.hashCode()' on a null object reference
                at java.util.concurrent.ConcurrentHashMap.get(ConcurrentHashMap.java:915)
                at java.util.concurrent.ConcurrentHashMap.containsKey(ConcurrentHashMap.java:943)
                at io.appium.espressoserver.lib.model.Element.exists(Element.java:100)
                at io.appium.espressoserver.lib.model.Element.getViewInteractionById(Element.java:78)
                at io.appium.espressoserver.lib.handlers.SetOrientation.handle(SetOrientation.java:35)
                at io.appium.espressoserver.lib.handlers.SetOrientation.handle(SetOrientation.java:30)
                at io.appium.espressoserver.lib.http.Router.route(Router.java:277)
                at io.appium.espressoserver.lib.http.Server.serve(Server.java:65)
                at fi.iki.elonen.NanoHTTPD.serve(NanoHTTPD.java:2244)
                at fi.iki.elonen.NanoHTTPD$HTTPSession.execute(NanoHTTPD.java:945)
                at fi.iki.elonen.NanoHTTPD$ClientHandler.run(NanoHTTPD.java:192)
                at java.lang.Thread.run(Thread.java:761)
```

This PR modifies the SetOrientation handler to use `onView(isRoot())` when `elementId` is not provided. Support for the `elementId` parameter should possible be removed entirely?