### PR TITLE
refactor: Allow target SDK 29

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/ListIdlingResources.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/ListIdlingResources.kt
@@ -23,7 +23,7 @@ class ListIdlingResources : RequestHandler<AppiumParams, List<String>> {
 
     override fun handleInternal(params: AppiumParams): List<String> {
         return IdlingRegistry.getInstance().resources.map {
-            it::class.java.canonicalName
+            it::class.java.canonicalName!!
         }
     }
 

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/ClipboardHelper.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/ClipboardHelper.kt
@@ -46,6 +46,6 @@ class ClipboardHelper(private val context: Context) {
             data.substring(0, DEFAULT_LABEL_LEN)
         else
             data
-        cm.primaryClip = ClipData.newPlainText(labelToSet, data)
+        cm.setPrimaryClip(ClipData.newPlainText(labelToSet, data))
     }
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/LocaleHelpers.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/LocaleHelpers.kt
@@ -35,7 +35,7 @@ fun changeLocale(context: Context, locale: Locale) {
     if (SDK_INT >= Build.VERSION_CODES.N) {
         val localeList = LocaleList(locale)
         LocaleList.setDefault(localeList)
-        config.locales = localeList
+        config.setLocales(localeList)
         context.createConfigurationContext(config)
     } else {
         config.setLocale(locale)


### PR DESCRIPTION
In order to test our application, we need to build the espresso test app with Target SDK version 29.

To do so, I've addressed several minor changes.