### PR TITLE
add 'open' modifier description for backdoor

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -184,7 +184,7 @@ commands.mobileScrollToPage = async function mobileScrollToPage (opts = {}) {
  *  If target is set to 'activity', methods will be invoked on current activity
  *  If target is set to 'element', 'elementId' must be specified
  *
- * - Only Public methods can be invoked
+ * - Only 'Public' methods can be invoked. ('open' modifire is necessary in Kotlin)
  * - following primitive types are supported: "int", "boolean", "byte", "short", "long", "float", "char"
  * -  Non-primitive types with fully qualified name "java.lang.*" is also supported:
  *                              Eg. "java.lang.CharSequence", "java.lang.String", "java.lang.Integer", "java.lang.Float",


### PR DESCRIPTION
https://github.com/appium/appium-espresso-driver/issues/470#issuecomment-512662214

Kotlin should be `open fun void targetMethod`. It will be `public void targetMethod` in Java.