### PR TITLE
add uninstallOtherPackages for espresso driver

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1,11 +1,11 @@
 import _ from 'lodash';
 import { BaseDriver } from 'appium-base-driver';
-import EspressoRunner from './espresso-runner';
+import { EspressoRunner, TEST_APK_PKG } from './espresso-runner';
 import { fs } from 'appium-support';
 import logger from './logger';
 import commands from './commands';
 import { DEFAULT_ADB_PORT } from 'appium-adb';
-import { androidHelpers, androidCommands } from 'appium-android-driver';
+import { androidHelpers, androidCommands, SETTINGS_HELPER_PKG_ID } from 'appium-android-driver';
 import desiredCapConstraints from './desired-caps';
 import { version } from '../../package.json'; // eslint-disable-line import/no-unresolved
 import { findAPortNotInUse } from 'portscanner';
@@ -339,6 +339,15 @@ class EspressoDriver extends BaseDriver {
     // ition bug in old appium and need to be replicated here
     // this.apkStrings[this.opts.language] = await androidHelpers.pushStrings(
     //     this.opts.language, this.adb, this.opts);
+
+    // Uninstall any uninstallOtherPackages which were specified in caps
+    if (this.opts.uninstallOtherPackages) {
+      await helpers.uninstallOtherPackages(
+        this.adb,
+        helpers.parseArray(this.opts.uninstallOtherPackages),
+        [SETTINGS_HELPER_PKG_ID, TEST_APK_PKG]
+      );
+    }
 
     if (!this.opts.app) {
       if (this.opts.fullReset) {

--- a/lib/espresso-runner.js
+++ b/lib/espresso-runner.js
@@ -241,5 +241,5 @@ class EspressoRunner {
   }
 }
 
-export { EspressoRunner, REQUIRED_PARAMS };
+export { EspressoRunner, REQUIRED_PARAMS, TEST_APK_PKG };
 export default EspressoRunner;

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "appium-adb": "^7.0.0",
-    "appium-android-driver": "^4.0.0",
+    "appium-android-driver": "^4.9.0",
     "appium-base-driver": "^3.5.0",
     "appium-support": "^2.20.0",
     "asyncbox": "^2.3.1",


### PR DESCRIPTION
appium/appium-android-driver#502 for espresso driver.

This feature helps users to remove unnecessary apps before their tests.

https://github.com/appium/appium/pull/12278