### PR TITLE
fix a toast regression

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/viewmatcher/ToastMatcher.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/viewmatcher/ToastMatcher.kt
@@ -26,7 +26,15 @@ class ToastMatcher : TypeSafeMatcher<Root>() {
     }
 
     public override fun matchesSafely(root: Root): Boolean {
-        return if (root.windowLayoutParams.get().type != WindowManager.LayoutParams.TYPE_TOAST) {
+
+        val notToast = try {
+            // 'TYPE_TOAST' is deprecated, so it will be removed in the future
+            root.windowLayoutParams.get().type != WindowManager.LayoutParams::class.members.single { it.name == "TYPE_TOAST" }.call()
+        } catch (e: NoSuchElementException) {
+            root.windowLayoutParams.get().type != WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY
+        }
+
+        return if (notToast) {
             false
         } else root.decorView.windowToken === root.decorView.applicationWindowToken
     }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/viewmatcher/ToastMatcher.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/viewmatcher/ToastMatcher.kt
@@ -34,7 +34,7 @@ class ToastMatcher : TypeSafeMatcher<Root>() {
         } catch (e: NoSuchElementException) {
             AndroidLogger.logger.info("WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY " +
                     "was called instead of WindowManager.LayoutParams.TYPE_TOAST in this environment " +
-                    "because of the deprecation. It could affect to find a toast element")
+                    "because the latter has been deprecated. This could affect toast elements lookup")
             root.windowLayoutParams.get().type != WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY
         }
 

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/viewmatcher/ToastMatcher.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/viewmatcher/ToastMatcher.kt
@@ -26,7 +26,7 @@ class ToastMatcher : TypeSafeMatcher<Root>() {
     }
 
     public override fun matchesSafely(root: Root): Boolean {
-        return if (root.windowLayoutParams.get().type != WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY) {
+        return if (root.windowLayoutParams.get().type != WindowManager.LayoutParams.TYPE_TOAST) {
             false
         } else root.decorView.windowToken === root.decorView.applicationWindowToken
     }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/viewmatcher/ToastMatcher.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/viewmatcher/ToastMatcher.kt
@@ -17,6 +17,7 @@ package io.appium.espressoserver.lib.viewmatcher
 
 import android.view.WindowManager
 import androidx.test.espresso.Root
+import io.appium.espressoserver.lib.helpers.AndroidLogger
 import org.hamcrest.Description
 import org.hamcrest.TypeSafeMatcher
 
@@ -31,6 +32,9 @@ class ToastMatcher : TypeSafeMatcher<Root>() {
             // 'TYPE_TOAST' is deprecated, so it will be removed in the future
             root.windowLayoutParams.get().type != WindowManager.LayoutParams::class.members.single { it.name == "TYPE_TOAST" }.call()
         } catch (e: NoSuchElementException) {
+            AndroidLogger.logger.info("WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY " +
+                    "was called instead of WindowManager.LayoutParams.TYPE_TOAST in this environment " +
+                    "because of the deprecation. It could affect to find a toast element")
             root.windowLayoutParams.get().type != WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY
         }
 


### PR DESCRIPTION
I found a regression
https://dev.azure.com/kazucocoa/ruby_lib_core/_build/results?buildId=1733&view=logs&j=cf3f09f0-b33f-5a9c-9a54-00702f010006&t=0c6beea2-cf53-5c48-3d66-9fd06ae199bb

Espresso driver failed to find a toast message after tapping 'pot toast' below.
`TYPE_TOAST` has a deprecated mark, so it was replaced with `TYPE_APPLICATION_OVERLAY`, but it caused the regression.

<img src='https://user-images.githubusercontent.com/5511591/80918754-90fd6c80-8da1-11ea-8ff7-8ee0a6563bfa.png' width=300>

Espresso driver's build environment could depend on a user environment, so I think it is safe to check the running environment has `TYPE_TOAST`. It makes performance slightly slow, but on my local test, the slowness should not be an issue since this effect only for toast.