### PR TITLE
[fix the build] Add clickAction to mobile mapping

### DIFF
--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -31,7 +31,9 @@ extensions.executeMobile = async function (mobileCommand, opts = {}) {
 
     flashElement: 'mobileFlashElement',
 
-    uiautomator: 'mobileUiautomator'
+    uiautomator: 'mobileUiautomator',
+
+    clickAction: 'mobileClickAction',
   };
 
   if (!_.has(mobileCommandsMapping, mobileCommand)) {


### PR DESCRIPTION
`clickAction` was missing from the mobile command mapping.