### PR TITLE
fix raise an error for launch app and close app since they do not need in espresso

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -23,12 +23,12 @@ function assertRequiredOptions (options, requiredOptionNames) {
 
 // eslint-disable-next-line require-await
 commands.launchApp = async function launchApp () {
-  throw new errors.UnsupportedOperationError('Please re-create a new session to configure the app under test correctly');
+  throw new errors.UnsupportedOperationError('Please create a new session in order to launch the application under test');
 };
 
 // eslint-disable-next-line require-await
 commands.closeApp = async function closeApp () {
-  throw new errors.UnsupportedOperationError('Please quit the session instead of closeApp');
+  throw new errors.UnsupportedOperationError('Please quit the session in order to close the application under test');
 };
 
 commands.mobilePerformEditorAction = async function mobilePerformEditorAction (opts = {}) {

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -21,6 +21,16 @@ function assertRequiredOptions (options, requiredOptionNames) {
     `You have only provided: ${JSON.stringify(presentOptionNames)}`);
 }
 
+/**
+ * Launch the app under test with a new Espresso session
+ */
+commands.launchApp = async function launchApp () {
+  await this.initAUT();
+  // launch espresso and wait till its online and we have a session
+  await this.espresso.startSession(this.caps);
+  await this.adb.waitForActivity(this.caps.appWaitPackage, this.caps.appWaitActivity, this.opts.appWaitDuration);
+};
+
 commands.mobilePerformEditorAction = async function mobilePerformEditorAction (opts = {}) {
   const {action} = assertRequiredOptions(opts, ['action']);
   return await this.espresso.jwproxy.command('/appium/device/perform_editor_action', 'POST', {action});

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -21,14 +21,9 @@ function assertRequiredOptions (options, requiredOptionNames) {
     `You have only provided: ${JSON.stringify(presentOptionNames)}`);
 }
 
-/**
- * Launch the app under test with a new Espresso session
- */
+// eslint-disable-next-line require-await
 commands.launchApp = async function launchApp () {
-  await this.initAUT();
-  // launch espresso and wait till its online and we have a session
-  await this.espresso.startSession(this.caps);
-  await this.adb.waitForActivity(this.caps.appWaitPackage, this.caps.appWaitActivity, this.opts.appWaitDuration);
+  throw new errors.UnsupportedOperationError('Please re-create a new session');
 };
 
 commands.mobilePerformEditorAction = async function mobilePerformEditorAction (opts = {}) {

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -23,7 +23,12 @@ function assertRequiredOptions (options, requiredOptionNames) {
 
 // eslint-disable-next-line require-await
 commands.launchApp = async function launchApp () {
-  throw new errors.UnsupportedOperationError('Please re-create a new session');
+  throw new errors.UnsupportedOperationError('Please re-create a new session to configure the app under test correctly');
+};
+
+// eslint-disable-next-line require-await
+commands.closeApp = async function closeApp () {
+  throw new errors.UnsupportedOperationError('Please quit the session instead of closeApp');
 };
 
 commands.mobilePerformEditorAction = async function mobilePerformEditorAction (opts = {}) {


### PR DESCRIPTION
Current `launchApp` missed espresso session like below scenario since espresso-driver does not establish a new session with the launched app

```
@driver.close_app
assert(@@core.wait { @driver.app_state('io.appium.android.apis') != :running_in_foreground })

@driver.launch_app
e = @@core.wait { @driver.find_element :accessibility_id, 'App' }
assert_equal 'App', e.text
```

Then, below error raises in `find_element`.
```
Appium::Core::Wait::TimeoutError: timed out after 20 seconds (An unknown server-side error occurred while processing the command. Original error: Could not proxy. Proxy error: Could not proxy command to remote server. Original error: Error: socket hang up)
```

https://dev.azure.com/kazucocoa/ruby_lib_core/_build/results?buildId=1265