### PR TITLE
fix: Use ip4 localhost address by default

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -382,7 +382,7 @@ class EspressoDriver extends BaseDriver {
     // now that we have package and activity, we can create an instance of
     // espresso with the appropriate data
     this.espresso = new EspressoRunner({
-      host: this.opts.remoteAdbHost || this.opts.host || 'localhost',
+      host: this.opts.remoteAdbHost || this.opts.host || '127.0.0.1',
       systemPort: this.opts.systemPort,
       devicePort: DEVICE_PORT,
       adb: this.adb,


### PR DESCRIPTION
ADB only does port forwarding for ip4 addresses, so it does not make sense to have `localhost` there if it is pointing to ipv6 address by default.

Addresses https://github.com/appium/appium-espresso-driver/issues/747