### PR TITLE
feat: Add mobile endpoint to retrieve UIAutomator page source dump

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/UiautomatorPageSource.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/UiautomatorPageSource.kt
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.espressoserver.lib.handlers
+
+import io.appium.espressoserver.lib.handlers.exceptions.AppiumException
+import io.appium.espressoserver.lib.helpers.InteractionHelper
+import io.appium.espressoserver.lib.model.AppiumParams
+import java.io.File
+
+class UiautomatorPageSource : RequestHandler<AppiumParams, String> {
+
+    @Throws(AppiumException::class)
+    override fun handleInternal(params: AppiumParams): String {
+        var dumpXml = ""
+        var dumpView: File? = null
+
+        try {
+            val uiDevice = InteractionHelper.getUiDevice()
+            dumpView = File.createTempFile("window_dump", "uix")
+            uiDevice.dumpWindowHierarchy(dumpView)
+            dumpXml = dumpView.inputStream().readBytes().toString(Charsets.UTF_8)
+            dumpView.delete()
+        } catch (e: Exception) {
+            throw AppiumException("Could not get page source with UiAutomator", e)
+        } finally {
+            dumpView?.delete()
+        }
+        return dumpXml
+    }
+}

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/UiautomatorPageSource.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/UiautomatorPageSource.kt
@@ -19,26 +19,20 @@ package io.appium.espressoserver.lib.handlers
 import io.appium.espressoserver.lib.handlers.exceptions.AppiumException
 import io.appium.espressoserver.lib.helpers.InteractionHelper
 import io.appium.espressoserver.lib.model.AppiumParams
