### PR TITLE
fix: raise an error for reset as same as launchApp and closeApp

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -31,6 +31,11 @@ commands.closeApp = async function closeApp () {
   throw new errors.UnsupportedOperationError('Please quit the session in order to close the application under test');
 };
 
+// eslint-disable-next-line require-await
+commands.reset = async function reset () {
+  throw new errors.UnsupportedOperationError('Please quit the session and create a new session in order to close and launch the application under test');
+};
+
 commands.mobilePerformEditorAction = async function mobilePerformEditorAction (opts = {}) {
   const {action} = assertRequiredOptions(opts, ['action']);
   return await this.espresso.jwproxy.command('/appium/device/perform_editor_action', 'POST', {action});


### PR DESCRIPTION
https://github.com/appium/appium-espresso-driver/pull/485 for `reset`
Reset also close/launch the app.
For espresso, delete/create session are the same meaning.

closes https://github.com/appium/appium-espresso-driver/issues/459