### PR TITLE
[wip] chore: replace jcenter with mavenCentral

### DIFF
--- a/espresso-server/build.gradle
+++ b/espresso-server/build.gradle
@@ -21,7 +21,7 @@ buildscript {
         maven {
             url "https://maven.google.com"
         }
-        jcenter()
+        mavenCentral()
         google()
     }
     dependencies {
@@ -37,7 +37,7 @@ allprojects {
     repositories {
         google()
         maven { url 'https://maven.google.com' }
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
blocking:

```
* What went wrong:
A problem occurred configuring root project 'espresso-server'.
> Could not resolve all artifacts for configuration ':classpath'.
   > Could not find org.jetbrains.trove4j:trove4j:20160824.
     Searched in the following locations:
       - https://maven.google.com/org/jetbrains/trove4j/trove4j/20160824/trove4j-20160824.pom
       - https://repo.maven.apache.org/maven2/org/jetbrains/trove4j/trove4j/20160824/trove4j-20160824.pom
       - https://dl.google.com/dl/android/maven2/org/jetbrains/trove4j/trove4j/20160824/trove4j-20160824.pom
     Required by:
         project : > com.android.tools.build:gradle:4.1.1 > com.android.tools.build:builder:4.1.1 > com.android.tools:sdk-common:27.1.1
```