### PR TITLE
fix set value immediately, replace value

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/ElementValue.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/ElementValue.kt
@@ -15,7 +15,13 @@ class ElementValue(private val isReplacing: Boolean) : RequestHandler<ElementVal
 
     @Throws(AppiumException::class)
     override fun handleInternal(params: ElementValueParams): Void? {
-        val value = params.value ?: throw InvalidArgumentException("Must provide 'value' property");
+        val value = if (params.value != null) {
+            params.value!!.joinToString()
+        } else {
+            throw InvalidArgumentException("Must provide 'value' property")
+        }
+
+
         val elementId = params.elementId
         val view = Element.getViewById(elementId)
 
@@ -35,9 +41,9 @@ class ElementValue(private val isReplacing: Boolean) : RequestHandler<ElementVal
 
         val viewInteraction = Element.getViewInteractionById(elementId)
         if (isReplacing) {
-            viewInteraction.perform(replaceText(params.value))
+            viewInteraction.perform(replaceText(value))
         } else {
-            viewInteraction.perform(typeText(params.value))
+            viewInteraction.perform(typeText(value))
         }
         return null
     }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/ElementValue.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/ElementValue.kt
@@ -15,12 +15,12 @@ class ElementValue(private val isReplacing: Boolean) : RequestHandler<ElementVal
 
     @Throws(AppiumException::class)
     override fun handleInternal(params: ElementValueParams): Void? {
-        val value = if (params.value != null) {
-            params.value!!.joinToString()
-        } else {
-            throw InvalidArgumentException("Must provide 'value' property")
+        val value: String = when (Pair(params.value == null, params.text == null)) {
+            Pair(first=true, second=true) -> throw InvalidArgumentException("Must provide 'value' or 'text' property")
+            Pair(first=false, second=true) -> params.value!!.joinToString(separator="")
+            Pair(first=true, second=false) -> params.text!!
+            else -> params.value!!.joinToString() // for backward-compatibility
         }
-
 
         val elementId = params.elementId
         val view = Element.getViewById(elementId)

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/ElementValueParams.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/ElementValueParams.kt
@@ -1,5 +1,6 @@
 package io.appium.espressoserver.lib.model
 
 data class ElementValueParams(
-    var value: List<String>? = null
+    val value: List<String>? = null,
+    val text: String? = null
 ) : AppiumParams()

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/ElementValueParams.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/ElementValueParams.kt
@@ -1,5 +1,5 @@
 package io.appium.espressoserver.lib.model
 
 data class ElementValueParams(
-    var value: String? = null
+    var value: List<String>? = null
 ) : AppiumParams()

--- a/test/functional/commands/element-values-e2e-specs.js
+++ b/test/functional/commands/element-values-e2e-specs.js
@@ -24,7 +24,7 @@ describe('ElementValue', function () {
 
   it('should set value and replace them', async function () {
     let el = await driver.elementById('io.appium.android.apis:id/left_text_edit');
-    await el.setImmediateValue('hello');
+    await el.setImmediateValue(['hello']);
 
     let elValue = await driver.elementById('io.appium.android.apis:id/left_text_edit');
     await elValue.text().should.eventually.equal('Left is besthello');

--- a/test/functional/commands/element-values-e2e-specs.js
+++ b/test/functional/commands/element-values-e2e-specs.js
@@ -1,0 +1,35 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { initSession, deleteSession, MOCHA_TIMEOUT } from '../helpers/session';
+import { APIDEMO_CAPS } from '../desired';
+
+
+chai.should();
+chai.use(chaiAsPromised);
+
+
+describe('ElementValue', function () {
+  this.timeout(MOCHA_TIMEOUT);
+
+  let driver;
+  before(async function () {
+    let caps = Object.assign({
+      appActivity: 'io.appium.android.apis.app.CustomTitle',
+    }, APIDEMO_CAPS);
+    driver = await initSession(caps);
+  });
+  after(async function () {
+    await deleteSession();
+  });
+
+  it('should set value and replace them', async function () {
+    let el = await driver.elementById('io.appium.android.apis:id/left_text_edit');
+    await el.setImmediateValue('hello');
+
+    let elValue = await driver.elementById('io.appium.android.apis:id/left_text_edit');
+    await elValue.text().should.eventually.equal('Left is besthello');
+
+    elValue.setText(['テスト']);
+    await elValue.text().should.eventually.equal('テスト');
+  });
+});

--- a/test/functional/commands/keyboard-e2e-specs.js
+++ b/test/functional/commands/keyboard-e2e-specs.js
@@ -63,9 +63,9 @@ describe('keyboard', function () {
 
   it('should send keys to the correct element', async function () {
     let el = await driver.elementByXPath('//android.widget.AutoCompleteTextView');
-    await el.setImmediateValue('hello world');
+    await el.setImmediateValue(['hello world']);
     await el.text().should.eventually.equal('hello world');
-    await el.setImmediateValue('!!!');
+    await el.setImmediateValue(['!!!']);
     await el.text().should.eventually.equal('hello world!!!');
     await el.clear();
   });


### PR DESCRIPTION
Below error happens for set immediate value and replace value.

```
Selenium::WebDriver::Error::InvalidArgumentError:         Selenium::WebDriver::Error::InvalidArgumentError: com.google.gson.JsonSyntaxException: java.lang.IllegalStateException: Expected a string but was BEGIN_ARRAY at line 1 column 11 path $.value
            io.appium.espressoserver.lib.handlers.exceptions.InvalidArgumentException: com.google.gson.JsonSyntaxException: java.lang.IllegalStateException: Expected a string but was BEGIN_ARRAY at line 1 column 11 path $.value
            	at io.appium.espressoserver.lib.http.Router.route(Router.kt:203)
            	at io.appium.espressoserver.lib.http.Server.serve(Server.kt:49)
            	at fi.iki.elonen.NanoHTTPD$HTTPSession.execute(NanoHTTPD.java:945)
            	at fi.iki.elonen.NanoHTTPD$ClientHandler.run(NanoHTTPD.java:192)
            	at java.lang.Thread.run(Thread.java:764)
```

Tested in Ruby to make the behaviour the same as UIA2

---

https://dev.azure.com/kazucocoa/ruby_lib_core/_build/results?buildId=1265