### PR TITLE
fix: Sync createSession parameters with W3C spec

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/CreateSession.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/CreateSession.kt
@@ -22,16 +22,18 @@ import io.appium.espressoserver.lib.handlers.exceptions.SessionNotCreatedExcepti
 import io.appium.espressoserver.lib.helpers.ActivityHelper.startActivity
 import io.appium.espressoserver.lib.helpers.w3c.caps.parseCapabilities
 import io.appium.espressoserver.lib.model.Session
-import io.appium.espressoserver.lib.model.W3CCapabilities
+import io.appium.espressoserver.lib.model.SessionParams
 
 
-class CreateSession : RequestHandler<W3CCapabilities, Session> {
+class CreateSession : RequestHandler<SessionParams, Session> {
 
     @Throws(AppiumException::class)
-    override fun handleInternal(params: W3CCapabilities): Session {
-        val appiumSession = Session.createGlobalSession(params)
+    override fun handleInternal(params: SessionParams): Session {
+        val appiumSession = Session.createGlobalSession(params.capabilities
+                ?: throw SessionNotCreatedException("'capabilities' field is mandatory"))
         try {
-            val parsedCaps = parseCapabilities(params.firstMatch, params.alwaysMatch)
+            val parsedCaps = parseCapabilities(params.capabilities.firstMatch,
+                    params.capabilities.alwaysMatch)
             val activityName = parsedCaps["appActivity"] as? String
                     ?: throw InvalidArgumentException("appActivity capability is mandatory")
             startActivity(parsedCaps["appPackage"] as? String, activityName)

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetSession.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetSession.kt
@@ -19,12 +19,12 @@ package io.appium.espressoserver.lib.handlers
 import io.appium.espressoserver.lib.handlers.exceptions.AppiumException
 import io.appium.espressoserver.lib.model.AppiumParams
 import io.appium.espressoserver.lib.model.Session
-import io.appium.espressoserver.lib.model.W3CCapabilities
+import io.appium.espressoserver.lib.model.SessionParams
 
-class GetSession : RequestHandler<AppiumParams, W3CCapabilities?> {
+class GetSession : RequestHandler<AppiumParams, SessionParams.W3CCapabilities?> {
 
     @Throws(AppiumException::class)
-    override fun handleInternal(params: AppiumParams): W3CCapabilities? {
+    override fun handleInternal(params: AppiumParams): SessionParams.W3CCapabilities? {
         Session.globalSession?.let {
             return it.capabilities
         }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetSessions.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetSessions.kt
@@ -26,7 +26,7 @@ class GetSessions : RequestHandler<AppiumParams, Collection<Map<String, Any?>>> 
     override fun handleInternal(params: AppiumParams): Collection<Map<String, Any?>> {
         Session.globalSession?.let { session ->
             return listOf<Map<String, Any?>>(mapOf(
-                    "id" to session.id,
+                    "id" to session.sessionId,
                     "capabilities" to mapOf(
                             "firstMatch" to session.capabilities.firstMatch,
                             "alwaysMatch" to session.capabilities.alwaysMatch

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/exceptions/SessionNotCreatedException.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/exceptions/SessionNotCreatedException.kt
@@ -18,7 +18,12 @@ package io.appium.espressoserver.lib.handlers.exceptions
 
 import fi.iki.elonen.NanoHTTPD
 
-class SessionNotCreatedException(cause: Throwable) : AppiumException(cause) {
+class SessionNotCreatedException: AppiumException {
+
+    constructor(reason: String) : super(reason) {}
+
+    constructor(cause: Throwable) : super(cause) {}
+
     override fun error(): String {
         return "session not created"
     }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.kt
@@ -39,7 +39,7 @@ internal class Router {
         routeMap = RouteMap()
 
         routeMap.addRoute(RouteDefinition(Method.GET, "/status", Status(), AppiumParams::class.java))
-        routeMap.addRoute(RouteDefinition(Method.POST, "/session", CreateSession(), W3CCapabilities::class.java))
+        routeMap.addRoute(RouteDefinition(Method.POST, "/session", CreateSession(), SessionParams::class.java))
         routeMap.addRoute(RouteDefinition(Method.GET, "/session/:sessionId", GetSession(), AppiumParams::class.java))
         routeMap.addRoute(RouteDefinition(Method.POST, "/session/:sessionId/actions", PerformAction(), Actions::class.java))
         routeMap.addRoute(RouteDefinition(Method.DELETE, "/session/:sessionId/actions", ReleaseActions(), Actions::class.java))

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.kt
@@ -208,7 +208,7 @@ internal class Router {
             // Validate the sessionId
             if (appiumParams.sessionId != null
                     && Session.globalSession != null
-                    && appiumParams.sessionId != Session.globalSession!!.id) {
+                    && appiumParams.sessionId != Session.globalSession!!.sessionId) {
                 return AppiumResponse(NoSuchDriverException("Invalid session ID ${appiumParams.sessionId!!}"))
             }
 
@@ -218,7 +218,7 @@ internal class Router {
 
             // If it's a new session, pull out the newly created Session ID
             if (handlerResult is Session) {
-                sessionId = handlerResult.id
+                sessionId = handlerResult.sessionId
             }
 
             // Construct the response and serve it

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/Session.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/Session.kt
@@ -20,7 +20,7 @@ import io.appium.espressoserver.lib.handlers.exceptions.SessionNotCreatedExcepti
 import io.appium.espressoserver.lib.helpers.AndroidLogger
 import java.util.*
 
-class Session private constructor(val id: String, val capabilities: W3CCapabilities)
+class Session private constructor(val id: String, val capabilities: SessionParams.W3CCapabilities)
 {
     companion object {
         // Only one session can run at a time so globally cache the current Session ID
@@ -37,7 +37,7 @@ class Session private constructor(val id: String, val capabilities: W3CCapabilit
          * @throws SessionNotCreatedException Thrown if a Session is already running
          */
         @Synchronized
-        fun createGlobalSession(capabilities: W3CCapabilities): Session {
+        fun createGlobalSession(capabilities: SessionParams.W3CCapabilities): Session {
             globalSession?.let {
                 AndroidLogger.logger.info("Got request for new session creation while the one " +
                         "is still in progress. Overriding the old session having the id ${it.id}");

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/Session.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/Session.kt
@@ -20,7 +20,7 @@ import io.appium.espressoserver.lib.handlers.exceptions.SessionNotCreatedExcepti
 import io.appium.espressoserver.lib.helpers.AndroidLogger
 import java.util.*
 
-class Session private constructor(val id: String, val capabilities: SessionParams.W3CCapabilities)
+class Session private constructor(val sessionId: String, val capabilities: SessionParams.W3CCapabilities)
 {
     companion object {
         // Only one session can run at a time so globally cache the current Session ID
@@ -40,7 +40,7 @@ class Session private constructor(val id: String, val capabilities: SessionParam
         fun createGlobalSession(capabilities: SessionParams.W3CCapabilities): Session {
             globalSession?.let {
                 AndroidLogger.logger.info("Got request for new session creation while the one " +
-                        "is still in progress. Overriding the old session having the id ${it.id}");
+                        "is still in progress. Overriding the old session having the id ${it.sessionId}");
             }
             val globalSession = Session(UUID.randomUUID().toString(), capabilities)
             Session.globalSession = globalSession

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/Session.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/Session.kt
@@ -40,7 +40,7 @@ class Session private constructor(val sessionId: String, val capabilities: Sessi
         fun createGlobalSession(capabilities: SessionParams.W3CCapabilities): Session {
             globalSession?.let {
                 AndroidLogger.logger.info("Got request for new session creation while the one " +
-                        "is still in progress. Overriding the old session having the id ${it.sessionId}");
+                        "is still in progress. Overriding the old session having the id ${it.sessionId}")
             }
             val globalSession = Session(UUID.randomUUID().toString(), capabilities)
             Session.globalSession = globalSession

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/SessionParams.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/SessionParams.kt
@@ -16,5 +16,8 @@
 
 package io.appium.espressoserver.lib.model
 
-data class W3CCapabilities(val firstMatch: List<Map<String, Any?>>?, val alwaysMatch: Map<String, Any?>?)
-    : AppiumParams()
+data class SessionParams(
+        val capabilities: W3CCapabilities?
+) : AppiumParams() {
+    data class W3CCapabilities(val firstMatch: List<Map<String, Any?>>?, val alwaysMatch: Map<String, Any?>?)
+}

--- a/lib/espresso-runner.js
+++ b/lib/espresso-runner.js
@@ -214,8 +214,12 @@ class EspressoRunner {
       }
     }
 
-    await this.jwproxy.command('/session', 'POST', {firstMatch: [caps], alwaysMatch: {}});
-
+    await this.jwproxy.command('/session', 'POST', {
+      capabilities: {
+        firstMatch: [caps],
+        alwaysMatch: {}
+      }
+    });
     await this.recordTargetAppPackage();
   }
 


### PR DESCRIPTION
I've totally missed the fact that firstMatch/alwaysMatch should be under 'capabilities' key