### PR TITLE
[do not merge yet] feat: allow apks

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -101,6 +101,7 @@ const CHROME_NO_PROXY = [
 ];
 
 const APP_EXTENSION = '.apk';
+const APPS_EXTENSION = '.apks';
 
 
 class EspressoDriver extends BaseDriver {
@@ -174,7 +175,7 @@ class EspressoDriver extends BaseDriver {
 
       if (this.opts.app) {
         // find and copy, or download and unzip an app url or path
-        this.opts.app = await this.helpers.configureApp(this.opts.app, APP_EXTENSION);
+        this.opts.app = await this.helpers.configureApp(this.opts.app, [APP_EXTENSION, APPS_EXTENSION]);
         await this.checkAppPresent();
       } else if (this.appOnDevice) {
         // the app isn't an actual app file but rather something we want to


### PR DESCRIPTION
I just tested as https://github.com/KazuCocoa/AppBundleSample#for-espresso-driver.
https://github.com/KazuCocoa/AppBundleSample/blob/master/test.rb passed.

So, for now, https://github.com/KazuCocoa/AppBundleSample#for-espresso-driver signs the modules in `apks` with appium's keys in appium-adb. (I've generated https://github.com/KazuCocoa/AppBundleSample/blob/master/apks/appium-ks from them)

Then, if the app under test has been a simple one, it worked.
We can ask https://github.com/appium/appium-espresso-driver/issues/713 in their cases.