### PR TITLE
fix: Use appropriate adb property

### DIFF
--- a/lib/espresso-runner.js
+++ b/lib/espresso-runner.js
@@ -42,7 +42,7 @@ class EspressoRunner {
     });
     this.proxyReqRes = this.jwproxy.proxyReqRes.bind(this.jwproxy);
 
-    this.modServerPath = path.resolve(this.tmpDir, `${TEST_APK_PKG}_${version}_${this.appPackage}_${this.adb.udid}.apk`);
+    this.modServerPath = path.resolve(this.tmpDir, `${TEST_APK_PKG}_${version}_${this.appPackage}_${this.adb.curDeviceId}.apk`);
     this.showGradleLog = opts.showGradleLog;
     this.espressoBuildConfig = opts.espressoBuildConfig;
 
@@ -134,7 +134,7 @@ class EspressoRunner {
         throw e;
       }
     }
-    const serverPath = path.resolve(this.tmpDir, `espresso-server-${this.adb.udid}`);
+    const serverPath = path.resolve(this.tmpDir, `espresso-server-${this.adb.curDeviceId}`);
     logger.info(`Building espresso server in '${serverPath}'`);
     logger.debug(`The build folder root could be customized by changing the 'tmpDir' capability`);
     await fs.rimraf(serverPath);


### PR DESCRIPTION
It seems like `adb.udid` is not actually used, although `curDeviceId` is used instead