### PR TITLE
Always print the original stacktrace rather than the wrapped one

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/DummyW3CActionAdapter.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/DummyW3CActionAdapter.kt
@@ -58,11 +58,11 @@ open class DummyW3CActionAdapter : BaseW3CActionAdapter() {
         }
     }
 
-    override fun keyDown(keyEvent: W3CKeyEvent) {
+    override fun keyDown(keyDownEvent: W3CKeyEvent) {
         // No-op
     }
 
-    override fun keyUp(keyEvent: W3CKeyEvent) {
+    override fun keyUp(keyUpEvent: W3CKeyEvent) {
         // No-op
     }
 

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/espresso/EspressoW3CActionAdapter.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/w3c/adapter/espresso/EspressoW3CActionAdapter.kt
@@ -2,10 +2,6 @@ package io.appium.espressoserver.lib.helpers.w3c.adapter.espresso
 
 import android.content.Context
 import android.graphics.Point
-import android.util.DisplayMetrics
-import android.view.View
-
-import java.util.Collections
 
 import androidx.test.espresso.UiController
 import androidx.test.espresso.action.GeneralLocation
@@ -47,13 +43,13 @@ class EspressoW3CActionAdapter(private val uiController: UiController) : BaseW3C
     }
 
     @Throws(AppiumException::class)
-    override fun keyDown(keyEvent: W3CKeyEvent) {
-        androidKeyEvent.keyDown(keyEvent)
+    override fun keyDown(keyDownEvent: W3CKeyEvent) {
+        androidKeyEvent.keyDown(keyDownEvent)
     }
 
     @Throws(AppiumException::class)
-    override fun keyUp(keyEvent: W3CKeyEvent) {
-        androidKeyEvent.keyUp(keyEvent)
+    override fun keyUp(keyUpEvent: W3CKeyEvent) {
+        androidKeyEvent.keyUp(keyUpEvent)
     }
 
     @Throws(AppiumException::class)

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/response/AppiumResponse.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/response/AppiumResponse.kt
@@ -38,16 +38,17 @@ class AppiumResponse : BaseResponse {
         init(value, sessionId)
     }
 
-    private fun formatError(e: AppiumException): Map<String, String> = mapOf(
+    private fun formatError(e: AppiumException,
+                            originalStacktrace: String): Map<String, String> = mapOf(
         "error" to e.error(),
         "message" to (e.message ?: MESSAGE_UNKNOWN_ERROR),
-        "stacktrace" to Log.getStackTraceString(e)
+        "stacktrace" to originalStacktrace
     )
 
     private fun init(value: Any?, sessionId: String?) {
         if (value is Throwable) {
             val e = if (value is AppiumException) value else AppiumException(value)
-            this.value = formatError(e)
+            this.value = formatError(e, Log.getStackTraceString(value))
             this.httpStatus = e.status()
         } else {
             this.value = value

--- a/espresso-server/app/src/test/java/io/appium/espressoserver/test/helpers/w3c/ActionSequenceTest.kt
+++ b/espresso-server/app/src/test/java/io/appium/espressoserver/test/helpers/w3c/ActionSequenceTest.kt
@@ -31,9 +31,7 @@ import io.appium.espressoserver.lib.helpers.w3c.models.InputSource.ActionType.PO
 import io.appium.espressoserver.lib.helpers.w3c.models.InputSource.InputSourceType.KEY
 import io.appium.espressoserver.lib.helpers.w3c.models.InputSource.InputSourceType.POINTER
 import io.appium.espressoserver.test.helpers.w3c.Helpers.assertFloatEquals
-import junit.framework.Assert.assertTrue
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
+import org.junit.Assert.*
 
 class ActionSequenceTest {
 

--- a/espresso-server/app/src/test/java/io/appium/espressoserver/test/helpers/w3c/ProcessorTest.kt
+++ b/espresso-server/app/src/test/java/io/appium/espressoserver/test/helpers/w3c/ProcessorTest.kt
@@ -8,7 +8,6 @@ import java.util.ArrayList
 
 import io.appium.espressoserver.lib.handlers.exceptions.InvalidArgumentException
 import io.appium.espressoserver.lib.handlers.exceptions.NotYetImplementedException
-import io.appium.espressoserver.lib.helpers.w3c.models.ActionObject
 import io.appium.espressoserver.lib.helpers.w3c.models.InputSource
 import io.appium.espressoserver.lib.helpers.w3c.models.InputSource.Action
 import io.appium.espressoserver.lib.helpers.w3c.models.InputSource.ActionType
@@ -25,11 +24,7 @@ import io.appium.espressoserver.lib.helpers.w3c.processor.PointerProcessor.proce
 import io.appium.espressoserver.lib.helpers.w3c.processor.PointerProcessor.processPointerMoveAction
 import io.appium.espressoserver.lib.helpers.w3c.processor.PointerProcessor.processPointerUpOrDownAction
 import io.appium.espressoserver.test.helpers.w3c.Helpers.assertFloatEquals
-import junit.framework.Assert.assertFalse
-import junit.framework.Assert.assertNull
-import junit.framework.Assert.fail
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
+import org.junit.Assert.*
 
 class ProcessorTest {
 

--- a/espresso-server/app/src/test/java/io/appium/espressoserver/test/helpers/w3c/TickTest.kt
+++ b/espresso-server/app/src/test/java/io/appium/espressoserver/test/helpers/w3c/TickTest.kt
@@ -2,18 +2,13 @@ package io.appium.espressoserver.test.helpers.w3c
 
 
 import org.junit.Test
-import java.util.concurrent.Callable
-import java.util.concurrent.CompletionService
 import java.util.concurrent.ExecutionException
-import java.util.concurrent.Executor
 import java.util.concurrent.ExecutorCompletionService
 import java.util.concurrent.Executors
-import java.util.concurrent.Future
 
 import io.appium.espressoserver.lib.handlers.exceptions.AppiumException
 import io.appium.espressoserver.lib.handlers.exceptions.InvalidArgumentException
 import io.appium.espressoserver.lib.helpers.w3c.adapter.DummyW3CActionAdapter
-import io.appium.espressoserver.lib.helpers.w3c.adapter.W3CActionAdapter
 import io.appium.espressoserver.lib.helpers.w3c.dispatcher.BaseDispatchResult
 import io.appium.espressoserver.lib.helpers.w3c.models.ActionObject
 import io.appium.espressoserver.lib.helpers.w3c.models.InputSource.PointerType
@@ -206,6 +201,7 @@ class TickTest {
         tick.addAction(actionObjectTwo)
 
         class ExtendedDummyW3CActionAdapter : DummyW3CActionAdapter() {
+            @Suppress("UNUSED_PARAMETER", "unused")
             fun pointerMove(sourceId: String,
                             pointerType: PointerType,
                             currentX: Float?, currentY: Float?,


### PR DESCRIPTION
This simplifies parsing of debug logs