### PR TITLE
fix element id in mobile backdoor

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/AppiumParams.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/AppiumParams.kt
@@ -17,7 +17,6 @@
 package io.appium.espressoserver.lib.model
 
 import io.appium.espressoserver.lib.handlers.exceptions.AppiumException
-import io.appium.espressoserver.lib.handlers.exceptions.InvalidArgumentException
 
 
 val SESSION_ID_PARAM_NAME = "sessionId"

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -204,8 +204,8 @@ commands.mobileBackdoor = async function mobileBackdoor (opts = {}) {
   if (target === 'element') {
     assertRequiredOptions(opts, ['elementId']);
   }
-  const {elementId} = opts;
-  return await this.espresso.jwproxy.command(`/appium/execute_mobile/backdoor`, 'POST', {target, methods, elementId});
+  const {elementId: targetElement} = opts;
+  return await this.espresso.jwproxy.command(`/appium/execute_mobile/backdoor`, 'POST', {target, methods, targetElement});
 };
 
 /**

--- a/test/functional/commands/mobile-e2e-specs.js
+++ b/test/functional/commands/mobile-e2e-specs.js
@@ -2,6 +2,7 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { initSession, deleteSession, MOCHA_TIMEOUT } from '../helpers/session';
 import { APIDEMO_CAPS } from '../desired';
+import { util } from 'appium-support';
 
 chai.should();
 chai.use(chaiAsPromised);
@@ -211,5 +212,15 @@ describe('mobile', function () {
         }).should.eventually.be.rejectedWith(error);
       });
     }
+  });
+
+  describe('mobile: backdoor', function () {
+    it('should get element type face', async function () {
+      let element = await driver.elementByAccessibilityId('Views');
+      // Below returns like: {"mStyle"=>0, "mSupportedAxes"=>nil, "mWeight"=>400, "native_instance"=>131438067610240}
+      await driver.execute('mobile: backdoor', {
+        target: 'element', elementId: util.unwrapElement(element), methods: [{ name: 'getTypeface' }]}
+      ).should.eventually.contain({ mWeight: 400 })
+    });
   });
 });

--- a/test/functional/commands/mobile-e2e-specs.js
+++ b/test/functional/commands/mobile-e2e-specs.js
@@ -2,7 +2,6 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { initSession, deleteSession, MOCHA_TIMEOUT } from '../helpers/session';
 import { APIDEMO_CAPS } from '../desired';
-import { util } from 'appium-support';
 
 chai.should();
 chai.use(chaiAsPromised);
@@ -219,7 +218,7 @@ describe('mobile', function () {
       const element = await driver.elementByAccessibilityId('Views');
       // Below returns like: {"mStyle"=>0, "mSupportedAxes"=>nil, "mWeight"=>400, "native_instance"=>131438067610240}
       await driver.execute('mobile: backdoor', {
-        target: 'element', elementId: util.unwrapElement(element), methods: [{ name: 'getTypeface' }]}
+        target: 'element', elementId: element.value, methods: [{ name: 'getTypeface' }]}
       ).should.eventually.contain({ mWeight: 400 });
     });
   });

--- a/test/functional/commands/mobile-e2e-specs.js
+++ b/test/functional/commands/mobile-e2e-specs.js
@@ -220,7 +220,7 @@ describe('mobile', function () {
       // Below returns like: {"mStyle"=>0, "mSupportedAxes"=>nil, "mWeight"=>400, "native_instance"=>131438067610240}
       await driver.execute('mobile: backdoor', {
         target: 'element', elementId: util.unwrapElement(element), methods: [{ name: 'getTypeface' }]}
-      ).should.eventually.contain({ mWeight: 400 })
+      ).should.eventually.contain({ mWeight: 400 });
     });
   });
 });

--- a/test/functional/commands/mobile-e2e-specs.js
+++ b/test/functional/commands/mobile-e2e-specs.js
@@ -219,7 +219,7 @@ describe('mobile', function () {
       // Below returns like: {"mStyle"=>0, "mSupportedAxes"=>nil, "mWeight"=>400, "native_instance"=>131438067610240}
       await driver.execute('mobile: backdoor', {
         target: 'element', elementId: element.value, methods: [{ name: 'getTypeface' }]}
-      ).should.eventually.contain({ mWeight: 400 });
+      ).should.eventually.contain({ mStyle: 0 });
     });
   });
 });

--- a/test/functional/commands/mobile-e2e-specs.js
+++ b/test/functional/commands/mobile-e2e-specs.js
@@ -216,7 +216,7 @@ describe('mobile', function () {
 
   describe('mobile: backdoor', function () {
     it('should get element type face', async function () {
-      let element = await driver.elementByAccessibilityId('Views');
+      const element = await driver.elementByAccessibilityId('Views');
       // Below returns like: {"mStyle"=>0, "mSupportedAxes"=>nil, "mWeight"=>400, "native_instance"=>131438067610240}
       await driver.execute('mobile: backdoor', {
         target: 'element', elementId: util.unwrapElement(element), methods: [{ name: 'getTypeface' }]}


### PR DESCRIPTION
closes https://github.com/appium/appium-espresso-driver/issues/453

`targetElement`  is used by Gson in MobileBackdoorParams to map a parameter instead of `elementId` after https://github.com/appium/appium-espresso-driver/pull/405 