### PR TITLE
refactor: Move Espresso server state check into the corresponding proxy

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -440,14 +440,6 @@ class EspressoDriver extends BaseDriver {
     }
   }
 
-  async executeCommand (cmd, ...args) {
-    if (cmd !== 'deleteSession' && this.espresso?.didInstrumentationCrash) {
-      throw new errors.InvalidContextError(
-        'The instrumentation process has unexpectedly crashed. Check the logcat output for more details.');
-    }
-    return await super.executeCommand(cmd, ...args);
-  }
-
   async deleteSession () {
     logger.debug('Deleting espresso session');
     await this.mobileStopScreenStreaming();

--- a/lib/espresso-runner.js
+++ b/lib/espresso-runner.js
@@ -242,25 +242,22 @@ class EspressoRunner {
     logger.info(`Starting Espresso Server v${version} with cmd: adb ${cmd.join(' ')}`);
 
     let hasSocketError = false;
-
     // start the instrumentation process
     this.instProcess = this.adb.createSubProcess(cmd);
     this.instProcess.on('exit', (code, signal) => {
-      if (code === 0) {
-        logger.info(`Instrumentation process exited with code ${code}`);
-      } else {
-        logger.warn(`Instrumentation process exited with code ${code} from signal ${signal}`);
-      }
+      logger.info(`Instrumentation process exited with code ${code} from signal ${signal}`);
       this.jwproxy.instrumentationState.exited = true;
     });
-    this.instProcess.on('stream-line', (line) => {
+    this.instProcess.on('output', (stdout, stderr) => {
+      const line = stdout || stderr;
       if (_.isEmpty(line.trim())) {
         // Do not print empty lines into the system log
         return;
       }
 
       logger.debug(`[Instrumentation] ${line.trim()}`);
-      // A 'SocketException' indicates that we couldn't connect to the Espresso Server, because the INTERNET permission is not set
+      // A 'SocketException' indicates that we couldn't connect to the Espresso server,
+      // because the INTERNET permission is not set
       if (line.toLowerCase().includes('java.net.socketexception')) {
         hasSocketError = true;
       } else if (line.includes('Process crashed')) {

--- a/lib/espresso-runner.js
+++ b/lib/espresso-runner.js
@@ -1,4 +1,4 @@
-import { JWProxy } from 'appium-base-driver';
+import { JWProxy, errors } from 'appium-base-driver';
 import { waitForCondition } from 'asyncbox';
 import logger from './logger';
 import { ServerBuilder, buildServerSigningConfig } from './server-builder';
@@ -25,6 +25,18 @@ const REQUIRED_PARAMS = [
 const ESPRESSO_SERVER_LAUNCH_TIMEOUT_MS = 45000;
 const TARGET_PACKAGE_CONTAINER = '/data/local/tmp/espresso.apppackage';
 
+class EspressoProxy extends JWProxy {
+  async proxyCommand (url, method, body = null) {
+    const {crashed, exited} = this.instrumentationState;
+    if (exited) {
+      throw new errors.InvalidContextError(`'${method} ${url}' cannot be proxied to Espresso server because ` +
+        `the instrumentation process has ${crashed ? 'crashed' : 'been unexpectedly terminated'}. ` +
+        `Check the Appium server log and the logcat output for more details`);
+    }
+    return await super.proxyCommand(url, method, body);
+  }
+}
+
 class EspressoRunner {
   constructor (opts = {}) {
     for (let req of REQUIRED_PARAMS) {
@@ -33,13 +45,17 @@ class EspressoRunner {
       }
       this[req] = opts[req];
     }
-    this.jwproxy = new JWProxy({
+    this.jwproxy = new EspressoProxy({
       server: this.host,
       port: this.systemPort,
       base: '',
       keepAlive: true,
     });
     this.proxyReqRes = this.jwproxy.proxyReqRes.bind(this.jwproxy);
+    this.jwproxy.instrumentationState = {
+      exited: false,
+      crashed: false,
+    };
 
     const modServerName = fs.sanitizeName(`${TEST_APK_PKG}_${version}_${this.appPackage}_${this.adb.curDeviceId}.apk`, {
       replacement: '-',
@@ -50,7 +66,6 @@ class EspressoRunner {
 
     this.serverLaunchTimeout = opts.serverLaunchTimeout || ESPRESSO_SERVER_LAUNCH_TIMEOUT_MS;
     this.androidInstallTimeout = opts.androidInstallTimeout;
-    this.didInstrumentationCrash = false;
 
     this.disableSuppressAccessibilityService = opts.disableSuppressAccessibilityService;
 
@@ -227,17 +242,16 @@ class EspressoRunner {
     logger.info(`Starting Espresso Server v${version} with cmd: adb ${cmd.join(' ')}`);
 
     let hasSocketError = false;
-    let didInstrumentationQuit = false;
 
     // start the instrumentation process
     this.instProcess = this.adb.createSubProcess(cmd);
     this.instProcess.on('exit', (code, signal) => {
-      logger.info(`Instrumentation process exited with code ${code} from signal ${signal}`);
-      didInstrumentationQuit = true;
-    });
-    this.instProcess.on('die', (code, signal) => {
-      logger.error(`Instrumentation process died with code ${code} and signal ${signal}`);
-      didInstrumentationQuit = true;
+      if (code === 0) {
+        logger.info(`Instrumentation process exited with code ${code}`);
+      } else {
+        logger.warn(`Instrumentation process exited with code ${code} from signal ${signal}`);
+      }
+      this.jwproxy.instrumentationState.exited = true;
     });
     this.instProcess.on('stream-line', (line) => {
       if (_.isEmpty(line.trim())) {
@@ -250,7 +264,7 @@ class EspressoRunner {
       if (line.toLowerCase().includes('java.net.socketexception')) {
         hasSocketError = true;
       } else if (line.includes('Process crashed')) {
-        this.didInstrumentationCrash = true;
+        this.jwproxy.instrumentationState.crashed = true;
       }
     });
 
@@ -263,7 +277,7 @@ class EspressoRunner {
           logger.errorAndThrow(`Espresso server has failed to start due to an unexpected exception. ` +
             `Make sure the 'INTERNET' permission is requested in the Android manifest of your ` +
             `application under test (<uses-permission android:name="android.permission.INTERNET" />)`);
-        } else if (didInstrumentationQuit) {
+        } else if (this.jwproxy.instrumentationState.exited) {
           logger.errorAndThrow(`Espresso server process has been unexpectedly terminated. ` +
             `Check the Appium server log and the logcat output for more details`);
         }


### PR DESCRIPTION
It makes sense to check if the server is alive before we sending any request to it. `executeCommand` might also fail even if the proxy is pointing to a web view, which is not the behaviour we want. 