### PR TITLE
feat: Throw InvalidContextError if instrumentation process crashes unexpectedly

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -434,6 +434,14 @@ class EspressoDriver extends BaseDriver {
     }
   }
 
+  async executeCommand (cmd, ...args) {
+    if (cmd !== 'deleteSession' && this.espresso?.didInstrumentationCrash) {
+      throw new errors.InvalidContextError(
+        'The instrumentation process has unexpectedly crashed. Check the logcat output for more details.');
+    }
+    return await super.executeCommand(cmd, ...args);
+  }
+
   async deleteSession () {
     logger.debug('Deleting espresso session');
     await this.mobileStopScreenStreaming();

--- a/lib/espresso-runner.js
+++ b/lib/espresso-runner.js
@@ -50,6 +50,7 @@ class EspressoRunner {
 
     this.serverLaunchTimeout = opts.serverLaunchTimeout || ESPRESSO_SERVER_LAUNCH_TIMEOUT;
     this.androidInstallTimeout = opts.androidInstallTimeout;
+    this.didInstrumentationCrash = false;
 
     this.disableSuppressAccessibilityService = opts.disableSuppressAccessibilityService;
 
@@ -238,6 +239,8 @@ class EspressoRunner {
       // A 'SocketException' indicates that we couldn't connect to the Espresso Server, because the INTERNET permission is not set
       if (line.toLowerCase().includes('java.net.socketexception')) {
         hasSocketError = true;
+      } else if (line.includes('Process crashed')) {
+        this.didInstrumentationCrash = true;
       }
     });
 


### PR DESCRIPTION
https://github.com/appium/appium-espresso-driver/issues/590