### PR TITLE
feat: add link to troubleshooting to guide users to the troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The key difference between [UiAutomator2 Driver](https://github.com/appium/appiu
 
 * If there are ever problems starting a session, try setting the capability `forceEspressoRebuild=true` and retrying. This will rebuild a fresh Espresso Server APK. If the session is succcesful, set it back to false so that it doesn't re-install on every single test.
 * Espresso requires the debug APK and app-under-test APK (AUT) to have the same signature. It automatically signs the AUT with the `io.appium.espressoserver.test` signature. This may have problems if you're using an outdated Android SDK tools and/or an outdated Java version.
-* If you failed to establish Espresso session in `proguard` environment because of `Resources$NotFoundException`, for example, please try to add below rule. Please read [#449](https://github.com/appium/appium-espresso-driver/issues/449#issuecomment-537833139) for more various cases.
+* If you experience session startup failures due to exceptions similar to `Resources$NotFoundException` then try to adjust your ProGuard rules:
   ```
   -dontwarn com.google.android.material.**
   -keep class com.google.android.material.** { *; }
@@ -29,6 +29,7 @@ The key difference between [UiAutomator2 Driver](https://github.com/appium/appiu
   -dontwarn android.support.v7.**
   -keep class android.support.v7.** { *; }
   ```
+  Please read [#449](https://github.com/appium/appium-espresso-driver/issues/449#issuecomment-537833139) for more details on this topic.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,21 @@ The key difference between [UiAutomator2 Driver](https://github.com/appium/appiu
 
 * If there are ever problems starting a session, try setting the capability `forceEspressoRebuild=true` and retrying. This will rebuild a fresh Espresso Server APK. If the session is succcesful, set it back to false so that it doesn't re-install on every single test.
 * Espresso requires the debug APK and app-under-test APK (AUT) to have the same signature. It automatically signs the AUT with the `io.appium.espressoserver.test` signature. This may have problems if you're using an outdated Android SDK tools and/or an outdated Java version.
+* If you failed to establish Espresso session in `proguard` environment because of `Resources$NotFoundException`, for example, please try to add below rule. Please read [#449](https://github.com/appium/appium-espresso-driver/issues/449#issuecomment-537833139) for more various cases.
+  ```
+  -dontwarn com.google.android.material.**
+  -keep class com.google.android.material.** { *; }
+
+  -dontwarn androidx.**
+  -keep class androidx.** { *; }
+  -keep interface androidx.** { *; }
+
+  -dontwarn android.support.v4.**
+  -keep class android.support.v4.** { *; }
+
+  -dontwarn android.support.v7.**
+  -keep class android.support.v7.** { *; }
+  ```
 
 ## Contributing
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -171,6 +171,7 @@ class EspressoDriver extends BaseDriver {
       return [sessionId, caps];
     } catch (e) {
       await this.deleteSession();
+      e.message += '. Please check troubleshooting https://github.com/appium/appium-espresso-driver#contributing';
       throw e;
     }
   }

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -171,9 +171,11 @@ class EspressoDriver extends BaseDriver {
       return [sessionId, caps];
     } catch (e) {
       await this.deleteSession();
-      e.message += '. If the cause might be espresso driver or server, ' +
-        'please read troubleshooting https://github.com/appium/appium-espresso-driver#contributing';
-      throw new errors.SessionNotCreatedError(e);
+      e.message += '. Check https://github.com/appium/appium-espresso-driver#troubleshooting regarding advanced session startup troubleshooting.';
+      if (e instanceof errors.SessionNotCreatedError) {
+        throw e;
+      }
+      throw new errors.SessionNotCreatedError(e.message);
     }
   }
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { BaseDriver, errors } from 'appium-base-driver';
+import { BaseDriver, errors, isErrorType } from 'appium-base-driver';
 import { EspressoRunner, TEST_APK_PKG } from './espresso-runner';
 import { fs } from 'appium-support';
 import logger from './logger';
@@ -172,10 +172,12 @@ class EspressoDriver extends BaseDriver {
     } catch (e) {
       await this.deleteSession();
       e.message += '. Check https://github.com/appium/appium-espresso-driver#troubleshooting regarding advanced session startup troubleshooting.';
-      if (e instanceof errors.SessionNotCreatedError) {
+      if (isErrorType(e, errors.SessionNotCreatedError)) {
         throw e;
       }
-      throw new errors.SessionNotCreatedError(e.message);
+      const err = new errors.SessionNotCreatedError(e.message);
+      err.stack = e.stack;
+      throw err;
     }
   }
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { BaseDriver } from 'appium-base-driver';
+import { BaseDriver, errors } from 'appium-base-driver';
 import { EspressoRunner, TEST_APK_PKG } from './espresso-runner';
 import { fs } from 'appium-support';
 import logger from './logger';
@@ -171,8 +171,9 @@ class EspressoDriver extends BaseDriver {
       return [sessionId, caps];
     } catch (e) {
       await this.deleteSession();
-      e.message += '. Please check troubleshooting https://github.com/appium/appium-espresso-driver#contributing';
-      throw e;
+      e.message += '. If the cause might be espresso driver or server, ' +
+        'please read troubleshooting https://github.com/appium/appium-espresso-driver#contributing';
+      throw new errors.SessionNotCreatedError(e);
     }
   }
 


### PR DESCRIPTION
(I inserted `new Error()` in create session)

- server
```
[debug] [Espresso] Deleting espresso session
[Espresso] Unable to remove port forward 'Cannot read property 'removePortForward' of undefined'
[debug] [BaseDriver] Event 'newSessionStarted' logged at 1570106294202 (21:38:14 GMT+0900 (Japan Standard Time))
[debug] [W3C] Encountered internal error running command: Error: Error!!!!. If the reason might be espresso driver or server, please read troubleshooting https://github.com/appium/appium-espresso-driver#contributing
[debug] [W3C]     at EspressoDriver.Error [as createSession] (/Users/kazu/GitHub/appium-espresso-driver/lib/driver.js:171:13)
[HTTP] <-- POST /wd/hub/session 500 9 ms - 779
[HTTP]
```


- client
```
Selenium::WebDriver::Error::SessionNotCreatedError:         Selenium::WebDriver::Error::SessionNotCreatedError: A new session could not be created. Details: Error: Error!!!!. If the reason might be espresso driver or server, please read troubleshooting https://github.com/appium/appium-espresso-driver#contributing
```