### PR TITLE
[wip] fix: webatom

### DIFF
--- a/espresso-server/app/src/test/java/io/appium/espressoserver/test/handlers/WebAtomsTest.kt
+++ b/espresso-server/app/src/test/java/io/appium/espressoserver/test/handlers/WebAtomsTest.kt
@@ -1,0 +1,21 @@
+package io.appium.espressoserver.test.handlers
+
+import io.appium.espressoserver.lib.handlers.LOCATOR_ENUMS
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class WebAtomsTest {
+    @Test
+    fun shouldHasLocatorEnums() {
+        assertEquals(LOCATOR_ENUMS, listOf(
+            "CLASS_NAME",
+            "CSS_SELECTOR",
+            "ID",
+            "LINK_TEXT",
+            "NAME",
+            "PARTIAL_LINK_TEXT",
+            "TAG_NAME",
+            "XPATH"
+        ))
+    }
+}


### PR DESCRIPTION
This is still wip.(This code works only some cases. The return error also haven't tweaked.)

https://github.com/appium/appium-espresso-driver/issues/599 failed by `kclass.functions`.
The same code worked without issues on our CI like this and ruby_lib_core repo.

So, would like to ensure vanilla Java reflection might avoid the error first.