### PR TITLE
use skipServerInstallation same way as with uiautomator2-driver

### DIFF
--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -28,6 +28,9 @@ let espressoCapConstraints = {
   },
   showGradleLog: {
     isBoolean: true
+  },
+  skipServerInstallation: {
+    isBoolean: true
   }
 };
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -356,6 +356,7 @@ class EspressoDriver extends BaseDriver {
       showGradleLog: !!this.opts.showGradleLog,
       serverLaunchTimeout: this.opts.espressoServerLaunchTimeout,
       androidInstallTimeout: this.opts.androidInstallTimeout,
+      skipServerInstallation: this.opts.skipServerInstallation,
     });
     this.proxyReqRes = this.espresso.proxyReqRes.bind(this.espresso);
   }
@@ -400,7 +401,11 @@ class EspressoDriver extends BaseDriver {
       }
       await helpers.installApk(this.adb, this.opts);
     }
-    await this.espresso.installTestApk();
+    if (this.opts.skipServerInstallation) {
+      logger.debug('skipServerInstallation capability is set. Not installig espresso-server ');
+    } else {
+      await this.espresso.installTestApk();
+    }
   }
 
   async deleteSession () {


### PR DESCRIPTION
Rebuilding the espresso-server using Gradle is time-consuming on slower machines and increases startup time significantly. With uiautomator2-driver there is a capability called `skipServerInstallation` which assumes that the device already has required servers. This can be usable with espresso-driver