### PR TITLE
refactor: Improve the server startup logic

### DIFF
--- a/lib/espresso-runner.js
+++ b/lib/espresso-runner.js
@@ -1,9 +1,9 @@
 import { JWProxy } from 'appium-base-driver';
-import { retryInterval } from 'asyncbox';
+import { waitForCondition } from 'asyncbox';
 import logger from './logger';
 import { ServerBuilder, buildServerSigningConfig } from './server-builder';
 import path from 'path';
-import { fs, util, mkdirp } from 'appium-support';
+import { fs, util, mkdirp, timing } from 'appium-support';
 import { version } from '../../package.json'; // eslint-disable-line import/no-unresolved
 import B from 'bluebird';
 import _ from 'lodash';
@@ -22,7 +22,7 @@ const REQUIRED_PARAMS = [
   'appPackage',
   'forceEspressoRebuild',
 ];
-const ESPRESSO_SERVER_LAUNCH_TIMEOUT = 30000;
+const ESPRESSO_SERVER_LAUNCH_TIMEOUT_MS = 45000;
 const TARGET_PACKAGE_CONTAINER = '/data/local/tmp/espresso.apppackage';
 
 class EspressoRunner {
@@ -48,7 +48,7 @@ class EspressoRunner {
     this.showGradleLog = opts.showGradleLog;
     this.espressoBuildConfig = opts.espressoBuildConfig;
 
-    this.serverLaunchTimeout = opts.serverLaunchTimeout || ESPRESSO_SERVER_LAUNCH_TIMEOUT;
+    this.serverLaunchTimeout = opts.serverLaunchTimeout || ESPRESSO_SERVER_LAUNCH_TIMEOUT_MS;
     this.androidInstallTimeout = opts.androidInstallTimeout;
     this.didInstrumentationCrash = false;
 
@@ -220,14 +220,17 @@ class EspressoRunner {
     logger.info(`Starting Espresso Server v${version} with cmd: adb ${cmd.join(' ')}`);
 
     let hasSocketError = false;
+    let didInstrumentationQuit = false;
 
     // start the instrumentation process
     this.instProcess = this.adb.createSubProcess(cmd);
     this.instProcess.on('exit', (code, signal) => {
       logger.info(`Instrumentation process exited with code ${code} from signal ${signal}`);
+      didInstrumentationQuit = true;
     });
     this.instProcess.on('die', (code, signal) => {
       logger.error(`Instrumentation process died with code ${code} and signal ${signal}`);
+      didInstrumentationQuit = true;
     });
     this.instProcess.on('stream-line', (line) => {
       if (_.isEmpty(line.trim())) {
@@ -244,35 +247,41 @@ class EspressoRunner {
       }
     });
 
-    await this.instProcess.start((stdout, stderr) => {
-      // for any call to the start detector, one of stdout or stderr will have
-      // content, so merge for checks here
-      const out = stdout.trim() || stderr.trim();
-
-      // adb always prints this out on success. If this is found not to be the
-      // case, add other conditions
-      if (out.includes('io.appium.espressoserver.EspressoServerRunnerTest:')) {
-        return true;
-      }
-      if (out.toLowerCase().includes('exception')) {
-        throw new Error(out);
-      }
-    }, this.serverLaunchTimeout);
-
-    logger.info('Waiting for Espresso to be online...');
-
-    // wait 20s for espresso to be online
+    const timer = new timing.Timer().start();
+    await this.instProcess.start(0);
+    logger.info(`Waiting up to ${this.serverLaunchTimeout}ms for Espresso server to be online`);
     try {
-      await retryInterval(20, 1000, async () => {
-        await this.jwproxy.command('/status', 'GET');
+      await waitForCondition(async () => {
+        if (hasSocketError) {
+          logger.errorAndThrow(`Espresso server has failed to start due to Socket exception. ` +
+            `Make sure the 'INTERNET' permission is requested in the Android manifest of your ` +
+            `application under test (<uses-permission android:name="android.permission.INTERNET" />)`);
+        } else if (didInstrumentationQuit) {
+          logger.errorAndThrow(`Espresso server process has been unexpectedly terminated.` +
+            `Check the Appium server log and the logcat output for more details`);
+        }
+        try {
+          await this.jwproxy.command('/status', 'GET');
+          return true;
+        } catch (e) {
+          logger.debug(e.message);
+          return false;
+        }
+      }, {
+        waitMs: this.serverLaunchTimeout,
+        intervalMs: 500,
       });
     } catch (e) {
-      if (hasSocketError) {
-        logger.errorAndThrow(`Timed out waiting for Espresso Server to start due to Socket exception. Espresso Server requires the 'INTERNET' permission to be set in the Android manifest for the app-under-test (<uses-permission android:name="android.permission.INTERNET" />)`);
-      } else {
-        logger.errorAndThrow(`Timed out waiting for Espresso Server to start. Original error: ${e.message}`);
+      if (/Condition unmet/.test(e.message)) {
+        logger.errorAndThrow(`Timed out waiting for Espresso server to be ` +
+          `online within ${this.serverLaunchTimeout}ms.The timeout value could be ` +
+          `customized using 'espressoServerLaunchTimeout' capability`);
       }
+      throw e;
     }
+    logger.info(`Espresso server is online. ` +
+      `The initialization process took ${timer.getDuration().asMilliSeconds.toFixed(0)}ms`);
+    logger.info('Starting the session');
 
     await this.jwproxy.command('/session', 'POST', {
       capabilities: {

--- a/lib/espresso-runner.js
+++ b/lib/espresso-runner.js
@@ -274,7 +274,7 @@ class EspressoRunner {
     } catch (e) {
       if (/Condition unmet/.test(e.message)) {
         logger.errorAndThrow(`Timed out waiting for Espresso server to be ` +
-          `online within ${this.serverLaunchTimeout}ms.The timeout value could be ` +
+          `online within ${this.serverLaunchTimeout}ms. The timeout value could be ` +
           `customized using 'espressoServerLaunchTimeout' capability`);
       }
       throw e;

--- a/lib/espresso-runner.js
+++ b/lib/espresso-runner.js
@@ -264,7 +264,6 @@ class EspressoRunner {
           await this.jwproxy.command('/status', 'GET');
           return true;
         } catch (e) {
-          logger.debug(e.message);
           return false;
         }
       }, {

--- a/lib/espresso-runner.js
+++ b/lib/espresso-runner.js
@@ -253,11 +253,11 @@ class EspressoRunner {
     try {
       await waitForCondition(async () => {
         if (hasSocketError) {
-          logger.errorAndThrow(`Espresso server has failed to start due to Socket exception. ` +
+          logger.errorAndThrow(`Espresso server has failed to start due to an unexpected exception. ` +
             `Make sure the 'INTERNET' permission is requested in the Android manifest of your ` +
             `application under test (<uses-permission android:name="android.permission.INTERNET" />)`);
         } else if (didInstrumentationQuit) {
-          logger.errorAndThrow(`Espresso server process has been unexpectedly terminated.` +
+          logger.errorAndThrow(`Espresso server process has been unexpectedly terminated. ` +
             `Check the Appium server log and the logcat output for more details`);
         }
         try {

--- a/test/functional/driver-e2e-specs.js
+++ b/test/functional/driver-e2e-specs.js
@@ -79,13 +79,13 @@ describe('EspressoDriver', function () {
       it('should reject opening of appPackage with incorrect signature', async function () {
         await driver.init(Object.assign({
           appPackage: 'com.android.settings',
-        }, APIDEMO_CAPS)).should.eventually.be.rejectedWith(/does not have a signature matching/i);
+        }, APIDEMO_CAPS)).should.eventually.be.rejected;
       });
       it('should reject start session for internet permissions not set', async function () {
         // for now the activity needs to be fully qualified
         await driver.init(Object.assign({}, APIDEMO_CAPS, {
           app: path.resolve('test', 'assets', 'ContactManager.apk'),
-        })).should.eventually.be.rejectedWith(/requires the 'INTERNET' permission/i);
+        })).should.eventually.be.rejectedWith(/INTERNET/);
       });
     });
   });

--- a/test/functional/helpers/session.js
+++ b/test/functional/helpers/session.js
@@ -2,7 +2,7 @@ import wd from 'wd';
 import { startServer } from '../../..';
 
 
-const HOST = '0.0.0.0',
+const HOST = '127.0.0.1',
       PORT = 4994;
 const MOCHA_TIMEOUT = 60 * 1000 * (process.env.TRAVIS ? 10 : 4);
 


### PR DESCRIPTION
It looks like on some device the instrumentation process keeps silence, so it makes sense to detect the server startup using the fact it starts responding to `/status` requests like we do in UIA2. Also, added more visibility and perf starts to the server startup process.