### PR TITLE
fix: allow array return type from backdoor

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/MobileBackdoor.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/MobileBackdoor.kt
@@ -25,6 +25,12 @@ class MobileBackdoor : RequestHandler<MobileBackdoorParams, Any?> {
                 else -> throw InvalidArgumentException("target cannot be '$target'")
             } ?: return null
 
+            if (result is Array<*> && result.filterNotNull()
+                    .all { it is String || (ClassUtils.wrapperToPrimitive(it.javaClass) != null) }
+            ) {
+                return result
+            }
+
             ClassUtils.wrapperToPrimitive(result.javaClass)?.let { return result }
                 ?: return result.toString()
         }


### PR DESCRIPTION
recent fix #697 had broke this facility to return array types