### PR TITLE
Add tiemzone and locale in deviceinfo

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetDeviceInfo.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetDeviceInfo.kt
@@ -37,6 +37,8 @@ class GetDeviceInfo : RequestHandler<AppiumParams, Map<String, Any?>> {
         result["carrierName"] = deviceInfoHelper.carrierName
         result["realDisplaySize"] = deviceInfoHelper.realDisplaySize
         result["displayDensity"] = deviceInfoHelper.displayDensity
+        result["locale"] = deviceInfoHelper.locale
+        result["timeZone"] = deviceInfoHelper.timeZone
         return result
     }
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/DeviceInfoHelper.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/DeviceInfoHelper.kt
@@ -24,6 +24,7 @@ import android.telephony.TelephonyManager
 import android.util.DisplayMetrics
 import android.view.Display
 import android.view.WindowManager
+import java.util.*
 
 class DeviceInfoHelper(private val context: Context) {
 
@@ -120,4 +121,16 @@ class DeviceInfoHelper(private val context: Context) {
             display.getRealSize(p)
             return "${p.x}x${p.y}"
         }
+
+    /**
+     * Get current system locale
+     */
+    val locale: String
+        get() = Locale.getDefault().toString()
+
+    /**
+     * Get current system timezone
+     */
+    val timeZone: String
+        get() = TimeZone.getDefault().toZoneId().id
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/DeviceInfoHelper.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/DeviceInfoHelper.kt
@@ -130,7 +130,15 @@ class DeviceInfoHelper(private val context: Context) {
 
     /**
      * Get current system timezone
+     * e.g. "Asia/Tokyo", "America/Caracas"
+     *
      */
     val timeZone: String
-        get() = TimeZone.getDefault().toZoneId().id
+        get() {
+            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                TimeZone.getDefault().toZoneId().id
+            } else {
+                TimeZone.getDefault().id
+            }
+        }
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/DeviceInfoHelper.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/DeviceInfoHelper.kt
@@ -24,7 +24,8 @@ import android.telephony.TelephonyManager
 import android.util.DisplayMetrics
 import android.view.Display
 import android.view.WindowManager
-import java.util.*
+import java.util.TimeZone
+import java.util.Locale
 
 class DeviceInfoHelper(private val context: Context) {
 
@@ -124,6 +125,8 @@ class DeviceInfoHelper(private val context: Context) {
 
     /**
      * Get current system locale
+     *
+     * @return The locale as string
      */
     val locale: String
         get() = Locale.getDefault().toString()
@@ -132,6 +135,7 @@ class DeviceInfoHelper(private val context: Context) {
      * Get current system timezone
      * e.g. "Asia/Tokyo", "America/Caracas"
      *
+     * @return The timezone as string
      */
     val timeZone: String
         get() {


### PR DESCRIPTION
Added timezone and locale as same as https://github.com/appium/appium-xcuitest-driver/pull/1003

```
@driver.execute_script 'mobile: deviceInfo', {}
=> {"realDisplaySize"=>"1080x1920",
 "apiVersion"=>"28",
 "carrierName"=>"Android",
 "platformVersion"=>"9",
 "timeZone"=>"Asia/Tokyo",
 "model"=>"Android SDK built for x86_64",
 "locale"=>"ja_JP",
 "brand"=>"google",
 "androidId"=>"918a8c16d0e7c7ec",
 "manufacturer"=>"Google",
 "displayDensity"=>420}
```