### PR TITLE
fix: Update size detection

### DIFF
--- a/ci-jobs/pr-validation.yml
+++ b/ci-jobs/pr-validation.yml
@@ -1,6 +1,8 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/android
 jobs:
   - job: gradle_junit_tests
+    variables:
+      CI: true
     steps:
       - task: Gradle@2
         inputs:

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/SizeHelpers.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/SizeHelpers.kt
@@ -25,14 +25,14 @@ import androidx.test.core.app.ApplicationProvider
 
 fun getCurrentWindowRect(): Rect {
     val context = ApplicationProvider.getApplicationContext<Context>()
-    val windowManager = (context.applicationContext.getSystemService(Context.WINDOW_SERVICE) as? WindowManager
-        ?: throw IllegalStateException("Could not retrieve Window Manager Service instance"))
-    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-        windowManager.currentWindowMetrics.bounds
-    } else {
-        val displayMetrics = DisplayMetrics()
-        @Suppress("DEPRECATION")
-        windowManager.defaultDisplay.getMetrics(displayMetrics)
-        Rect(0, 0, displayMetrics.widthPixels, displayMetrics.heightPixels)
+    val windowManager =
+        (context.applicationContext.getSystemService(Context.WINDOW_SERVICE) as? WindowManager)
+            ?: throw IllegalStateException("Could not retrieve Window Manager Service instance")
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        return windowManager.currentWindowMetrics.bounds
     }
+    val displayMetrics = DisplayMetrics()
+    @Suppress("DEPRECATION")
+    windowManager.defaultDisplay.getMetrics(displayMetrics)
+    return Rect(0, 0, displayMetrics.widthPixels, displayMetrics.heightPixels)
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/SizeHelpers.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/SizeHelpers.kt
@@ -18,13 +18,21 @@ package io.appium.espressoserver.lib.helpers
 
 import android.content.Context
 import android.graphics.Rect
-import android.view.WindowManager
+import android.hardware.display.DisplayManager
+import android.os.Build
+import android.util.DisplayMetrics
+import android.view.Display
 import androidx.test.core.app.ApplicationProvider
 
 fun getCurrentWindowRect(): Rect {
     val context = ApplicationProvider.getApplicationContext<Context>()
-    val winManager = context.applicationContext.getSystemService(Context.WINDOW_SERVICE) as? WindowManager
-        ?: throw IllegalStateException("Couldn't retrieve Window Manager Service instance: " +
-                "context.getApplicationContext().getSystemService(Context.WINDOW_SERVICE) is null")
-    return winManager.currentWindowMetrics.bounds
+    val display = (if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        context.display
+    } else {
+        (context.applicationContext.getSystemService(Context.DISPLAY_SERVICE) as? DisplayManager)
+            ?.getDisplay(Display.DEFAULT_DISPLAY)
+    }) ?: throw IllegalStateException("Could not retrieve the display instance")
+    val displayMetrics = DisplayMetrics()
+    display.getRealMetrics(displayMetrics)
+    return Rect(0, 0, displayMetrics.widthPixels, displayMetrics.heightPixels)
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/SizeHelpers.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/SizeHelpers.kt
@@ -18,21 +18,21 @@ package io.appium.espressoserver.lib.helpers
 
 import android.content.Context
 import android.graphics.Rect
-import android.hardware.display.DisplayManager
 import android.os.Build
 import android.util.DisplayMetrics
-import android.view.Display
+import android.view.WindowManager
 import androidx.test.core.app.ApplicationProvider
 
 fun getCurrentWindowRect(): Rect {
     val context = ApplicationProvider.getApplicationContext<Context>()
-    val display = (if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-        context.display
+    val windowManager = (context.applicationContext.getSystemService(Context.WINDOW_SERVICE) as? WindowManager
+        ?: throw IllegalStateException("Could not retrieve Window Manager Service instance"))
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        windowManager.currentWindowMetrics.bounds
     } else {
-        (context.applicationContext.getSystemService(Context.DISPLAY_SERVICE) as? DisplayManager)
-            ?.getDisplay(Display.DEFAULT_DISPLAY)
-    }) ?: throw IllegalStateException("Could not retrieve the display instance")
-    val displayMetrics = DisplayMetrics()
-    display.getRealMetrics(displayMetrics)
-    return Rect(0, 0, displayMetrics.widthPixels, displayMetrics.heightPixels)
+        val displayMetrics = DisplayMetrics()
+        @Suppress("DEPRECATION")
+        windowManager.defaultDisplay.getMetrics(displayMetrics)
+        Rect(0, 0, displayMetrics.widthPixels, displayMetrics.heightPixels)
+    }
 }

--- a/test/functional/webview/webatoms-e2e-specs.js
+++ b/test/functional/webview/webatoms-e2e-specs.js
@@ -24,7 +24,7 @@ describe('mobile web atoms', function () {
 
   it('should input text into textbox and click links', async function () {
     const webviewEl = await driver.elementById('wv1');
-    await B.delay(5000); // Wait for WebView to load
+    await B.delay(10000); // Wait for WebView to load
     await driver.execute(`mobile: webAtoms`, {
       webviewElement: webviewEl.value,
       forceJavascriptEnabled: true,


### PR DESCRIPTION
`currentWindowMetrics` has only been added since API 30, so we need to use a proper approach for earlier versions of it