### PR TITLE
chore: tweak assembleAndroidTest command

### DIFF
--- a/espresso-server/settings.gradle
+++ b/espresso-server/settings.gradle
@@ -1,1 +1,0 @@
-include ':app'

--- a/espresso-server/settings.gradle.kts
+++ b/espresso-server/settings.gradle.kts
@@ -1,0 +1,1 @@
+include(":app")

--- a/lib/server-builder.js
+++ b/lib/server-builder.js
@@ -93,7 +93,7 @@ class ServerBuilder {
     if (this.testAppPackage) {
       args.push(buildProperty('appiumTargetPackage', this.testAppPackage));
     }
-    args.push('assembleAndroidTest');
+    args.push('app:assembleAndroidTest');
 
     return {cmd, args};
   }

--- a/test/unit/server-builder-specs.js
+++ b/test/unit/server-builder-specs.js
@@ -14,12 +14,12 @@ describe('server-builder', function () {
     const expectedCmd = system.isWindows() ? 'gradlew.bat' : './gradlew';
 
     it('should not pass properties when no versions are specified', function () {
-      const expected = {cmd: expectedCmd, args: ['assembleAndroidTest']};
+      const expected = {cmd: expectedCmd, args: ['app:assembleAndroidTest']};
       new ServerBuilder().getCommand().should.eql(expected);
     });
 
     it('should pass only specified versions as properties and pass them correctly', function () {
-      const expected = {cmd: expectedCmd, args: ['-PappiumAndroidGradlePlugin=1.2.3', 'assembleAndroidTest']};
+      const expected = {cmd: expectedCmd, args: ['-PappiumAndroidGradlePlugin=1.2.3', 'app:assembleAndroidTest']};
       let serverBuilder = new ServerBuilder({
         buildConfiguration: {
           toolsVersions: {
@@ -34,7 +34,7 @@ describe('server-builder', function () {
       const unknownKey = 'unknown_key';
       VERSION_KEYS.should.not.contain(unknownKey);
 
-      const expected = {cmd: expectedCmd, args: ['assembleAndroidTest']};
+      const expected = {cmd: expectedCmd, args: ['app:assembleAndroidTest']};
       const serverBuilder = new ServerBuilder({
         buildConfiguration: {
           toolsVersions: {
@@ -46,7 +46,7 @@ describe('server-builder', function () {
     });
 
     it('should not pass gradle_version as property', function () {
-      const expected = {cmd: expectedCmd, args: ['assembleAndroidTest']};
+      const expected = {cmd: expectedCmd, args: ['app:assembleAndroidTest']};
       const serverBuilder = new ServerBuilder({
         buildConfiguration: {
           toolsVersions: {


### PR DESCRIPTION
https://github.com/appium/appium-espresso-driver/issues/664 failed because of no proper command on the Azure host.
Potentially we should add `app:`  for some environment.

Let me try this change out.

(My local env had no issue with/without `app:`)