### PR TITLE
Exclude transitive dependencies of espresso-contrib

### DIFF
--- a/espresso-server/app/build.gradle
+++ b/espresso-server/app/build.gradle
@@ -60,7 +60,9 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
     testImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 
-    androidTestImplementation "androidx.test.espresso:espresso-contrib:$espresso_version"
+    androidTestImplementation("androidx.test.espresso:espresso-contrib:$espresso_version") {
+        transitive = false
+    }
     androidTestImplementation "androidx.test.espresso:espresso-core:$espresso_version"
     androidTestImplementation "androidx.test.espresso:espresso-web:$espresso_version"
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'


### PR DESCRIPTION
Should fix #449

Exclude transitive dependencies of espresso-contrib when building espresso-server APK. The dependencies include many AndroidX view libraries and thus has a big chance of conflict with AndroidX libraries in AUT.
These dependencies now would come from APK of AUT, so this change should not break tests.

Kotlin dependencies are addressed in #496
Hopefully, "non test" dependencies that are still left will not conflict with the most apps:
- androidx.lifecycle:lifecycle-common:2.0.0
- com.google.code.findbugs:jsr305:2.0.1
- com.google.code.gson:gson:2.8.5
- com.squareup:javawriter:2.1.1
- javax.inject:javax.inject:1
- javax.ws.rs:jsr311-api:1.1.1
- net.sf.kxml:kxml2:2.3.0
- org.hamcrest:hamcrest-integration:1.3
- org.ccil.cowan.tagsoup:tagsoup:1.2
- org.jetbrains:annotations:13.0
- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.31
- org.jetbrains.kotlin:kotlin-stdlib:1.3.31
- org.jetbrains.kotlin:kotlin-stdlib-common:1.3.31
- org.jetbrains.kotlin:kotlin-reflect:1.3.31
- org.nanohttpd:nanohttpd:2.3.1
- org.nanohttpd:nanohttpd-webserver:2.3.1

**Dependency tree for this PR**
```
+--- androidx.test.espresso:espresso-contrib:3.2.0
+--- androidx.test.espresso:espresso-core:3.2.0
|    +--- androidx.test:runner:1.2.0
|    |    +--- androidx.annotation:annotation:1.0.0
|    |    +--- androidx.test:monitor:1.2.0
|    |    |    \--- androidx.annotation:annotation:1.0.0
|    |    +--- junit:junit:4.12
|    |    |    \--- org.hamcrest:hamcrest-core:1.3
|    |    \--- net.sf.kxml:kxml2:2.3.0
|    +--- androidx.test.espresso:espresso-idling-resource:3.2.0
|    +--- com.squareup:javawriter:2.1.1
|    +--- javax.inject:javax.inject:1
|    +--- org.hamcrest:hamcrest-library:1.3
|    |    \--- org.hamcrest:hamcrest-core:1.3
|    +--- org.hamcrest:hamcrest-integration:1.3
|    |    \--- org.hamcrest:hamcrest-library:1.3 (*)
|    \--- com.google.code.findbugs:jsr305:2.0.1
+--- androidx.test.espresso:espresso-web:3.2.0
|    +--- androidx.test.espresso:espresso-core:3.2.0 (*)
|    +--- androidx.annotation:annotation:1.0.0
|    \--- org.ccil.cowan.tagsoup:tagsoup:1.2
+--- androidx.test.uiautomator:uiautomator:2.2.0
+--- androidx.test:core:1.2.0
|    +--- androidx.annotation:annotation:1.0.0
|    +--- androidx.test:monitor:1.2.0 (*)
|    \--- androidx.lifecycle:lifecycle-common:2.0.0
|         \--- androidx.annotation:annotation:1.0.0
+--- androidx.test:runner:1.2.0 (*)
+--- androidx.test:rules:1.2.0
|    \--- androidx.test:runner:1.2.0 (*)
+--- com.google.code.gson:gson:2.8.5
+--- javax.ws.rs:jsr311-api:1.1.1
+--- org.nanohttpd:nanohttpd-webserver:2.3.1
|    \--- org.nanohttpd:nanohttpd:2.3.1
+--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.31
|    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.31
|         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.3.31
|         \--- org.jetbrains:annotations:13.0
+--- org.jetbrains.kotlin:kotlin-reflect:1.3.31
|    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.31 (*)
+--- androidx.test.espresso:espresso-contrib:{strictly 3.2.0} -> 3.2.0 (c)
+--- androidx.test.espresso:espresso-core:{strictly 3.2.0} -> 3.2.0 (c)
+--- androidx.test:runner:{strictly 1.2.0} -> 1.2.0 (c)
+--- androidx.annotation:annotation:{strictly 1.0.0} -> 1.0.0 (c)
+--- androidx.test:monitor:{strictly 1.2.0} -> 1.2.0 (c)
+--- junit:junit:{strictly 4.12} -> 4.12 (c)
+--- org.hamcrest:hamcrest-core:{strictly 1.3} -> 1.3 (c)
+--- net.sf.kxml:kxml2:{strictly 2.3.0} -> 2.3.0 (c)
+--- androidx.test.espresso:espresso-idling-resource:{strictly 3.2.0} -> 3.2.0 (c)
+--- com.squareup:javawriter:{strictly 2.1.1} -> 2.1.1 (c)
+--- javax.inject:javax.inject:{strictly 1} -> 1 (c)
+--- org.hamcrest:hamcrest-library:{strictly 1.3} -> 1.3 (c)
+--- org.hamcrest:hamcrest-integration:{strictly 1.3} -> 1.3 (c)
+--- com.google.code.findbugs:jsr305:{strictly 2.0.1} -> 2.0.1 (c)
+--- androidx.test.espresso:espresso-web:{strictly 3.2.0} -> 3.2.0 (c)
+--- org.ccil.cowan.tagsoup:tagsoup:{strictly 1.2} -> 1.2 (c)
+--- androidx.test.uiautomator:uiautomator:{strictly 2.2.0} -> 2.2.0 (c)
+--- androidx.test:core:{strictly 1.2.0} -> 1.2.0 (c)
+--- androidx.lifecycle:lifecycle-common:{strictly 2.0.0} -> 2.0.0 (c)
+--- androidx.test:rules:{strictly 1.2.0} -> 1.2.0 (c)
+--- com.google.code.gson:gson:{strictly 2.8.5} -> 2.8.5 (c)
+--- javax.ws.rs:jsr311-api:{strictly 1.1.1} -> 1.1.1 (c)
+--- org.nanohttpd:nanohttpd-webserver:{strictly 2.3.1} -> 2.3.1 (c)
+--- org.nanohttpd:nanohttpd:{strictly 2.3.1} -> 2.3.1 (c)
+--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:{strictly 1.3.31} -> 1.3.31 (c)
+--- org.jetbrains.kotlin:kotlin-stdlib:{strictly 1.3.31} -> 1.3.31 (c)
+--- org.jetbrains.kotlin:kotlin-stdlib-common:{strictly 1.3.31} -> 1.3.31 (c)
+--- org.jetbrains:annotations:{strictly 13.0} -> 13.0 (c)
\--- org.jetbrains.kotlin:kotlin-reflect:{strictly 1.3.31} -> 1.3.31 (c)
```