### PR TITLE
feat: Add startService/stopService mobile helpers

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/StartService.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/StartService.kt
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.espressoserver.lib.handlers
+
+import android.content.Intent
+import androidx.test.platform.app.InstrumentationRegistry
+import io.appium.espressoserver.lib.helpers.extractQualifiedClassName
+import io.appium.espressoserver.lib.model.StartServiceParams
+
+class StartService : RequestHandler<StartServiceParams, String?> {
+
+    override fun handleInternal(params: StartServiceParams): String? {
+        val targetContext = InstrumentationRegistry.getInstrumentation().targetContext
+        val intent = Intent(targetContext,
+                Class.forName(extractQualifiedClassName(targetContext.packageName, params.intent)))
+        val componentName = if (params.foreground == true) {
+            targetContext.startForegroundService(intent)
+        } else {
+            targetContext.startService(intent)
+        }
+        componentName ?: throw IllegalStateException("The '${params.intent}' service cannot be started " +
+                "or is unknown. Does the service belong to ${targetContext.packageName} app?")
+
+        return "${componentName.packageName}/${componentName.className}"
+    }
+}

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/StopService.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/StopService.kt
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.espressoserver.lib.handlers
+
+import android.content.Intent
+import androidx.test.platform.app.InstrumentationRegistry
+import io.appium.espressoserver.lib.handlers.exceptions.AppiumException
+import io.appium.espressoserver.lib.helpers.extractQualifiedClassName
+import io.appium.espressoserver.lib.model.StopServiceParams
+
+class StopService : RequestHandler<StopServiceParams, String?> {
+
+    @Throws(AppiumException::class)
+    override fun handleInternal(params: StopServiceParams): String? {
+        val targetContext = InstrumentationRegistry.getInstrumentation().targetContext
+        val intent = Intent(targetContext,
+                Class.forName(extractQualifiedClassName(targetContext.packageName, params.intent)))
+        if (!targetContext.stopService(intent)) {
+            throw IllegalStateException("The '${params.intent}' service cannot be stopped " +
+                    "or is unknown. Does the service belong to ${targetContext.packageName} app?")
+        }
+
+        return "true"
+    }
+}

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/StopService.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/StopService.kt
@@ -18,13 +18,11 @@ package io.appium.espressoserver.lib.handlers
 
 import android.content.Intent
 import androidx.test.platform.app.InstrumentationRegistry
