### PR TITLE
feat: Speed up xpath lookup by only including the requested attributes

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/SourceDocument.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/SourceDocument.kt
@@ -75,16 +75,16 @@ private fun toXmlNodeName(className: String?): String {
 }
 
 
-class SourceDocument @JvmOverloads constructor(
-        private val root: View?,
-        private val viewMap: SparseArray<View> = SparseArray()
+class SourceDocument constructor(
+        private val root: View? = null,
+        private val includedAttributes: Set<ViewAttributesEnum>? = null
 ) {
+    @Suppress("PrivatePropertyName")
     private val RESOURCES_GUARD = Semaphore(1)
 
+    private val viewMap: SparseArray<View> = SparseArray()
     private var serializer: XmlSerializer? = null
     private var tmpXmlName: String? = null
-
-    constructor() : this(null)
 
     @Throws(IOException::class)
     private fun setAttribute(attrName: ViewAttributesEnum, attrValue: Any?) {
@@ -130,34 +130,75 @@ class SourceDocument @JvmOverloads constructor(
         }
 
         val viewElement = ViewElement(view)
-        val tagName = toXmlNodeName(viewElement.className)
+        val className = viewElement.className
+        val tagName = toXmlNodeName(className)
         serializer?.startTag(NAMESPACE, tagName)
 
         // Set attributes
-        setAttribute(ViewAttributesEnum.INDEX, viewElement.index)
-        setAttribute(ViewAttributesEnum.PACKAGE, viewElement.packageName)
-        setAttribute(ViewAttributesEnum.CLASS, viewElement.className)
-        setAttribute(ViewAttributesEnum.CONTENT_DESC, viewElement.contentDescription)
-        setAttribute(ViewAttributesEnum.CHECKABLE, viewElement.isCheckable)
-        setAttribute(ViewAttributesEnum.CHECKED, viewElement.isChecked)
-        setAttribute(ViewAttributesEnum.CLICKABLE, viewElement.isClickable)
-        setAttribute(ViewAttributesEnum.ENABLED, viewElement.isEnabled)
-        setAttribute(ViewAttributesEnum.FOCUSABLE, viewElement.isFocusable)
-        setAttribute(ViewAttributesEnum.FOCUSED, viewElement.isFocused)
-        setAttribute(ViewAttributesEnum.SCROLLABLE, viewElement.isScrollable)
-        setAttribute(ViewAttributesEnum.LONG_CLICKABLE, viewElement.isLongClickable)
-        setAttribute(ViewAttributesEnum.PASSWORD, viewElement.isPassword)
-        setAttribute(ViewAttributesEnum.SELECTED, viewElement.isSelected)
-        setAttribute(ViewAttributesEnum.VISIBLE, viewElement.isVisible)
-        setAttribute(ViewAttributesEnum.BOUNDS, viewElement.bounds.toShortString())
-        val viewText = viewElement.text
-        viewText?.let {
-            setAttribute(ViewAttributesEnum.TEXT, it.rawText)
-            setAttribute(ViewAttributesEnum.HINT, it.isHint)
+        if (null == includedAttributes || includedAttributes.contains(ViewAttributesEnum.INDEX)) {
+            setAttribute(ViewAttributesEnum.INDEX, viewElement.index)
         }
-        setAttribute(ViewAttributesEnum.RESOURCE_ID, viewElement.resourceId)
-        setAttribute(ViewAttributesEnum.VIEW_TAG, viewElement.viewTag)
-        if (view is AdapterView<*>) {
+        if (null == includedAttributes || includedAttributes.contains(ViewAttributesEnum.PACKAGE)) {
+            setAttribute(ViewAttributesEnum.PACKAGE, viewElement.packageName)
+        }
+        // class name is always included
+        setAttribute(ViewAttributesEnum.CLASS, className)
+        if (null == includedAttributes || includedAttributes.contains(ViewAttributesEnum.CONTENT_DESC)) {
+            setAttribute(ViewAttributesEnum.CONTENT_DESC, viewElement.contentDescription)
+        }
+        if (null == includedAttributes || includedAttributes.contains(ViewAttributesEnum.CHECKABLE)) {
+            setAttribute(ViewAttributesEnum.CHECKABLE, viewElement.isCheckable)
+        }
+        if (null == includedAttributes || includedAttributes.contains(ViewAttributesEnum.CHECKED)) {
+            setAttribute(ViewAttributesEnum.CHECKED, viewElement.isChecked)
+        }
+        if (null == includedAttributes || includedAttributes.contains(ViewAttributesEnum.CLICKABLE)) {
+            setAttribute(ViewAttributesEnum.CLICKABLE, viewElement.isClickable)
+        }
+        if (null == includedAttributes || includedAttributes.contains(ViewAttributesEnum.ENABLED)) {
+            setAttribute(ViewAttributesEnum.ENABLED, viewElement.isEnabled)
+        }
+        if (null == includedAttributes || includedAttributes.contains(ViewAttributesEnum.FOCUSABLE)) {
+            setAttribute(ViewAttributesEnum.FOCUSABLE, viewElement.isFocusable)
+        }
+        if (null == includedAttributes || includedAttributes.contains(ViewAttributesEnum.FOCUSED)) {
+            setAttribute(ViewAttributesEnum.FOCUSED, viewElement.isFocused)
+        }
+        if (null == includedAttributes || includedAttributes.contains(ViewAttributesEnum.SCROLLABLE)) {
+            setAttribute(ViewAttributesEnum.SCROLLABLE, viewElement.isScrollable)
+        }
+        if (null == includedAttributes || includedAttributes.contains(ViewAttributesEnum.LONG_CLICKABLE)) {
+            setAttribute(ViewAttributesEnum.LONG_CLICKABLE, viewElement.isLongClickable)
+        }
+        if (null == includedAttributes || includedAttributes.contains(ViewAttributesEnum.PASSWORD)) {
+            setAttribute(ViewAttributesEnum.PASSWORD, viewElement.isPassword)
+        }
+        if (null == includedAttributes || includedAttributes.contains(ViewAttributesEnum.SELECTED)) {
+            setAttribute(ViewAttributesEnum.SELECTED, viewElement.isSelected)
+        }
+        if (null == includedAttributes || includedAttributes.contains(ViewAttributesEnum.VISIBLE)) {
+            setAttribute(ViewAttributesEnum.VISIBLE, viewElement.isVisible)
+        }
+        if (null == includedAttributes || includedAttributes.contains(ViewAttributesEnum.VISIBLE)) {
+            setAttribute(ViewAttributesEnum.BOUNDS, viewElement.bounds.toShortString())
+        }
+        if (null == includedAttributes
+                || includedAttributes.contains(ViewAttributesEnum.TEXT)
+                || includedAttributes.contains(ViewAttributesEnum.HINT)) {
+            viewElement.text?.let {
+                setAttribute(ViewAttributesEnum.TEXT, it.rawText)
+                setAttribute(ViewAttributesEnum.HINT, it.isHint)
+            }
+        }
+        if (null == includedAttributes || includedAttributes.contains(ViewAttributesEnum.RESOURCE_ID)) {
+            setAttribute(ViewAttributesEnum.RESOURCE_ID, viewElement.resourceId)
+        }
+        if (null == includedAttributes || includedAttributes.contains(ViewAttributesEnum.VIEW_TAG)) {
+            setAttribute(ViewAttributesEnum.VIEW_TAG, viewElement.viewTag)
+        }
+        if (view is AdapterView<*> && (null == includedAttributes
+                        || includedAttributes.contains(ViewAttributesEnum.ADAPTERS)
+                        || includedAttributes.contains(ViewAttributesEnum.ADAPTER_TYPE))) {
             recordAdapterViewInfo(view)
         }
 

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/SourceDocument.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/SourceDocument.kt
@@ -116,8 +116,7 @@ class SourceDocument constructor(
         }
     }
 
-    private fun isAttributeIncluded(attr: ViewAttributesEnum): Boolean
-        = null == includedAttributes || includedAttributes.contains(attr)
+    private fun isAttributeIncluded(attr: ViewAttributesEnum): Boolean = null == includedAttributes || includedAttributes.contains(attr)
 
     /**
      * Recursively visit all of the views and map them to XML elements
@@ -161,21 +160,23 @@ class SourceDocument constructor(
                 ViewAttributesEnum.ADAPTERS to null,
                 ViewAttributesEnum.ADAPTER_TYPE to null
         ).forEach {
-            if (it.key == ViewAttributesEnum.TEXT || it.key == ViewAttributesEnum.HINT) {
-                if (!isTextOrHintRecorded && isAttributeIncluded(it.key)) {
-                    viewElement.text?.let { text ->
-                        setAttribute(ViewAttributesEnum.TEXT, text.rawText)
-                        setAttribute(ViewAttributesEnum.HINT, text.isHint)
-                        isTextOrHintRecorded = true
+            when (it.key) {
+                ViewAttributesEnum.TEXT, ViewAttributesEnum.HINT ->
+                    if (!isTextOrHintRecorded && isAttributeIncluded(it.key)) {
+                        viewElement.text?.let { text ->
+                            setAttribute(ViewAttributesEnum.TEXT, text.rawText)
+                            setAttribute(ViewAttributesEnum.HINT, text.isHint)
+                            isTextOrHintRecorded = true
+                        }
                     }
+                ViewAttributesEnum.ADAPTERS, ViewAttributesEnum.ADAPTER_TYPE ->
+                    if (!isAdapterInfoRecorded && view is AdapterView<*> && isAttributeIncluded(it.key)) {
+                        recordAdapterViewInfo(view)
+                        isAdapterInfoRecorded = true
+                    }
+                else -> if (isAttributeIncluded(it.key)) {
+                    setAttribute(it.key, it.value!!())
                 }
-            } else if (it.key == ViewAttributesEnum.ADAPTERS || it.key == ViewAttributesEnum.ADAPTER_TYPE) {
-                if (!isAdapterInfoRecorded && view is AdapterView<*> && isAttributeIncluded(it.key)) {
-                    recordAdapterViewInfo(view)
-                    isAdapterInfoRecorded = true
-                }
-            } else if (isAttributeIncluded(it.key)) {
-                setAttribute(it.key, it.value!!())
             }
         }
 

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/SourceDocument.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/SourceDocument.kt
@@ -179,7 +179,7 @@ class SourceDocument constructor(
         if (null == includedAttributes || includedAttributes.contains(ViewAttributesEnum.VISIBLE)) {
             setAttribute(ViewAttributesEnum.VISIBLE, viewElement.isVisible)
         }
-        if (null == includedAttributes || includedAttributes.contains(ViewAttributesEnum.VISIBLE)) {
+        if (null == includedAttributes || includedAttributes.contains(ViewAttributesEnum.BOUNDS)) {
             setAttribute(ViewAttributesEnum.BOUNDS, viewElement.bounds.toShortString())
         }
         if (null == includedAttributes

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/SourceDocument.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/SourceDocument.kt
@@ -116,7 +116,8 @@ class SourceDocument constructor(
         }
     }
 
-    private fun isAttributeIncluded(attr: ViewAttributesEnum): Boolean = null == includedAttributes || includedAttributes.contains(attr)
+    private fun isAttributeIncluded(attr: ViewAttributesEnum): Boolean
+        = null == includedAttributes || includedAttributes.contains(attr)
 
     /**
      * Recursively visit all of the views and map them to XML elements

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/viewmatcher/WithXPath.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/viewmatcher/WithXPath.kt
@@ -17,13 +17,27 @@ package io.appium.espressoserver.lib.viewmatcher
 
 import android.view.View
 import io.appium.espressoserver.lib.model.SourceDocument
+import io.appium.espressoserver.lib.model.ViewAttributesEnum
 import org.hamcrest.Description
 import org.hamcrest.Matcher
 import org.hamcrest.TypeSafeMatcher
 
+fun fetchIncludedAttributes(xpath: String): Set<ViewAttributesEnum>? {
+    if (xpath.contains("@*")) {
+        return null
+    }
+
+    return ViewAttributesEnum.values().fold(mutableSetOf()) { acc, value ->
+        if (xpath.contains("@$value")) {
+            acc.add(value)
+        }
+        acc
+    }
+}
+
 fun withXPath(root: View?, xpath: String, index: Int? = null): Matcher<View> {
     // Get a list of the Views that match the provided xpath
-    val matchedXPathViews = SourceDocument(root).findViewsByXPath(xpath)
+    val matchedXPathViews = SourceDocument(root, fetchIncludedAttributes(xpath)).findViewsByXPath(xpath)
     return object : TypeSafeMatcher<View>() {
         override fun matchesSafely(item: View): Boolean {
             return if (index != null) {

--- a/espresso-server/app/src/test/java/io/appium/espressoserver/test/helpers/XpathQueryParserTests.kt
+++ b/espresso-server/app/src/test/java/io/appium/espressoserver/test/helpers/XpathQueryParserTests.kt
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.espressoserver.test.helpers
+
+import io.appium.espressoserver.lib.model.ViewAttributesEnum
+import io.appium.espressoserver.lib.viewmatcher.fetchIncludedAttributes
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class `Xpath Query Parser Tests` {
+
+    @Test
+    fun `should parse attributes from query`() {
+        assertEquals(fetchIncludedAttributes("//*[@text=\"yolo\" and @enabled=\"true\"]"),
+        setOf(ViewAttributesEnum.TEXT, ViewAttributesEnum.ENABLED))
+    }
+
+    @Test
+    fun `should include all attributes for a wildcard`() {
+        assertNull(fetchIncludedAttributes("//*[@*=\"yolo\"]"))
+    }
+
+    @Test
+    fun `should include no attributes if the query has none`() {
+        assertEquals(fetchIncludedAttributes("//*[@foo=\"yolo\"]"), setOf())
+    }
+}


### PR DESCRIPTION
Querying view attributes is expensive and takes time. Although xpath lookup only requires some attributes to be there and does not need them all