### PR TITLE
fix set/get orientation

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetOrientation.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetOrientation.kt
@@ -20,19 +20,21 @@ import android.content.pm.ActivityInfo
 
 import io.appium.espressoserver.lib.handlers.exceptions.AppiumException
 import io.appium.espressoserver.lib.model.AppiumParams
-import io.appium.espressoserver.lib.model.Element
+import io.appium.espressoserver.lib.model.OrientationType
 import io.appium.espressoserver.lib.model.ViewElement
+import io.appium.espressoserver.lib.viewaction.ViewGetter
 
-class GetOrientation : RequestHandler<AppiumParams, Int> {
+class GetOrientation : RequestHandler<AppiumParams, String> {
 
     @Throws(AppiumException::class)
-    override fun handleInternal(params: AppiumParams): Int {
-        val view = Element.getViewById(params.elementId)
-        return try {
-            when (ViewElement(view).extractActivity()?.requestedOrientation) {
+    override fun handleInternal(params: AppiumParams): String {
+        val rootView = ViewGetter().rootView
+
+        try {
+            return when (ViewElement(rootView).extractActivity()?.requestedOrientation) {
                 ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE,
-                ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
-                else -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+                ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE -> OrientationType.LANDSCAPE.name
+                else -> OrientationType.PORTRAIT.name
             }
         } catch (e: Exception) {
             throw AppiumException("Cannot get screen orientation", e)

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/SetOrientation.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/SetOrientation.kt
@@ -23,6 +23,7 @@ import io.appium.espressoserver.lib.viewaction.OrientationChange
 
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.matcher.ViewMatchers.isRoot
+import io.appium.espressoserver.lib.model.OrientationType
 
 class SetOrientation : RequestHandler<OrientationParams, Void?> {
 
@@ -33,8 +34,8 @@ class SetOrientation : RequestHandler<OrientationParams, Void?> {
         // Validate the orientaiton
         orientation ?: throw AppiumException("Screen orientation value must not be null")
 
-        if (!listOf("LANDSCAPE", "PORTRAIT").contains(orientation.toUpperCase())) {
-            throw AppiumException("Screen orientation must be one of LANDSCAPE or PORTRAIT. Found '${orientation}'");
+        if (!OrientationType.supportedOrientationTypes().contains(orientation.toUpperCase())) {
+            throw AppiumException("Screen orientation must be one of LANDSCAPE or PORTRAIT. Found '$orientation'");
         }
 
         // Get the view interaction for the element or for the root, if no element provided
@@ -45,14 +46,14 @@ class SetOrientation : RequestHandler<OrientationParams, Void?> {
         }
 
         try {
-            if (orientation.equals("LANDSCAPE", ignoreCase = true)) {
+            if (orientation.equals(OrientationType.LANDSCAPE.name, ignoreCase = true)) {
                 viewInteraction.perform(OrientationChange.orientationLandscape())
             } else {
                 viewInteraction.perform(OrientationChange.orientationPortrait())
             }
-            return null;
+            return null
         } catch (e: Exception) {
-            throw AppiumException("Cannot change screen orientation to '${orientation}'", e)
+            throw AppiumException("Cannot change screen orientation to '$orientation'", e)
         }
     }
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/OrientationType.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/OrientationType.kt
@@ -1,0 +1,15 @@
+package io.appium.espressoserver.lib.model
+
+import java.util.Arrays
+
+
+enum class OrientationType {
+    LANDSCAPE,
+    PORTRAIT;
+
+    companion object {
+        fun supportedOrientationTypes(): String {
+            return Arrays.toString(values())
+        }
+    }
+}

--- a/test/functional/commands/orientation-e2e-specs.js
+++ b/test/functional/commands/orientation-e2e-specs.js
@@ -1,0 +1,31 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { initSession, deleteSession, MOCHA_TIMEOUT } from '../helpers/session';
+import { APIDEMO_CAPS } from '../desired';
+
+
+chai.should();
+chai.use(chaiAsPromised);
+
+
+describe('orientation', function () {
+  this.timeout(MOCHA_TIMEOUT);
+
+  let driver;
+  before(async function () {
+    driver = await initSession(APIDEMO_CAPS);
+  });
+  after(async function () {
+    await deleteSession();
+  });
+
+  it('should set and get orientation', async function () {
+    await driver.getOrientation().should.eventually.eql('PORTRAIT');
+
+    await driver.setOrientation('landscape');
+    await driver.getOrientation().should.eventually.eql('LANDSCAPE');
+
+    await driver.setOrientation('PORTRAIT');
+    await driver.getOrientation().should.eventually.eql('PORTRAIT');
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/appium/appium-espresso-driver/issues/479

I noticed current get orientation did not work since it returned error or int value instead of 'LANDSCAPE' or 'PORTRAIT' strings


----

I've tested with Ruby code on my local, for now.