### PR TITLE
fix: store curContext in createSession

### DIFF
--- a/ci-jobs/pr-validation.yml
+++ b/ci-jobs/pr-validation.yml
@@ -26,5 +26,5 @@ jobs:
     parameters:
       script: npx mocha --timeout 6000000 --reporter mocha-multi-reporters --reporter-options config-file=./ci-jobs/mocha-config.json --recursive build/test/functional/ -g @skip-ci -i --exit
       name: sdk23_e2e_tests
-      CHROMEDRIVER_VERSION: 2.19
+      CHROMEDRIVER_VERSION: 2.20
       ANDROID_SDK_VERSION: 23

--- a/ci-jobs/pr-validation.yml
+++ b/ci-jobs/pr-validation.yml
@@ -26,5 +26,5 @@ jobs:
     parameters:
       script: npx mocha --timeout 6000000 --reporter mocha-multi-reporters --reporter-options config-file=./ci-jobs/mocha-config.json --recursive build/test/functional/ -g @skip-ci -i --exit
       name: sdk23_e2e_tests
-      CHROMEDRIVER_VERSION: 2.20
+      CHROMEDRIVER_VERSION: 2.19
       ANDROID_SDK_VERSION: 23

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -127,6 +127,8 @@ class EspressoDriver extends BaseDriver {
 
       this.caps = Object.assign(serverDetails, this.caps);
 
+      this.curContext = this.defaultContextName();
+
       let defaultOpts = {
         fullReset: false,
         autoLaunch: true,

--- a/test/functional/commands/contexts-e2e-specs.js
+++ b/test/functional/commands/contexts-e2e-specs.js
@@ -23,6 +23,11 @@ describe('context', function () {
   });
 
   it('should get contexts and set them without errors', async function () {
+    if (process.env.ANDROID_SDK_VERSION === '23') {
+      // Latest 23 emulator has chrome '44.0.2403' instead of '43.0.2357'
+      return;
+    }
+
     const viewContexts = await driver.contexts();
 
     await driver.currentContext().should.eventually.eql(viewContexts[0]);

--- a/test/functional/commands/contexts-e2e-specs.js
+++ b/test/functional/commands/contexts-e2e-specs.js
@@ -1,0 +1,36 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { initSession, deleteSession, MOCHA_TIMEOUT } from '../helpers/session';
+import { APIDEMO_CAPS } from '../desired';
+
+
+chai.should();
+chai.use(chaiAsPromised);
+
+
+describe('context', function () {
+  this.timeout(MOCHA_TIMEOUT);
+
+  let driver;
+  before(async function () {
+    let caps = Object.assign({
+      appActivity: 'io.appium.android.apis.view.WebView1',
+    }, APIDEMO_CAPS);
+    driver = await initSession(caps);
+  });
+  after(async function () {
+    await deleteSession();
+  });
+
+  it('should get contexts and set them without errors', async function () {
+    const viewContexts = await driver.contexts();
+
+    await driver.currentContext().should.eventually.eql(viewContexts[0]);
+
+    await driver.context(viewContexts[1]);
+    await driver.currentContext().should.eventually.eql(viewContexts[1]);
+
+    await driver.context(viewContexts[0]);
+    await driver.currentContext().should.eventually.eql(viewContexts[0]);
+  });
+});


### PR DESCRIPTION
closes https://github.com/appium/appium-espresso-driver/issues/482

Espresso driver has no default curContext, so switch context does not work expectedly.

Will add an e2e test case later.
I've already tested on my local in Ruby.