### PR TITLE
fix: Use unmerged tree for better details

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/drivers/ComposeDriver.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/drivers/ComposeDriver.kt
@@ -69,7 +69,7 @@ class ComposeDriver : AppDriver {
     // https://developer.android.com/jetpack/compose/semantics#merged-vs-unmerged
     override fun getText(params: AppiumParams): String {
         val config = getSemanticsNode(params.elementId!!).config
-        if (!(config.contains(SemanticsProperties.Text) || config[SemanticsProperties.Text].isEmpty())) throw InvalidElementStateException()
+        if (!(config.contains(SemanticsProperties.Text)) || config[SemanticsProperties.Text].isEmpty()) throw InvalidElementStateException()
         return config[SemanticsProperties.Text][0].text
     }
 

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/drivers/ComposeDriver.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/drivers/ComposeDriver.kt
@@ -49,7 +49,10 @@ class ComposeDriver : AppDriver {
     private fun toNodeInteractionsCollection(params: Locator): SemanticsNodeInteractionCollection {
         val parentNodeInteraction = params.elementId?.let { getNodeInteractionById(it) }
         return parentNodeInteraction?.findDescendantNodeInteractions(params)
-            ?: EspressoServerRunnerTest.composeTestRule.onAllNodes(semanticsMatcherForLocator(params))
+            ?: EspressoServerRunnerTest.composeTestRule.onAllNodes(
+                useUnmergedTree = true,
+                matcher = semanticsMatcherForLocator(params)
+            )
     }
 
     override fun click(params: AppiumParams): Unit {

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/SourceDocument.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/SourceDocument.kt
@@ -273,7 +273,7 @@ class SourceDocument constructor(
                         when (context.driverStrategy.name) {
                             DriverContext.StrategyType.COMPOSE -> {
                                 val rootView =
-                                    root ?: EspressoServerRunnerTest.composeTestRule.onRoot()
+                                    root ?: EspressoServerRunnerTest.composeTestRule.onRoot(useUnmergedTree = true)
                                         .fetchSemanticsNode()
                                 serializeComposeNode(rootView as SemanticsNode, 0)
                             }

--- a/test/functional/commands/jetpack-compose-e2e-specs.js
+++ b/test/functional/commands/jetpack-compose-e2e-specs.js
@@ -34,7 +34,7 @@ describe('Jetpack Compose', function () {
     await driver.updateSettings({ driver: 'compose' });
 
     let e = await driver.elementByTagName('lol');
-    await e.text().should.eventually.equal('Click to see dialog');
+    e.isDisplayed().should.eventually.be.true;
 
     let elementWithDescription = await driver.elementByAccessibilityId('desc');
     await elementWithDescription.text().should.eventually.equal('Click to see dialog');
@@ -56,7 +56,7 @@ describe('Jetpack Compose', function () {
 
     await driver.updateSettings({ driver: 'compose' });
 
-    let e = await driver.elementByXPath("//*[@view-tag='lol']");
+    let e = await driver.elementByXPath("//*[@view-tag='lol']//*[@content-desc='desc']");
     await e.text().should.eventually.equal('Click to see dialog');
   });
 

--- a/test/functional/commands/jetpack-compose-e2e-specs.js
+++ b/test/functional/commands/jetpack-compose-e2e-specs.js
@@ -41,7 +41,7 @@ describe('Jetpack Compose', function () {
     await elementWithDescription.isDisplayed().should.eventually.be.true;
 
     let clickableText = await driver.elementByLinkText('Click to see dialog');
-    clickableText.click();
+    await clickableText.click();
 
     await driver.elementByLinkText('Congratulations! You just clicked the text successfully');
     await driver.settings().should.eventually.eql({ driver: 'compose' });

--- a/test/functional/commands/jetpack-compose-e2e-specs.js
+++ b/test/functional/commands/jetpack-compose-e2e-specs.js
@@ -34,11 +34,11 @@ describe('Jetpack Compose', function () {
     await driver.updateSettings({ driver: 'compose' });
 
     let e = await driver.elementByTagName('lol');
-    e.isDisplayed().should.eventually.be.true;
+    await e.isDisplayed().should.eventually.be.true;
 
     let elementWithDescription = await driver.elementByAccessibilityId('desc');
     await elementWithDescription.text().should.eventually.equal('Click to see dialog');
-    elementWithDescription.isDisplayed().should.eventually.be.true;
+    await elementWithDescription.isDisplayed().should.eventually.be.true;
 
     let clickableText = await driver.elementByLinkText('Click to see dialog');
     clickableText.click();

--- a/test/functional/commands/jetpack-compose-source-e2e-specs.js
+++ b/test/functional/commands/jetpack-compose-source-e2e-specs.js
@@ -13,7 +13,7 @@ describe('source commands', function () {
   this.timeout(MOCHA_TIMEOUT);
 
   let driver;
-  describe('regular app', function () {
+  describe('jetpack-compose app', function () {
     before(async function () {
       // For SDK 23 and below Jetpack compose app crashes while running under instrumentation.
       if (parseInt(process.env.ANDROID_SDK_VERSION, 10) <= 23) {
@@ -25,7 +25,7 @@ describe('source commands', function () {
       await deleteSession();
     });
 
-    it('should get sourceXML, parse it, and find a node by xpath', async function () {
+    it('should get jetpack-compose sourceXML, parse it, and find a node by xpath', async function () {
       let el = await driver.elementByXPath("//*[@text='Display Text']");
       await driver.moveTo(el);
       await el.click();


### PR DESCRIPTION
When the nodes are merged, the attributes are merged too in an array. For such elements,  during a get_text call, we return only the first text of the array which is wrong. The merging of nodes also kills the possibility to finely locate a merged node's position
This can be solved by using an unmerged tree which gives a more detailed tree better suited for testing purpose