### PR TITLE
fix: add double quote for gradle build config

### DIFF
--- a/lib/server-builder.js
+++ b/lib/server-builder.js
@@ -74,7 +74,7 @@ class ServerBuilder {
 
   getCommand () {
     const cmd = system.isWindows() ? 'gradlew.bat' : './gradlew';
-    const buildProperty = (key, value) => value ? `-P${key}=${value}` : null;
+    const buildProperty = (key, value) => value ? `-P${key}="${value}"` : null;
     let args = VERSION_KEYS
       .filter((key) => key !== GRADLE_VERSION_KEY)
       .map((key) => {

--- a/test/unit/server-builder-specs.js
+++ b/test/unit/server-builder-specs.js
@@ -19,7 +19,7 @@ describe('server-builder', function () {
     });
 
     it('should pass only specified versions as properties and pass them correctly', function () {
-      const expected = {cmd: expectedCmd, args: ['-PappiumAndroidGradlePlugin=1.2.3', 'app:assembleAndroidTest']};
+      const expected = {cmd: expectedCmd, args: ['-PappiumAndroidGradlePlugin="1.2.3"', 'app:assembleAndroidTest']};
       let serverBuilder = new ServerBuilder({
         buildConfiguration: {
           toolsVersions: {


### PR DESCRIPTION
Fixes https://github.com/appium/appium-espresso-driver/issues/752

```
# before
% ./gradlew -PappiumKeyPassword=START&ENDStarting a Gradle Daemon (subsequent builds will be faster)

> Starting Daemon

%
[1]  + suspended (tty input)  ./gradlew -PappiumKeyPassword=START

# after
% ./gradlew -PappiumKeyPassword="START&END"
Starting a Gradle Daemon, 1 busy Daemon could not be reused, use --status for details
```