-import java.io.File
+import java.io.ByteArrayOutputStream
+import java.io.IOException
 
 class UiautomatorPageSource : RequestHandler<AppiumParams, String> {
 
     @Throws(AppiumException::class)
     override fun handleInternal(params: AppiumParams): String {
-        var dumpXml = ""
-        var dumpView: File? = null
-
         try {
-            val uiDevice = InteractionHelper.getUiDevice()
-            dumpView = File.createTempFile("window_dump", "uix")
-            uiDevice.dumpWindowHierarchy(dumpView)
-            dumpXml = dumpView.inputStream().readBytes().toString(Charsets.UTF_8)
-            dumpView.delete()
-        } catch (e: Exception) {
+
+            val stream = ByteArrayOutputStream()
+            InteractionHelper.getUiDevice().dumpWindowHierarchy(stream)
+            return String(stream.toByteArray())
+        } catch (e: IOException) {
             throw AppiumException("Could not get page source with UiAutomator", e)
-        } finally {
-            dumpView?.delete()
         }
-        return dumpXml
     }
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/UiautomatorPageSource.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/UiautomatorPageSource.kt
@@ -25,14 +25,11 @@ import java.io.IOException
 class UiautomatorPageSource : RequestHandler<AppiumParams, String> {
 
     @Throws(AppiumException::class)
-    override fun handleInternal(params: AppiumParams): String {
-        try {
-
-            val stream = ByteArrayOutputStream()
-            InteractionHelper.getUiDevice().dumpWindowHierarchy(stream)
-            return String(stream.toByteArray())
-        } catch (e: IOException) {
-            throw AppiumException("Could not get page source with UiAutomator", e)
-        }
+    override fun handleInternal(params: AppiumParams): String = try {
+        val stream = ByteArrayOutputStream()
+        InteractionHelper.getUiDevice().dumpWindowHierarchy(stream)
+        String(stream.toByteArray())
+    } catch (e: IOException) {
+        throw AppiumException("Could not get page source with UiAutomator", e)
     }
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.kt
@@ -130,6 +130,7 @@ internal class Router {
         routeMap.addRoute(RouteDefinition(Method.POST, "/session/:sessionId/appium/execute_mobile/backdoor", MobileBackdoor(), MobileBackdoorParams::class.java))
         routeMap.addRoute(RouteDefinition(Method.POST, "/session/:sessionId/appium/execute_mobile/:elementId/flash", MobileViewFlash(), ViewFlashParams::class.java))
         routeMap.addRoute(RouteDefinition(Method.POST, "/session/:sessionId/appium/execute_mobile/uiautomator", Uiautomator(), UiautomatorParams::class.java))
+        routeMap.addRoute(RouteDefinition(Method.POST, "/session/:sessionId/appium/execute_mobile/uiautomator_page_source", UiautomatorPageSource(), AppiumParams::class.java))
         routeMap.addRoute(RouteDefinition(Method.POST, "/session/:sessionId/appium/execute_mobile/:elementId/click_action", MobileClickAction(), MobileClickActionParams::class.java))
         routeMap.addRoute(RouteDefinition(Method.POST, "/session/:sessionId/appium/execute_mobile/web_atoms", WebAtoms(), WebAtomsParams::class.java))
         routeMap.addRoute(RouteDefinition(Method.POST, "/session/:sessionId/appium/execute_mobile/:elementId/dismiss_autofill", PerformAutofillDismissal(), AppiumParams::class.java))

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Router.kt
@@ -130,7 +130,7 @@ internal class Router {
         routeMap.addRoute(RouteDefinition(Method.POST, "/session/:sessionId/appium/execute_mobile/backdoor", MobileBackdoor(), MobileBackdoorParams::class.java))
         routeMap.addRoute(RouteDefinition(Method.POST, "/session/:sessionId/appium/execute_mobile/:elementId/flash", MobileViewFlash(), ViewFlashParams::class.java))
         routeMap.addRoute(RouteDefinition(Method.POST, "/session/:sessionId/appium/execute_mobile/uiautomator", Uiautomator(), UiautomatorParams::class.java))
-        routeMap.addRoute(RouteDefinition(Method.POST, "/session/:sessionId/appium/execute_mobile/uiautomator_page_source", UiautomatorPageSource(), AppiumParams::class.java))
+        routeMap.addRoute(RouteDefinition(Method.GET, "/session/:sessionId/appium/execute_mobile/uiautomator_page_source", UiautomatorPageSource(), AppiumParams::class.java))
         routeMap.addRoute(RouteDefinition(Method.POST, "/session/:sessionId/appium/execute_mobile/:elementId/click_action", MobileClickAction(), MobileClickActionParams::class.java))
         routeMap.addRoute(RouteDefinition(Method.POST, "/session/:sessionId/appium/execute_mobile/web_atoms", WebAtoms(), WebAtomsParams::class.java))
         routeMap.addRoute(RouteDefinition(Method.POST, "/session/:sessionId/appium/execute_mobile/:elementId/dismiss_autofill", PerformAutofillDismissal(), AppiumParams::class.java))

--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -43,7 +43,7 @@ extensions.executeMobile = async function executeMobile (mobileCommand, opts = {
 
     uiautomator: 'mobileUiautomator',
 
-    uiautomatorPageSource: 'mobileUiAutomatorPageSource',
+    uiautomatorPageSource: 'mobileUiautomatorPageSource',
 
     clickAction: 'mobileClickAction',
 

--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -43,6 +43,8 @@ extensions.executeMobile = async function executeMobile (mobileCommand, opts = {
 
     uiautomator: 'mobileUiautomator',
 
+    uiautomatorPageSource: 'mobileUiAutomatorPageSource',
+
     clickAction: 'mobileClickAction',
 
     webAtoms: 'mobileWebAtoms',

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -245,6 +245,14 @@ commands.mobileUiautomator = async function mobileUiautomator (opts = {}) {
 };
 
 /**
+ *  Execute UiAutomator2 command to return the UI dump when AUT is in background.
+ *
+ */
+commands.mobileUiAPageSource = async function mobileUiAPageSource () {
+  return await this.espresso.jwproxy.command(`/appium/execute_mobile/uiautomator_page_source`, 'GET');
+};
+
+/**
  *  Flash the element with given id.
  *  durationMillis and repeatCount are optional
  *

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -246,9 +246,10 @@ commands.mobileUiautomator = async function mobileUiautomator (opts = {}) {
 
 /**
  *  Execute UiAutomator2 command to return the UI dump when AUT is in background.
- *
+ * @throws  {Error} if uiautomator view dump is unsuccessful
+ * @returns {string} uiautomator DOM xml as string
  */
-commands.mobileUiAutomatorPageSource = async function mobileUiAutomatorPageSource () {
+commands.mobileUiautomatorPageSource = async function mobileUiautomatorPageSource () {
   return await this.espresso.jwproxy.command(`/appium/execute_mobile/uiautomator_page_source`, 'GET');
 };
 

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -248,7 +248,7 @@ commands.mobileUiautomator = async function mobileUiautomator (opts = {}) {
  *  Execute UiAutomator2 command to return the UI dump when AUT is in background.
  *
  */
-commands.mobileUiAPageSource = async function mobileUiAPageSource () {
+commands.mobileUiAutomatorPageSource = async function mobileUiAutomatorPageSource () {
   return await this.espresso.jwproxy.command(`/appium/execute_mobile/uiautomator_page_source`, 'GET');
 };
 


### PR DESCRIPTION
Problem: `driver.page_source` doesn't return page source when AUT is not in focus.

We had an issue while working on an application flow where the test navigates outside of the AUT's context. The test performs a photo upload operation as part of the test flow. When the active app is not AUT we use `driver.execute_script('mobile:uiautomator',*args)` to perform the UI interactions. 

When a test fails our framework attaches the screenshot and page source of the active screen. But when the active app is not AUT, espresso driver can't return the page source with `driver.page_source`. To overcome this we can dump the UI dom with UIDevice.

Problem with the current implementation:
1. UI dump returned by this PR's change is not ready to be consumed by the Appium Inspector.
2. I'm unsure whether this is the most suitable approach. 

I don't expect this PR change's to be merged, this is just what works for me now. Perhaps @mykola-mokhnach or @KazuCocoa can suggest a more refined solution for this.
