### PR TITLE
Fix looking up for methods in parent classes

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/InvocationOperation.java
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/InvocationOperation.java
@@ -68,7 +68,7 @@ public class InvocationOperation {
 
     private Method findCompatibleMethod(Object target) throws AppiumException {
         try {
-            Method result = target.getClass().getDeclaredMethod(methodName, argumentTypes);
+            Method result = target.getClass().getMethod(methodName, argumentTypes);
             result.setAccessible(true);
             return result;
         } catch (NoSuchMethodException e) {


### PR DESCRIPTION
Some Backdoors got broken recently because getDeclaredMethod finds only methods of current class. changing back to getMethod to fix the issue