### PR TITLE
fix: [compose] Fix class names in page source

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/ComposeNodeElement.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/ComposeNodeElement.kt
@@ -56,7 +56,7 @@ class ComposeNodeElement(private val node: SemanticsNode) {
         get() = node.config.getOrNull(SemanticsProperties.Selected) == true
 
     val className: String
-        get() = node.config.getOrNull(SemanticsProperties.Role)?.toString() ?: COMPOSE_TAG_NAME
+        get() = node.config.getOrNull(SemanticsProperties.Role)?.toString() ?: getClassName(node)
 
     val isPassword: Boolean
         get() = node.config.contains(SemanticsProperties.Password)
@@ -83,6 +83,20 @@ class ComposeNodeElement(private val node: SemanticsNode) {
 
     val rect: io.appium.espressoserver.lib.model.Rect
         get() = fromBounds(bounds)
+
+    fun getClassName(node: SemanticsNode): String {
+//        Compose API doesn't have class level info, relaying on node SemanticsProperties as a work around.
+//        Following are the list of possible properties.
+        val propertiesList = listOf(SemanticsProperties.EditableText,
+            SemanticsProperties.Text,
+            SemanticsProperties.ProgressBarRangeInfo,
+            SemanticsProperties.HorizontalScrollAxisRange,
+            SemanticsProperties.VerticalScrollAxisRange,
+            SemanticsProperties.SelectableGroup,
+            SemanticsProperties.PaneTitle,
+            SemanticsProperties.Password)
+        return propertiesList.firstOrNull{  node.config.contains(it) }?.name ?: COMPOSE_TAG_NAME
+    }
 
     fun getAttribute(attributeType: ViewAttributesEnum): String? {
         when (attributeType) {

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/ComposeNodeElement.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/ComposeNodeElement.kt
@@ -20,12 +20,26 @@ import android.graphics.Rect
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.SemanticsPropertyKey
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.state.ToggleableState
 import io.appium.espressoserver.lib.handlers.exceptions.NotYetImplementedException
 import io.appium.espressoserver.lib.model.Rect.Companion.fromBounds
 
 const val DEFAULT_TAG_NAME = "ComposeNode"
+
+val POSSIBLE_CLASS_PROPERTIES: List<SemanticsPropertyKey<out Any>> by lazy {
+    listOf(
+        SemanticsProperties.EditableText,
+        SemanticsProperties.Text,
+        SemanticsProperties.ProgressBarRangeInfo,
+        SemanticsProperties.HorizontalScrollAxisRange,
+        SemanticsProperties.VerticalScrollAxisRange,
+        SemanticsProperties.SelectableGroup,
+        SemanticsProperties.PaneTitle,
+        SemanticsProperties.Password
+    )
+}
 
 class ComposeNodeElement(private val node: SemanticsNode) {
 
@@ -61,18 +75,8 @@ class ComposeNodeElement(private val node: SemanticsNode) {
     val className: String
         get() {
             //  Compose API doesn't have class name info, as a workaround relaying on node SemanticsProperties.
-            val possibleClassProperties = listOf(
-                SemanticsProperties.EditableText,
-                SemanticsProperties.Text,
-                SemanticsProperties.ProgressBarRangeInfo,
-                SemanticsProperties.HorizontalScrollAxisRange,
-                SemanticsProperties.VerticalScrollAxisRange,
-                SemanticsProperties.SelectableGroup,
-                SemanticsProperties.PaneTitle,
-                SemanticsProperties.Password
-            )
             return node.config.getOrNull(SemanticsProperties.Role)?.toString()
-                ?: possibleClassProperties.firstOrNull { node.config.contains(it) }?.name
+                ?: POSSIBLE_CLASS_PROPERTIES.firstOrNull { node.config.contains(it) }?.name
                 ?: DEFAULT_TAG_NAME
         }
 


### PR DESCRIPTION
Problem Statement:
- Currently implementation of page source returns element node as "ComposeNode" for most of the elements(except for [Role](https://github.com/androidx/androidx/blob/fc686a1579c3e1d5b1680906835effb4598566b5/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/semantics/SemanticsProperties.kt#L544))
- Current [Logic](https://github.com/appium/appium-espresso-driver/blob/master/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/ComposeNodeElement.kt#L59)
e.g:
```
<ComposeNode bounds="[130,383][234,426]" class="ComposeNode" clickable="false" enabled="true" focused="false" index="0" password="false" properties="" resource-id="2623" scrollable="false" selected="false" text="Games"/>

<ComposeNode bounds="[150,322][213,385]" class="ComposeNode" clickable="false" content-desc="Favorite" enabled="true" focused="false" index="1" password="false" properties="" resource-id="2622" scrollable="false" selected="false"/>
```

Proposed Solution:
- As a better alternative, we can relay on semantic node properties to predict the element type and treat that as a class name.
- Using this approach above element nodes would look like
```
<Text bounds="[130,383][234,426]" class="Text" clickable="false" enabled="true" focused="false" index="0" password="false" properties="" resource-id="2623" scrollable="false" selected="false" text="Games"/>

<Image bounds="[150,322][213,385]" class="Image" clickable="false" content-desc="Favorite" enabled="true" focused="false" index="1" password="false" properties="" resource-id="2622" scrollable="false" selected="false"/>
```

Note:
Please review only after merging https://github.com/appium/appium-espresso-driver/pull/700, seems I created from wrong branch.