### PR TITLE
fix: Exclude transitive dependencies of espresso-contrib

### DIFF
--- a/espresso-server/app/build.gradle
+++ b/espresso-server/app/build.gradle
@@ -89,8 +89,10 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 
     androidTestImplementation "androidx.annotation:annotation:$annotation_version"
-    androidTestImplementation "androidx.test.espresso:espresso-contrib:$espresso_version"
-    androidTestImplementation "androidx.test.espresso:espresso-core:$espresso_version"
+    androidTestImplementation("androidx.test.espresso:espresso-contrib:$espresso_version") {
+        transitive = false
+    }
+    androidTestImplementation "com.google.android.material:material:1.2.0"
     androidTestImplementation "androidx.test.espresso:espresso-web:$espresso_version"
     androidTestImplementation "androidx.test.uiautomator:uiautomator:$uia_version"
     androidTestImplementation "androidx.test:core:$testlib_version"

--- a/espresso-server/app/build.gradle
+++ b/espresso-server/app/build.gradle
@@ -90,6 +90,8 @@ dependencies {
 
     androidTestImplementation "androidx.annotation:annotation:$annotation_version"
     androidTestImplementation("androidx.test.espresso:espresso-contrib:$espresso_version") {
+        // Exclude transitive dependencies to limit conflicts with AndroidX libraries from AUT.
+        // Link to PR with fix and discussion https://github.com/appium/appium-espresso-driver/pull/596
         transitive = false
     }
     androidTestImplementation "com.google.android.material:material:1.2.0"


### PR DESCRIPTION
This PR takes forward work started by @tinder-ktarasov in his PR #497, hoping that this will fix issues in #449.

Initial submission had some failing tests (but logs are no longer accessible). 

In a short setting "transitive = false" stops gradle from loading espresso-contrib's dependendencies. However, adding it fails one of the tests with some "Navigation" class missing. After adding "com.google.android.material:material:1.2.0" this test no longer failed.

Note that android.material package is in espresson-contrib dependencies, so in fact we're removing all but one of dependent packages from build.

I'm not sure if that's the right "gradle" solution. I'm open for a discussion.