-import io.appium.espressoserver.lib.handlers.exceptions.AppiumException
 import io.appium.espressoserver.lib.helpers.extractQualifiedClassName
 import io.appium.espressoserver.lib.model.StopServiceParams
 
 class StopService : RequestHandler<StopServiceParams, String?> {
 
-    @Throws(AppiumException::class)
     override fun handleInternal(params: StopServiceParams): String? {
         val targetContext = InstrumentationRegistry.getInstrumentation().targetContext
         val intent = Intent(targetContext,

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/IntentHelpers.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/IntentHelpers.kt
@@ -325,3 +325,12 @@ fun makeIntent(context: Context?, options: Map<String, Any?>): Intent {
     require(hasIntentInfo) { "Either intent action, data, type or categories must be supplied" }
     return intent
 }
+
+fun extractQualifiedClassName(pkg: String, fullName: String): String {
+    var className = fullName
+    val slashPos = className.indexOf("/")
+    if (slashPos >= 0 && className.length > slashPos) {
+        className = className.substring(slashPos + 1)
+    }
+    return if (className.startsWith(".")) "${pkg}${className}" else className
+}

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.kt
@@ -133,6 +133,8 @@ internal class Router {
         routeMap.addRoute(RouteDefinition(Method.POST, "/session/:sessionId/appium/execute_mobile/:elementId/click_action", MobileClickAction(), MobileClickActionParams::class.java))
         routeMap.addRoute(RouteDefinition(Method.POST, "/session/:sessionId/appium/execute_mobile/web_atoms", WebAtoms(), WebAtomsParams::class.java))
         routeMap.addRoute(RouteDefinition(Method.POST, "/session/:sessionId/appium/execute_mobile/:elementId/dismiss_autofill", PerformAutofillDismissal(), AppiumParams::class.java))
+        routeMap.addRoute(RouteDefinition(Method.POST, "/session/:sessionId/appium/execute_mobile/start_service", StartService(), StartServiceParams::class.java))
+        routeMap.addRoute(RouteDefinition(Method.POST, "/session/:sessionId/appium/execute_mobile/stop_service", StopService(), StopServiceParams::class.java))
 
         // Not implemented
         routeMap.addRoute(RouteDefinition(Method.POST, "/session/:sessionId/touch/flick", NotYetImplemented(), AppiumParams::class.java))

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/StartServiceParams.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/StartServiceParams.kt
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.espressoserver.lib.model
+
+data class StartServiceParams(
+    val intent: String,
+    val foreground: Boolean?
+) : AppiumParams()

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/StopServiceParams.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/StopServiceParams.kt
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.espressoserver.lib.model
+
+data class StopServiceParams(
+    val intent: String
+) : AppiumParams()

--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -56,6 +56,9 @@ extensions.executeMobile = async function executeMobile (mobileCommand, opts = {
     sensorSet: 'sensorSet',
 
     deleteFile: 'mobileDeleteFile',
+
+    startService: 'mobileStartService',
+    stopService: 'mobileStopService',
   };
 
   if (!_.has(mobileCommandsMapping, mobileCommand)) {

--- a/lib/commands/services.js
+++ b/lib/commands/services.js
@@ -1,0 +1,57 @@
+import _ from 'lodash';
+
+const commands = {};
+
+function requireOptions (opts, requiredKeys = []) {
+  const missingKeys = _.difference(requiredKeys, _.keys(opts));
+  if (!_.isEmpty(missingKeys)) {
+    throw new Error(`The following options are required: ${missingKeys}`);
+  }
+  return opts;
+}
+
+/**
+ * @typedef {Object} StartServiceOptions
+ * @property {!string} intent - The name of the service intent to start, for example
+ * `com.some.package.name/.YourServiceSubClassName`. This option is mandatory.
+ * !!! Only services in the app's under test scope could be started.
+ * @property {boolean} foreground [false] - Set it to `true` if your service must be
+ * started as foreground service.
+ */
+
+/**
+ * Starts the given service intent.
+ *
+ * @param {StartServiceOptions} opts
+ * @returns {string} The full component name
+ * @throws {Error} If there was a failure while starting the service
+ * or required options are missing
+ */
+commands.mobileStartService = async function mobileStartService (opts = {}) {
+  return await this.espresso.jwproxy.command('/appium/execute_mobile/start_service', 'POST',
+    requireOptions(opts, ['intent']));
+};
+
+/**
+ * @typedef {Object} StopServiceOptions
+ * @property {!string} intent - The name of the service intent to stop, for example
+ * `com.some.package.name/.YourServiceSubClassName`. This option is mandatory.
+ * !!! Only services in the app's under test scope could be stopped.
+ */
+
+/**
+ * Stops the given service intent.
+ *
+ * @param {StopServiceOptions} opts
+ * @returns {string} `true` if the service has been successfully stopped
+ * @throws {Error} If there was a failure while stopping the service
+ * or required options are missing
+ */
+commands.mobileStopService = async function mobileStopService (opts = {}) {
+  return await this.espresso.jwproxy.command('/appium/execute_mobile/stop_service', 'POST',
+    requireOptions(opts, ['intent']));
+};
+
+
+export { commands };
+export default commands;

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@babel/runtime": "^7.4.3",
     "appium-adb": "^8.0.0",
-    "appium-android-driver": "^4.32.0",
+    "appium-android-driver": "^4.37.0",
     "appium-base-driver": "^6.0.1",
     "appium-support": "^2.46.0",
     "asyncbox": "^2.3.1",


### PR DESCRIPTION
Espresso is limited to app sandbox, so there is no point to have this endpoint calling `adb shell am` like in UIA2. It works with `InstrumentationRegistry.getInstrumentation().targetContext` entity instead and only accepts services that are implemented in scope of the current app under test.