### PR TITLE
fix: Add device udid to the server folder root

### DIFF
--- a/lib/espresso-runner.js
+++ b/lib/espresso-runner.js
@@ -14,7 +14,15 @@ import { copyGradleProjectRecursively } from './utils';
 const TEST_SERVER_ROOT = path.resolve(__dirname, '..', '..', 'espresso-server');
 const TEST_MANIFEST_PATH = path.resolve(TEST_SERVER_ROOT, 'AndroidManifest-test.xml');
 const TEST_APK_PKG = 'io.appium.espressoserver.test';
-const REQUIRED_PARAMS = ['adb', 'tmpDir', 'host', 'systemPort', 'devicePort', 'appPackage', 'forceEspressoRebuild'];
+const REQUIRED_PARAMS = [
+  'adb',
+  'tmpDir',
+  'host',
+  'systemPort',
+  'devicePort',
+  'appPackage',
+  'forceEspressoRebuild',
+];
 const ESPRESSO_SERVER_LAUNCH_TIMEOUT = 30000;
 const TARGET_PACKAGE_CONTAINER = '/data/local/tmp/espresso.apppackage';
 
@@ -126,12 +134,12 @@ class EspressoRunner {
         throw e;
       }
     }
-    logger.info('Building espresso server');
-    const serverPath = path.resolve(this.tmpDir, 'espresso-server');
-    logger.debug(`build dir: ${serverPath}`);
+    const serverPath = path.resolve(this.tmpDir, `espresso-server-${this.adb.udid}`);
+    logger.info(`Building espresso server in '${serverPath}'`);
+    logger.debug(`The build folder root could be customized by changing the 'tmpDir' capability`);
     await fs.rimraf(serverPath);
     await mkdirp(serverPath);
-    logger.debug(`Copying espresso server template from (${TEST_SERVER_ROOT} to ${serverPath})`);
+    logger.debug(`Copying espresso server template from ('${TEST_SERVER_ROOT}' to '${serverPath}')`);
     await copyGradleProjectRecursively(TEST_SERVER_ROOT, serverPath);
     await new ServerBuilder({serverPath, buildConfiguration, showGradleLog: this.showGradleLog}).build();
     const apkPath = path.resolve(serverPath, 'app', 'build', 'outputs', 'apk', 'androidTest', 'debug', 'app-debug-androidTest.apk');

--- a/lib/espresso-runner.js
+++ b/lib/espresso-runner.js
@@ -42,7 +42,7 @@ class EspressoRunner {
     });
     this.proxyReqRes = this.jwproxy.proxyReqRes.bind(this.jwproxy);
 
-    this.modServerPath = path.resolve(this.tmpDir, `${TEST_APK_PKG}_${version}_${this.appPackage}.apk`);
+    this.modServerPath = path.resolve(this.tmpDir, `${TEST_APK_PKG}_${version}_${this.appPackage}_${this.adb.udid}.apk`);
     this.showGradleLog = opts.showGradleLog;
     this.espressoBuildConfig = opts.espressoBuildConfig;
 


### PR DESCRIPTION
Device udid is supposed to be always unique (we cannot start two sessions on the same device at the same time). This fix then guarantees there will be no conflicts if parallel tests are being executed on different devices for the same app version.