### PR TITLE
chore: Catch only NoMatchingViewException, do not swallow AppNotIdleException

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/ThreadHelpers.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/ThreadHelpers.kt
@@ -1,0 +1,18 @@
+package io.appium.espressoserver.lib.helpers
+
+object ThreadHelpers {
+    val threadDump: String
+        get(){
+            val threadDetails = StringBuilder()
+            val activeCount = Thread.activeCount()
+            val threads = arrayOfNulls<Thread>(activeCount)
+            Thread.enumerate(threads)
+            for (thread in threads.filterNotNull()) {
+                threadDetails.append("\n\n ThreadName: ${thread!!.name}: State: ${thread.state}")
+                for (stackTraceElement in thread.stackTrace) {
+                    threadDetails.append("\n\t\t$stackTraceElement")
+                }
+            }
+            return threadDetails.toString();
+        }
+}

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/ThreadHelpers.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/ThreadHelpers.kt
@@ -1,18 +1,15 @@
 package io.appium.espressoserver.lib.helpers
 
-object ThreadHelpers {
-    val threadDump: String
-        get(){
-            val threadDetails = StringBuilder()
-            val activeCount = Thread.activeCount()
-            val threads = arrayOfNulls<Thread>(activeCount)
-            Thread.enumerate(threads)
-            for (thread in threads.filterNotNull()) {
-                threadDetails.append("\n\n ThreadName: ${thread!!.name}: State: ${thread.state}")
-                for (stackTraceElement in thread.stackTrace) {
-                    threadDetails.append("\n\t\t$stackTraceElement")
-                }
-            }
-            return threadDetails.toString();
+fun getThreadDump() : String {
+    val threadDetails = StringBuilder()
+    val activeCount = Thread.activeCount()
+    val threads = arrayOfNulls<Thread>(activeCount)
+    Thread.enumerate(threads)
+    for (thread in threads.filterNotNull()) {
+        threadDetails.append("\n\n ThreadName: ${thread.name}: State: ${thread.state}")
+        for (stackTraceElement in thread.stackTrace) {
+            threadDetails.append("\n\t\t$stackTraceElement")
         }
+    }
+    return threadDetails.toString();
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/ViewFinder.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/ViewFinder.kt
@@ -49,6 +49,7 @@ import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withTagValue
 import androidx.test.espresso.matcher.ViewMatchers.withText
+import io.appium.espressoserver.lib.handlers.exceptions.InvalidElementStateException
 import io.appium.espressoserver.lib.model.MatcherJson
 import io.appium.espressoserver.lib.viewmatcher.withView
 import io.appium.espressoserver.lib.viewmatcher.withXPath
@@ -270,7 +271,8 @@ object ViewFinder {
                     onView(allOf(isDescendantOfA(`is`(root)), withIndex(matcher, 0)))
                 return listOf(ViewGetter().getView(viewInteraction))
             } catch (e: AppNotIdleException){
-                throw AppiumException("android.support.test.espresso.AppNotIdleException: Check thread dump below: ${threadDump()}", e)
+                throw InvalidElementStateException("The application is expected to be in idle state in order for Espresso to interact with it." +
+                        " Review the threads dump below to know more on which entity is hogging the events loop ${ThreadHelpers.threadDump}", e)
             } catch (e: Exception) {
                 if (e is EspressoException) {
                     return emptyList()
@@ -293,7 +295,8 @@ object ViewFinder {
                 val view = ViewGetter().getView(viewInteraction)
                 viewInteractions.add(view)
             } catch (e: AppNotIdleException){
-                throw AppiumException("android.support.test.espresso.AppNotIdleException: Check thread dump below: ${threadDump()}", e)
+                throw InvalidElementStateException("The application is expected to be in idle state in order for Espresso to interact with it." +
+                        " Review the threads dump below to know more on which entity is hogging the events loop ${ThreadHelpers.threadDump}", e)
             } catch (e: Exception) {
                 if (e is EspressoException) {
                     return viewInteractions
@@ -303,20 +306,6 @@ object ViewFinder {
 
         } while (i < Integer.MAX_VALUE)
         return viewInteractions
-    }
-
-    private fun threadDump(): String {
-        val threadDetils = StringBuilder()
-        val activeCount = Thread.activeCount()
-        val threads = arrayOfNulls<Thread>(activeCount)
-        Thread.enumerate(threads)
-        for (thread in threads) {
-            threadDetils.append("\n\n ThreadName: ${thread!!.name}: State: ${thread.state}")
-            for (stackTraceElement in thread.stackTrace) {
-                threadDetils.append("\n\t\t$stackTraceElement")
-            }
-        }
-        return threadDetils.toString();
     }
 
     private fun withIndex(matcher: Matcher<View>, index: Int): Matcher<View> {

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/ViewFinder.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/ViewFinder.kt
@@ -40,6 +40,7 @@ import io.appium.espressoserver.lib.viewaction.ViewGetter
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import androidx.test.espresso.Espresso.onData
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.NoMatchingViewException
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
@@ -269,7 +270,7 @@ object ViewFinder {
                     onView(allOf(isDescendantOfA(`is`(root)), withIndex(matcher, 0)))
                 return listOf(ViewGetter().getView(viewInteraction))
             } catch (e: Exception) {
-                if (e is EspressoException) {
+                if (e is NoMatchingViewException) {
                     return emptyList()
                 }
                 throw e
@@ -290,7 +291,7 @@ object ViewFinder {
                 val view = ViewGetter().getView(viewInteraction)
                 viewInteractions.add(view)
             } catch (e: Exception) {
-                if (e is EspressoException) {
+                if (e is NoMatchingViewException) {
                     return viewInteractions
                 }
                 throw e

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/ViewFinder.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/ViewFinder.kt
@@ -65,6 +65,8 @@ import org.hamcrest.Matchers.instanceOf
  */
 object ViewFinder {
     private const val ID_PATTERN = "[\\S]+:id/[\\S]+"
+    private const val APP_NOT_IDLE_MESSAGE = "The application is expected to be in idle state in order for Espresso to interact with it. " +
+            "Review the threads dump below to know more on which entity is hogging the events loop "
 
     @Throws(AppiumException::class)
     fun findBy(strategy: Strategy, selector: String): View? {
@@ -271,8 +273,7 @@ object ViewFinder {
                     onView(allOf(isDescendantOfA(`is`(root)), withIndex(matcher, 0)))
                 return listOf(ViewGetter().getView(viewInteraction))
             } catch (e: AppNotIdleException){
-                throw InvalidElementStateException("The application is expected to be in idle state in order for Espresso to interact with it." +
-                        " Review the threads dump below to know more on which entity is hogging the events loop ${ThreadHelpers.threadDump}", e)
+                throw InvalidElementStateException(APP_NOT_IDLE_MESSAGE + getThreadDump(), e)
             } catch (e: Exception) {
                 if (e is EspressoException) {
                     return emptyList()
@@ -295,8 +296,7 @@ object ViewFinder {
                 val view = ViewGetter().getView(viewInteraction)
                 viewInteractions.add(view)
             } catch (e: AppNotIdleException){
-                throw InvalidElementStateException("The application is expected to be in idle state in order for Espresso to interact with it." +
-                        " Review the threads dump below to know more on which entity is hogging the events loop ${ThreadHelpers.threadDump}", e)
+                throw InvalidElementStateException(APP_NOT_IDLE_MESSAGE + getThreadDump(), e)
             } catch (e: Exception) {
                 if (e is EspressoException) {
                     return viewInteractions


### PR DESCRIPTION
Sometimes, the find_elements take 60 seconds and returns empty results. 

This is because app is not idle and we swallow this exception and wait for 60 seconds of a timeout to finish

We must not swallow this AppNotIdleException