### PR TITLE
fix: send key multi byte string

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/SendKeys.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/SendKeys.kt
@@ -58,8 +58,9 @@ class SendKeys : RequestHandler<TextParams, Void?> {
         } catch (e: PerformException) {
             throw InvalidElementStateException("sendKeys", params.elementId, e)
         } catch (e: RuntimeException) {
+
             e.message?.let {
-                if (it.contains("IME does not understand how to translate")) throw e
+                if (!it.contains("IME does not understand how to translate")) throw e
             }
             params.text?.let {
                 value = it

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/SendKeys.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/SendKeys.kt
@@ -58,7 +58,6 @@ class SendKeys : RequestHandler<TextParams, Void?> {
         } catch (e: PerformException) {
             throw InvalidElementStateException("sendKeys", params.elementId, e)
         } catch (e: RuntimeException) {
-
             e.message?.let {
                 if (!it.contains("IME does not understand how to translate")) throw e
             }

--- a/test/functional/commands/keyboard-e2e-specs.js
+++ b/test/functional/commands/keyboard-e2e-specs.js
@@ -54,6 +54,13 @@ describe('keyboard', function () {
     await el.clear();
   });
 
+  it('should send keys to the correct element as replace text', async function () {
+    let el = await driver.elementByXPath('//android.widget.AutoCompleteTextView');
+    await el.click();
+    await el.sendKeys('ハロー');
+    await el.clear();
+  });
+
   it('should send keys to the correct element', async function () {
     let el = await driver.elementByXPath('//android.widget.AutoCompleteTextView');
     await el.setImmediateValue('hello world');


### PR DESCRIPTION
From Appium 1.12.0,  sending multibyte string has failed by _send key_ because the control flow was opposit
(worked till 1.11)