### PR TITLE
fix: clipboard get/set contentType

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetClipboard.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetClipboard.kt
@@ -33,12 +33,6 @@ class GetClipboard : RequestHandler<GetClipboardParams, String?> {
 
     @Throws(AppiumException::class)
     override fun handleInternal(params: GetClipboardParams): String? {
-        // FIXME: Can be null while contentType should be ClipboardDataType.PLAINTEXT by default
-        if (params.contentType == null
-            || !ClipboardDataType.supportedDataTypes().contains(params.contentType.toString().toLowerCase())) {
-            throw ClipboardDataType.invalidClipboardDataType(params.contentType)
-        }
-
         try {
             return getClipboardResponse(params.contentType)
         } catch (e: IllegalArgumentException) {

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetClipboard.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetClipboard.kt
@@ -33,10 +33,9 @@ class GetClipboard : RequestHandler<GetClipboardParams, String?> {
 
     @Throws(AppiumException::class)
     override fun handleInternal(params: GetClipboardParams): String? {
-        // Can be null if contentType was no plaintext
+        // FIXME: Can be null while contentType should be ClipboardDataType.PLAINTEXT by default
         if (params.contentType == null
             || !ClipboardDataType.supportedDataTypes().contains(params.contentType.toString().toLowerCase())) {
-
             throw ClipboardDataType.invalidClipboardDataType(params.contentType)
         }
 

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetClipboard.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetClipboard.kt
@@ -33,6 +33,13 @@ class GetClipboard : RequestHandler<GetClipboardParams, String?> {
 
     @Throws(AppiumException::class)
     override fun handleInternal(params: GetClipboardParams): String? {
+        // Can be null if contentType was no plaintext
+        if (params.contentType == null
+            || !ClipboardDataType.supportedDataTypes().contains(params.contentType.toString().toLowerCase())) {
+
+            throw ClipboardDataType.invalidClipboardDataType(params.contentType)
+        }
+
         try {
             return getClipboardResponse(params.contentType)
         } catch (e: IllegalArgumentException) {

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/SetClipboard.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/SetClipboard.kt
@@ -35,10 +35,9 @@ class SetClipboard : RequestHandler<SetClipboardParams, Void?> {
     override fun handleInternal(params: SetClipboardParams): Void? {
         params.content ?: throw InvalidArgumentException("The 'content' argument is mandatory")
 
-        // Can be null if contentType was no plaintext
+        // FIXME: Can be null while contentType should be ClipboardDataType.PLAINTEXT by default
         if (params.contentType == null
             || !ClipboardDataType.supportedDataTypes().contains(params.contentType.toString().toLowerCase())) {
-
             throw ClipboardDataType.invalidClipboardDataType(params.contentType)
         }
 

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/SetClipboard.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/SetClipboard.kt
@@ -34,7 +34,6 @@ class SetClipboard : RequestHandler<SetClipboardParams, Void?> {
     @Throws(AppiumException::class)
     override fun handleInternal(params: SetClipboardParams): Void? {
         params.content ?: throw InvalidArgumentException("The 'content' argument is mandatory")
-
         try {
             mInstrumentation.runOnMainSync(SetClipboardRunnable(
                     params.contentType, params.label, fromBase64String(params.content)))

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/SetClipboard.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/SetClipboard.kt
@@ -16,7 +16,6 @@
 
 package io.appium.espressoserver.lib.handlers
 
-import android.app.Instrumentation
 import android.util.Base64
 
 import java.nio.charset.StandardCharsets
@@ -35,6 +34,14 @@ class SetClipboard : RequestHandler<SetClipboardParams, Void?> {
     @Throws(AppiumException::class)
     override fun handleInternal(params: SetClipboardParams): Void? {
         params.content ?: throw InvalidArgumentException("The 'content' argument is mandatory")
+
+        // Can be null if contentType was no plaintext
+        if (params.contentType == null
+            || !ClipboardDataType.supportedDataTypes().contains(params.contentType.toString().toLowerCase())) {
+
+            throw ClipboardDataType.invalidClipboardDataType(params.contentType)
+        }
+
         try {
             mInstrumentation.runOnMainSync(SetClipboardRunnable(
                     params.contentType, params.label, fromBase64String(params.content)))

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/SetClipboard.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/SetClipboard.kt
@@ -35,12 +35,6 @@ class SetClipboard : RequestHandler<SetClipboardParams, Void?> {
     override fun handleInternal(params: SetClipboardParams): Void? {
         params.content ?: throw InvalidArgumentException("The 'content' argument is mandatory")
 
-        // FIXME: Can be null while contentType should be ClipboardDataType.PLAINTEXT by default
-        if (params.contentType == null
-            || !ClipboardDataType.supportedDataTypes().contains(params.contentType.toString().toLowerCase())) {
-            throw ClipboardDataType.invalidClipboardDataType(params.contentType)
-        }
-
         try {
             mInstrumentation.runOnMainSync(SetClipboardRunnable(
                     params.contentType, params.label, fromBase64String(params.content)))

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/ClipboardDataType.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/ClipboardDataType.kt
@@ -1,16 +1,14 @@
 package io.appium.espressoserver.lib.model
 
-import com.google.gson.annotations.SerializedName
 import io.appium.espressoserver.lib.handlers.exceptions.InvalidArgumentException
 
 enum class ClipboardDataType {
-    @SerializedName("plaintext", alternate = ["PLAINTEXT"])
     PLAINTEXT;
 
     companion object {
-        fun supportedDataTypes(): List<String> = values().map { it.toString().toLowerCase() }
+        private fun supportedDataTypes(): List<String> = values().map { it.toString().toLowerCase() }
 
-        fun invalidClipboardDataType(contentType: ClipboardDataType?) : InvalidArgumentException {
+        fun invalidClipboardDataType(contentType: String?) : InvalidArgumentException {
             return InvalidArgumentException(
                 "Only ${supportedDataTypes()} content types are supported. '$contentType' is given instead"
             )

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/ClipboardDataType.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/ClipboardDataType.kt
@@ -8,7 +8,7 @@ enum class ClipboardDataType {
     companion object {
         fun invalidClipboardDataType(contentType: String?) : InvalidArgumentException {
             return InvalidArgumentException(
-                "Only ${values().map { it.toString().toLowerCase() }} content types are supported. " +
+                "Only case insensitive ${values().map { it.toString().toUpperCase() }} content types are supported. " +
                         "'$contentType' is given instead"
             )
         }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/ClipboardDataType.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/ClipboardDataType.kt
@@ -6,11 +6,18 @@ enum class ClipboardDataType {
     PLAINTEXT;
 
     companion object {
-        fun invalidClipboardDataType(contentType: String?) : InvalidArgumentException {
-            return InvalidArgumentException(
-                "Only case insensitive ${values().map { it.toString() }} content types are supported. " +
-                        "'$contentType' is given instead"
-            )
+        fun getContentType(contentType: String?): ClipboardDataType {
+            if (contentType == null) return PLAINTEXT
+
+            return when (contentType.toUpperCase()) {
+                PLAINTEXT.name ->
+                    PLAINTEXT
+                else ->
+                    throw InvalidArgumentException(
+                        "Only case insensitive ${values().map { it.toString() }} content types are supported. " +
+                                "'$contentType' is given instead")
+            }
+
         }
     }
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/ClipboardDataType.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/ClipboardDataType.kt
@@ -8,7 +8,7 @@ enum class ClipboardDataType {
     companion object {
         fun invalidClipboardDataType(contentType: String?) : InvalidArgumentException {
             return InvalidArgumentException(
-                "Only case insensitive ${values().map { it.toString().toUpperCase() }} content types are supported. " +
+                "Only case insensitive ${values().map { it.toString() }} content types are supported. " +
                         "'$contentType' is given instead"
             )
         }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/ClipboardDataType.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/ClipboardDataType.kt
@@ -1,18 +1,19 @@
 package io.appium.espressoserver.lib.model
 
 import com.google.gson.annotations.SerializedName
-
-import java.util.Arrays
+import io.appium.espressoserver.lib.handlers.exceptions.InvalidArgumentException
 
 enum class ClipboardDataType {
-    @SerializedName("PLAINTEXT")
+    @SerializedName("plaintext", alternate = ["PLAINTEXT"])
     PLAINTEXT;
 
-
     companion object {
+        fun supportedDataTypes(): List<String> = values().map { it.toString().toLowerCase() }
 
-        fun supportedDataTypes(): String {
-            return Arrays.toString(values())
+        fun invalidClipboardDataType(contentType: ClipboardDataType?) : InvalidArgumentException {
+            return InvalidArgumentException(
+                "Only ${supportedDataTypes()} content types are supported. '$contentType' is given instead"
+            )
         }
     }
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/ClipboardDataType.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/ClipboardDataType.kt
@@ -6,11 +6,10 @@ enum class ClipboardDataType {
     PLAINTEXT;
 
     companion object {
-        private fun supportedDataTypes(): List<String> = values().map { it.toString().toLowerCase() }
-
         fun invalidClipboardDataType(contentType: String?) : InvalidArgumentException {
             return InvalidArgumentException(
-                "Only ${supportedDataTypes()} content types are supported. '$contentType' is given instead"
+                "Only ${values().map { it.toString().toLowerCase() }} content types are supported. " +
+                        "'$contentType' is given instead"
             )
         }
     }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/GetClipboardParams.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/GetClipboardParams.kt
@@ -24,8 +24,10 @@ data class GetClipboardParams(
 ) : AppiumParams() {
     val contentType : ClipboardDataType
         get() {
-            return when (_contentType) {
-                null, ClipboardDataType.PLAINTEXT.name, ClipboardDataType.PLAINTEXT.name.toLowerCase()  ->
+            if (_contentType == null) return ClipboardDataType.PLAINTEXT
+
+            return when (_contentType.toUpperCase()) {
+                ClipboardDataType.PLAINTEXT.name ->
                     ClipboardDataType.PLAINTEXT
                 else ->
                     throw ClipboardDataType.invalidClipboardDataType(_contentType)

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/GetClipboardParams.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/GetClipboardParams.kt
@@ -17,5 +17,5 @@
 package io.appium.espressoserver.lib.model
 
 data class GetClipboardParams(
-    val contentType: ClipboardDataType? = ClipboardDataType.PLAINTEXT
+    val contentType: ClipboardDataType = ClipboardDataType.PLAINTEXT
 ) : AppiumParams()

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/GetClipboardParams.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/GetClipboardParams.kt
@@ -17,5 +17,5 @@
 package io.appium.espressoserver.lib.model
 
 data class GetClipboardParams(
-    val contentType: ClipboardDataType = ClipboardDataType.PLAINTEXT
+    val contentType: ClipboardDataType? = ClipboardDataType.PLAINTEXT
 ) : AppiumParams()

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/GetClipboardParams.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/GetClipboardParams.kt
@@ -23,14 +23,5 @@ data class GetClipboardParams(
     private val _contentType: String?
 ) : AppiumParams() {
     val contentType : ClipboardDataType
-        get() {
-            if (_contentType == null) return ClipboardDataType.PLAINTEXT
-
-            return when (_contentType.toUpperCase()) {
-                ClipboardDataType.PLAINTEXT.name ->
-                    ClipboardDataType.PLAINTEXT
-                else ->
-                    throw ClipboardDataType.invalidClipboardDataType(_contentType)
-            }
-        }
+        get() = ClipboardDataType.getContentType(_contentType)
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/GetClipboardParams.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/GetClipboardParams.kt
@@ -16,6 +16,19 @@
 
 package io.appium.espressoserver.lib.model
 
+import com.google.gson.annotations.SerializedName
+
 data class GetClipboardParams(
-    val contentType: ClipboardDataType = ClipboardDataType.PLAINTEXT
-) : AppiumParams()
+    @SerializedName("contentType")
+    private val _contentType: String?
+) : AppiumParams() {
+    val contentType : ClipboardDataType
+        get() {
+            return when (_contentType) {
+                null, ClipboardDataType.PLAINTEXT.name, ClipboardDataType.PLAINTEXT.name.toLowerCase()  ->
+                    ClipboardDataType.PLAINTEXT
+                else ->
+                    throw ClipboardDataType.invalidClipboardDataType(_contentType)
+            }
+        }
+}

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/SetClipboardParams.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/SetClipboardParams.kt
@@ -17,7 +17,7 @@
 package io.appium.espressoserver.lib.model
 
 data class SetClipboardParams(
-    val contentType: ClipboardDataType = ClipboardDataType.PLAINTEXT,
+    val contentType: ClipboardDataType? = ClipboardDataType.PLAINTEXT,
     val content: String? = null,
     val label: String? = null
 ) : AppiumParams()

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/SetClipboardParams.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/SetClipboardParams.kt
@@ -16,8 +16,21 @@
 
 package io.appium.espressoserver.lib.model
 
+import com.google.gson.annotations.SerializedName
+
 data class SetClipboardParams(
-    val contentType: ClipboardDataType = ClipboardDataType.PLAINTEXT,
+    @SerializedName("contentType")
+    private val _contentType: String?,
     val content: String? = null,
     val label: String? = null
-) : AppiumParams()
+) : AppiumParams() {
+    val contentType : ClipboardDataType
+        get() {
+            return when (_contentType) {
+                null, ClipboardDataType.PLAINTEXT.name, ClipboardDataType.PLAINTEXT.name.toLowerCase()  ->
+                    ClipboardDataType.PLAINTEXT
+                else ->
+                    throw ClipboardDataType.invalidClipboardDataType(_contentType)
+            }
+        }
+}

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/SetClipboardParams.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/SetClipboardParams.kt
@@ -17,7 +17,7 @@
 package io.appium.espressoserver.lib.model
 
 data class SetClipboardParams(
-    val contentType: ClipboardDataType? = ClipboardDataType.PLAINTEXT,
+    val contentType: ClipboardDataType = ClipboardDataType.PLAINTEXT,
     val content: String? = null,
     val label: String? = null
 ) : AppiumParams()

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/SetClipboardParams.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/SetClipboardParams.kt
@@ -26,8 +26,10 @@ data class SetClipboardParams(
 ) : AppiumParams() {
     val contentType : ClipboardDataType
         get() {
-            return when (_contentType) {
-                null, ClipboardDataType.PLAINTEXT.name, ClipboardDataType.PLAINTEXT.name.toLowerCase()  ->
+            if (_contentType == null) return ClipboardDataType.PLAINTEXT
+
+            return when (_contentType.toUpperCase()) {
+                ClipboardDataType.PLAINTEXT.name ->
                     ClipboardDataType.PLAINTEXT
                 else ->
                     throw ClipboardDataType.invalidClipboardDataType(_contentType)

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/SetClipboardParams.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/SetClipboardParams.kt
@@ -25,14 +25,5 @@ data class SetClipboardParams(
     val label: String? = null
 ) : AppiumParams() {
     val contentType : ClipboardDataType
-        get() {
-            if (_contentType == null) return ClipboardDataType.PLAINTEXT
-
-            return when (_contentType.toUpperCase()) {
-                ClipboardDataType.PLAINTEXT.name ->
-                    ClipboardDataType.PLAINTEXT
-                else ->
-                    throw ClipboardDataType.invalidClipboardDataType(_contentType)
-            }
-        }
+        get() = ClipboardDataType.getContentType(_contentType)
 }

--- a/test/functional/commands/clipboard-e2e-specs.js
+++ b/test/functional/commands/clipboard-e2e-specs.js
@@ -21,7 +21,9 @@ describe('clipboard', function () {
 
   it('should set and get clipboard', async function () {
     await driver.setClipboard(new Buffer.from('Hello').toString('base64'), 'plaintext');
-    // 'SGVsbG8=' is 'Hello' in base 64 encoding
-    await driver.getClipboard('PLAINTEXT').should.eventually.eql('SGVsbG8=');
+    // 'SGVsbG8=' is 'Hello' in base 64 encoding with a new line.
+    const text = await driver.getClipboard('PLAINTEXT');
+    text.should.eql('SGVsbG8=\n');
+    (new Buffer('SGVsbG8=\n', 'base64').toString()).should.eql('Hello');
   });
 });

--- a/test/functional/commands/clipboard-e2e-specs.js
+++ b/test/functional/commands/clipboard-e2e-specs.js
@@ -19,8 +19,8 @@ describe('clipboard', function () {
     await deleteSession();
   });
 
-  it('should send keys to the correct element', async function () {
+  it('should set and get clipboard', async function () {
     await driver.setClipboard(new Buffer.from('Hello').toString('base64'), 'plaintext');
-    await driver.getClipboard.should.eventually.eql('Hello');
+    await driver.getClipboard().should.eventually.eql('Hello');
   });
 });

--- a/test/functional/commands/clipboard-e2e-specs.js
+++ b/test/functional/commands/clipboard-e2e-specs.js
@@ -21,6 +21,7 @@ describe('clipboard', function () {
 
   it('should set and get clipboard', async function () {
     await driver.setClipboard(new Buffer.from('Hello').toString('base64'), 'plaintext');
-    await driver.getClipboard().should.eventually.eql('Hello');
+    // 'SGVsbG8=' is 'Hello' in base 64 encoding
+    await driver.getClipboard('PLAINTEXT').should.eventually.eql('SGVsbG8=');
   });
 });

--- a/test/functional/commands/clipboard-e2e-specs.js
+++ b/test/functional/commands/clipboard-e2e-specs.js
@@ -1,0 +1,26 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { initSession, deleteSession, MOCHA_TIMEOUT } from '../helpers/session';
+import { APIDEMO_CAPS } from '../desired';
+
+
+chai.should();
+chai.use(chaiAsPromised);
+
+
+describe('clipboard', function () {
+  this.timeout(MOCHA_TIMEOUT);
+
+  let driver;
+  before(async function () {
+    driver = await initSession(APIDEMO_CAPS);
+  });
+  after(async function () {
+    await deleteSession();
+  });
+
+  it('should send keys to the correct element', async function () {
+    await driver.setClipboard(new Buffer.from('Hello').toString('base64'), 'plaintext');
+    await driver.getClipboard.should.eventually.eql('Hello');
+  });
+});


### PR DESCRIPTION
Below error happens against `[debug] [WD Proxy] Proxying [POST /wd/hub/session/50c33b86-8579-4d8a-911b-b175996978b6/appium/device/set_clipboard] to [POST http://localhost:8200/session/24fe3836-7a6c-4a01-a57c-be0c4a6e327e/appium/device/set_clipboard] with body: {"contentType":"plaintext","content":"aGFwcHkgdGVzdGluZw==","label":"Note"}` since the contentType was lower case. Not sure from when, but recent espresso driver can work for `PLAINTEXT` case even if previosly it accepts `plaintext`.

```
Selenium::WebDriver::Error::InvalidArgumentError: io.appium.espressoserver.lib.handlers.exceptions.InvalidArgumentException: java.lang.IllegalArgumentException: Parameter specified as non-null is null: method kotlin.jvm.internal.Intrinsics.checkParameterIsNotNull, parameter contentType
        at io.appium.espressoserver.lib.handlers.SetClipboard.handleInternal(SetClipboard.kt:42)
        at io.appium.espressoserver.lib.handlers.SetClipboard.handleInternal(SetClipboard.kt:32)
        at io.appium.espressoserver.lib.handlers.RequestHandler$DefaultImpls.handle(RequestHandler.kt:28)
        at io.appium.espressoserver.lib.handlers.SetClipboard.handle(SetClipboard.kt:32)
        at io.appium.espressoserver.lib.handlers.SetClipboard.handle(SetClipboard.kt:32)
        at io.appium.espressoserver.lib.http.Router.route(Router.kt:216)
        at io.appium.espressoserver.lib.http.Server.serve(Server.kt:53)
        at fi.iki.elonen.NanoHTTPD$HTTPSession.execute(NanoHTTPD.java:945)
        at fi.iki.elonen.NanoHTTPD$ClientHandler.run(NanoHTTPD.java:192)
        at java.lang.Thread.run(Thread.java:764)
Caused by: java.lang.IllegalArgumentException: Parameter specified as non-null is null: method kotlin.jvm.internal.Intrinsics.checkParameterIsNotNull, parameter contentType
        at io.appium.espressoserver.lib.handlers.SetClipboard$SetClipboardRunnable.<init>(Unknown Source:2)
        at io.appium.espressoserver.lib.handlers.SetClipboard.handleInternal(SetClipboard.kt:39)
        ... 9 more
from InvalidArgumentError: io.appium.espressoserver.lib.handlers.exceptions.InvalidArgumentException: java.lang.IllegalArgumentException: Parameter specified as non-null is null: method kotlin.jvm.internal.Intrinsics.checkParameterIsNotNull, parameter contentType
```

In this PR, I changed to accept such lower case, too. Uppercase and lowercase are enough so far.
`contentType` can be null, so I've added `?`.