### PR TITLE
fix: Add session identifier verification

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/CreateSession.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/CreateSession.kt
@@ -26,7 +26,7 @@ import io.appium.espressoserver.lib.model.SessionParams
 import io.appium.espressoserver.lib.model.StartActivityParams
 
 
-class CreateSession : RequestHandler<SessionParams, GlobalSession> {
+class CreateSession : RequestHandler<SessionParams, GlobalSession>, NoSessionCommandHandler {
 
     @Throws(AppiumException::class)
     override fun handleInternal(params: SessionParams): GlobalSession {

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetSessions.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetSessions.kt
@@ -20,7 +20,8 @@ import io.appium.espressoserver.lib.handlers.exceptions.AppiumException
 import io.appium.espressoserver.lib.model.AppiumParams
 import io.appium.espressoserver.lib.model.GlobalSession
 
-class GetSessions : RequestHandler<AppiumParams, Collection<Map<String, Any?>>> {
+class GetSessions :
+    RequestHandler<AppiumParams, Collection<Map<String, Any?>>>, NoSessionCommandHandler {
 
     @Throws(AppiumException::class)
     override fun handleInternal(params: AppiumParams): Collection<Map<String, Any?>> {

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetWindowSize.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetWindowSize.kt
@@ -25,7 +25,6 @@ import io.appium.espressoserver.lib.model.AppiumParams
 import io.appium.espressoserver.lib.model.WindowSize
 
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
-import io.appium.espressoserver.lib.helpers.AndroidLogger
 
 class GetWindowSize : RequestHandler<AppiumParams, WindowSize> {
 

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/NoSessionCommandHandler.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/NoSessionCommandHandler.kt
@@ -1,0 +1,4 @@
+package io.appium.espressoserver.lib.handlers
+
+interface NoSessionCommandHandler {
+}

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/NotYetImplemented.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/NotYetImplemented.kt
@@ -20,7 +20,7 @@ import io.appium.espressoserver.lib.handlers.exceptions.AppiumException
 import io.appium.espressoserver.lib.handlers.exceptions.NotYetImplementedException
 import io.appium.espressoserver.lib.model.AppiumParams
 
-class NotYetImplemented : RequestHandler<AppiumParams, Void?> {
+class NotYetImplemented : RequestHandler<AppiumParams, Void?>, NoSessionCommandHandler {
     @Throws(AppiumException::class)
     override fun handleInternal(params: AppiumParams): Void? {
         throw NotYetImplementedException()

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/RequestHandler.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/RequestHandler.kt
@@ -17,8 +17,10 @@
 package io.appium.espressoserver.lib.handlers
 
 import io.appium.espressoserver.lib.handlers.exceptions.AppiumException
+import io.appium.espressoserver.lib.handlers.exceptions.NoSuchDriverException
 import io.appium.espressoserver.lib.helpers.AndroidLogger
 import io.appium.espressoserver.lib.model.AppiumParams
+import io.appium.espressoserver.lib.model.GlobalSession
 
 interface RequestHandler<in T : AppiumParams, out R> {
     @Throws(AppiumException::class)
@@ -28,7 +30,14 @@ interface RequestHandler<in T : AppiumParams, out R> {
     @Throws(AppiumException::class)
     fun handle(params: AppiumParams): R {
         AndroidLogger.info("Executing ${this::class.simpleName} handler")
+
+        if (this !is NoSessionCommandHandler
+            && (params.sessionId == null || params.sessionId != GlobalSession.sessionId)) {
+            throw NoSuchDriverException("The requested session id ${params.sessionId} does not exist")
+        }
+
         return handleInternal(params as? T
-                ?: throw IllegalArgumentException("Invalid type ${this::class.simpleName} passed to ${this::class.simpleName} handler"))
+                ?: throw IllegalArgumentException("Invalid type ${params::class.simpleName} " +
+                        "passed to ${this::class.simpleName} handler"))
     }
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/SetClipboard.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/SetClipboard.kt
@@ -49,7 +49,7 @@ class SetClipboard : RequestHandler<SetClipboardParams, Void?> {
     }
 
     // Clip feature should run with main thread
-    private inner class SetClipboardRunnable internal constructor(
+    private inner class SetClipboardRunnable constructor(
             private val contentType: ClipboardDataType,
             private val label: String?,
             private val content: String

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/SetDate.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/SetDate.kt
@@ -31,7 +31,7 @@ class SetDate : RequestHandler<SetDateParams, Void?> {
             viewInteraction.perform(PickerActions.setDate(params.year, params.monthOfYear, params.dayOfMonth))
         } catch (e: Exception) {
             if (e is EspressoException) {
-                throw AppiumException("Could not set date on element. Reason: ${e}")
+                throw AppiumException("Could not set date on element. Reason: $e")
             }
             throw e
         }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/SetOrientation.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/SetOrientation.kt
@@ -32,7 +32,7 @@ class SetOrientation : RequestHandler<OrientationParams, Void?> {
     override fun handleInternal(params: OrientationParams): Void? {
         val orientation = params.orientation
 
-        // Validate the orientaiton
+        // Validate the orientation
         orientation ?: throw AppiumException("Screen orientation value must not be null")
 
         val supportedValues = OrientationType.values().map { it.name }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/SetTime.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/SetTime.kt
@@ -31,7 +31,7 @@ class SetTime : RequestHandler<SetTimeParams, Void?> {
             viewInteraction.perform(PickerActions.setTime(params.hours, params.minutes))
         } catch (e: Exception) {
             if (e is EspressoException) {
-                throw AppiumException("Could not set time on element. Reason: ${e}")
+                throw AppiumException("Could not set time on element. Reason: $e")
             }
             throw e
         }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/StartService.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/StartService.kt
@@ -21,9 +21,9 @@ import androidx.test.platform.app.InstrumentationRegistry
 import io.appium.espressoserver.lib.helpers.extractQualifiedClassName
 import io.appium.espressoserver.lib.model.StartServiceParams
 
-class StartService : RequestHandler<StartServiceParams, String?> {
+class StartService : RequestHandler<StartServiceParams, String> {
 
-    override fun handleInternal(params: StartServiceParams): String? {
+    override fun handleInternal(params: StartServiceParams): String {
         val targetContext = InstrumentationRegistry.getInstrumentation().targetContext
         val intent = Intent(targetContext,
                 Class.forName(extractQualifiedClassName(targetContext.packageName, params.intent)))

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/Status.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/Status.kt
@@ -18,7 +18,7 @@ package io.appium.espressoserver.lib.handlers
 
 import io.appium.espressoserver.lib.model.AppiumParams
 
-class Status : RequestHandler<AppiumParams, Void?> {
+class Status : RequestHandler<AppiumParams, Void?>, NoSessionCommandHandler {
 
     override fun handleInternal(params: AppiumParams): Void? {
         return null

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/StopService.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/StopService.kt
@@ -21,9 +21,9 @@ import androidx.test.platform.app.InstrumentationRegistry
 import io.appium.espressoserver.lib.helpers.extractQualifiedClassName
 import io.appium.espressoserver.lib.model.StopServiceParams
 
-class StopService : RequestHandler<StopServiceParams, String?> {
+class StopService : RequestHandler<StopServiceParams, String> {
 
-    override fun handleInternal(params: StopServiceParams): String? {
+    override fun handleInternal(params: StopServiceParams): String {
         val targetContext = InstrumentationRegistry.getInstrumentation().targetContext
         val intent = Intent(targetContext,
                 Class.forName(extractQualifiedClassName(targetContext.packageName, params.intent)))

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/Text.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/Text.kt
@@ -21,10 +21,10 @@ import io.appium.espressoserver.lib.model.AppiumParams
 import io.appium.espressoserver.lib.model.Element
 import io.appium.espressoserver.lib.viewaction.ViewTextGetter
 
-class Text : RequestHandler<AppiumParams, String?> {
+class Text : RequestHandler<AppiumParams, String> {
 
     @Throws(AppiumException::class)
-    override fun handleInternal(params: AppiumParams): String? {
+    override fun handleInternal(params: AppiumParams): String {
         val viewInteraction = Element.getViewInteractionById(params.elementId)
         return ViewTextGetter()[viewInteraction].rawText
     }


### PR DESCRIPTION
Currently there is no such validation, which means one could execute session command with basically any provided id