### PR TITLE
fix: unzip if the file was zipped

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -261,8 +261,6 @@ class EspressoDriver extends BaseDriver {
       cwd: tmpRoot,
       strict: false,
     })).sort((a, b) => a.split(path.sep).length - b.split(path.sep).length);
-    logger.info(sortedBundleItems);
-
     const unzippedAppPath = path.join(tmpRoot, _.first(sortedBundleItems));
     logger.info(`'${unzippedAppPath}' is an unzipped file from '${appPath}'`);
     return unzippedAppPath;

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -260,9 +260,19 @@ class EspressoDriver extends BaseDriver {
       cwd: tmpRoot,
       strict: false,
     })).sort((a, b) => a.split(path.sep).length - b.split(path.sep).length);
-    const unzippedAppPath = path.resolve(tmpRoot, path.basename(_.first(sortedBundleItems)));
-    logger.info(`'${unzippedAppPath}' is the unzipped file from '${appPath}'`);
+    logger.info(sortedBundleItems);
+
+    const unzippedAppPath = path.join(tmpRoot, _.first(sortedBundleItems));
+    logger.info(`'${unzippedAppPath}' is an unzipped file from '${appPath}'`);
     return unzippedAppPath;
+  }
+
+  isApk (appPath) {
+    return _.endsWith(_.toLower(appPath), '.apk');
+  }
+
+  async extractUniversalApk (shouldExtract, appPath) {
+    return shouldExtract ? appPath : await this.adb.extractUniversalApk(appPath);
   }
 
   async onPostConfigureApp ({cachedAppInfo, isUrl, appPath}) {
@@ -276,28 +286,33 @@ class EspressoDriver extends BaseDriver {
       }
     };
 
-    const unzippedAppPath = await this.unzipAppIfNeeded(appPath);
-    if (unzippedAppPath) {
-      appPath = unzippedAppPath;
-    }
-
-    const isApk = _.endsWith(_.toLower(appPath), '.apk');
-    // Do not cache .apk if was already present on the local file system
-    const shouldResultAppPathBeCached = !isApk || (isApk && isUrl);
     let pathInCache = null;
     let isResultAppPathAlreadyCached = false;
     if (_.isPlainObject(cachedAppInfo)) {
       const packageHash = await fs.hash(appPath);
       if (packageHash === cachedAppInfo.packageHash && await fs.exists(cachedAppInfo.fullPath)) {
+        logger.info(`Using '${cachedAppInfo.fullPath}' that is cached from '${appPath}'`);
         isResultAppPathAlreadyCached = true;
         pathInCache = cachedAppInfo.fullPath;
       }
     }
+
+    // appPath can be .zip, .apk, .apks and .aab
+    const isApk = this.isApk(appPath);
+    // Do not cache .apk if was already present on the local file system
+    const shouldResultAppPathBeCached = !isApk || (isApk && isUrl);
+
     if (!isResultAppPathAlreadyCached) {
       if (shouldResultAppPathBeCached) {
-        pathInCache = isApk ? appPath : await this.adb.extractUniversalApk(appPath);
+        // .zip, .aab or downloaded .apk
+        const unzippedAppPath = await this.unzipAppIfNeeded(appPath);
+        const isZipAppPath = unzippedAppPath != null;
+        pathInCache = isZipAppPath
+          ? await this.extractUniversalApk(this.isApk(unzippedAppPath), unzippedAppPath)
+          : await this.extractUniversalApk(isApk, appPath);
+
         if (!isApk && isUrl) {
-          // Clean up the temporarily downloaded .aab package
+          // Clean up the temporarily downloaded one
           await fs.rimraf(appPath);
         }
         await presignApp(pathInCache);
@@ -308,11 +323,7 @@ class EspressoDriver extends BaseDriver {
       }
     }
 
-    if (shouldResultAppPathBeCached) {
-      return {appPath: pathInCache};
-    }
-
-    return unzippedAppPath ? {appPath} : false;
+    return shouldResultAppPathBeCached ? {appPath: pathInCache} : false;
   }
 
   get driverData () {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -237,6 +237,34 @@ class EspressoDriver extends BaseDriver {
     }
   }
 
+  /**
+   * Unzip the given app path if needed.
+   *
+   * @param {string} appPath The path to app file.
+   * @returns {?string} Retuns the path to an unzipped app file path
+   *                    if the given path was unzipped, otherwise null.
+   */
+  async unzipAppIfNeeded (appPath) {
+    if (path.extname(_.toLower(appPath)) !== ZIP_EXT) {
+      return null;
+    }
+
+    const useSystemUnzipEnv = process.env.APPIUM_PREFER_SYSTEM_UNZIP;
+    const useSystemUnzip = _.isEmpty(useSystemUnzipEnv)
+      || !['0', 'false'].includes(_.toLower(useSystemUnzipEnv));
+    const tmpRoot = await tempDir.openDir();
+    await zip.extractAllTo(appPath, tmpRoot, {useSystemUnzip});
+
+    const globPattern = `**/*.+(${SUPPORTED_EXTENSIONS.map((ext) => ext.replace(/^\./, '')).join('|')})`;
+    const sortedBundleItems = (await fs.glob(globPattern, {
+      cwd: tmpRoot,
+      strict: false,
+    })).sort((a, b) => a.split(path.sep).length - b.split(path.sep).length);
+    const unzippedAppPath = path.resolve(tmpRoot, path.basename(_.first(sortedBundleItems)));
+    logger.info(`'${unzippedAppPath}' is the unzipped file from '${appPath}'`);
+    return unzippedAppPath;
+  }
+
   async onPostConfigureApp ({cachedAppInfo, isUrl, appPath}) {
     const presignApp = async (appLocation) => {
       if (this.opts.noSign) {
@@ -248,24 +276,9 @@ class EspressoDriver extends BaseDriver {
       }
     };
 
-    let isUnzippedAppPath = false;
-    if (path.extname(_.toLower(appPath)) === ZIP_EXT) {
-      const useSystemUnzipEnv = process.env.APPIUM_PREFER_SYSTEM_UNZIP;
-      const useSystemUnzip = _.isEmpty(useSystemUnzipEnv)
-        || !['0', 'false'].includes(_.toLower(useSystemUnzipEnv));
-      const tmpRoot = await tempDir.openDir();
-      await zip.extractAllTo(appPath, tmpRoot, {useSystemUnzip});
-
-      const globPattern = `**/*.+(${SUPPORTED_EXTENSIONS.map((ext) => ext.replace(/^\./, '')).join('|')})`;
-      const sortedBundleItems = (await fs.glob(globPattern, {
-        cwd: tmpRoot,
-        strict: false,
-      })).sort((a, b) => a.split(path.sep).length - b.split(path.sep).length);
-      const unzippedAppPath = path.resolve(tmpRoot, path.basename(_.first(sortedBundleItems)));
-      logger.info(`'${unzippedAppPath}' is the unzipped file from '${appPath}'`);
-      // The appPath is used in the following steps
+    const unzippedAppPath = await this.unzipAppIfNeeded(appPath);
+    if (unzippedAppPath) {
       appPath = unzippedAppPath;
-      isUnzippedAppPath = true;
     }
 
     const isApk = _.endsWith(_.toLower(appPath), '.apk');
@@ -295,8 +308,11 @@ class EspressoDriver extends BaseDriver {
       }
     }
 
-    return shouldResultAppPathBeCached ?
-      {appPath: pathInCache} : isUnzippedAppPath ? {appPath} : false;
+    if (shouldResultAppPathBeCached) {
+      return {appPath: pathInCache};
+    }
+
+    return unzippedAppPath ? {appPath} : false;
   }
 
   get driverData () {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -261,17 +261,13 @@ class EspressoDriver extends BaseDriver {
       cwd: tmpRoot,
       strict: false,
     })).sort((a, b) => a.split(path.sep).length - b.split(path.sep).length);
+    if (sortedBundleItems.length === 0) {
+      // no expected packages in the zip
+      return null;
+    }
     const unzippedAppPath = path.join(tmpRoot, _.first(sortedBundleItems));
     logger.info(`'${unzippedAppPath}' is an unzipped file from '${appPath}'`);
     return unzippedAppPath;
-  }
-
-  isApk (appPath) {
-    return _.endsWith(_.toLower(appPath), APK_EXT);
-  }
-
-  async extractUniversalApk (shouldExtract, appPath) {
-    return shouldExtract ? appPath : await this.adb.extractUniversalApk(appPath);
   }
 
   async onPostConfigureApp ({cachedAppInfo, isUrl, appPath}) {
@@ -285,6 +281,11 @@ class EspressoDriver extends BaseDriver {
       }
     };
 
+    const hasApkExt = (appPath) => _.endsWith(_.toLower(appPath), APK_EXT);
+    const hasZipkExt = (appPath) => _.endsWith(_.toLower(appPath), ZIP_EXT);
+    const extractUniversalApk = async (shouldExtract, appPath) =>
+      shouldExtract ? appPath : await this.adb.extractUniversalApk(appPath);
+
     let pathInCache = null;
     let isResultAppPathAlreadyCached = false;
     if (_.isPlainObject(cachedAppInfo)) {
@@ -296,22 +297,31 @@ class EspressoDriver extends BaseDriver {
       }
     }
 
-    // appPath can be .zip, .apk, .apks and .aab
-    const isApk = this.isApk(appPath);
-    // Do not cache .apk if was already present on the local file system
+    // appPath can be .zip, .apk, .apks or .aab
+    const isApk = hasApkExt(appPath);
+    // local .zip, .aab and downloaded .zip, .aab and .apks should be cached
+    // to skip unzip and generate .apk from .aab.
     const shouldResultAppPathBeCached = !isApk || (isApk && isUrl);
 
     if (!isResultAppPathAlreadyCached) {
       if (shouldResultAppPathBeCached) {
         // .zip, .aab or downloaded .apk
         const unzippedAppPath = await this.unzipAppIfNeeded(appPath);
-        const isZipAppPath = unzippedAppPath != null;
+        const isZipAppPath = !!unzippedAppPath;
+
+        // Probably the appPath zip file did not have SUPPORTED_EXTENSIONS.
+        if (hasZipkExt(appPath) && !isZipAppPath) {
+          logger.errorAndThrow(`${this.opts.app} did not have any of '${SUPPORTED_EXTENSIONS.join(', ')}' ` +
+            `extension packages. Please make sure the zip file has a valid package.`);
+        }
+
+        // unzippedAppPath or appPath has SUPPORTED_EXTENSIONS.
         pathInCache = isZipAppPath
-          ? await this.extractUniversalApk(this.isApk(unzippedAppPath), unzippedAppPath)
-          : await this.extractUniversalApk(isApk, appPath);
+          ? await extractUniversalApk(hasApkExt(unzippedAppPath), unzippedAppPath)
+          : await extractUniversalApk(isApk, appPath);
 
         if (!isApk && isUrl) {
-          // Clean up the temporarily downloaded .aab package
+          // Clean up the temporarily downloaded .aab or .zip package
           await fs.rimraf(appPath);
         }
         await presignApp(pathInCache);

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1,7 +1,8 @@
 import _ from 'lodash';
+import path from 'path';
 import { BaseDriver, errors, isErrorType, DeviceSettings} from '@appium/base-driver';
 import { EspressoRunner, TEST_APK_PKG } from './espresso-runner';
-import { fs } from '@appium/support';
+import { fs, tempDir, zip } from '@appium/support';
 import logger from './logger';
 import commands from './commands';
 import { DEFAULT_ADB_PORT } from 'appium-adb';
@@ -119,6 +120,9 @@ const CHROME_NO_PROXY = [
   ['POST', new RegExp('^/session/[^/]+/se/log')],
 ];
 
+
+const ZIP_EXT = '.zip';
+const SUPPORTED_EXTENSIONS = ['.apk', '.aab'];
 
 class EspressoDriver extends BaseDriver {
   constructor (opts = {}, shouldValidateCaps = true) {
@@ -244,6 +248,26 @@ class EspressoDriver extends BaseDriver {
       }
     };
 
+    let isUnzippedAppPath = false;
+    if (path.extname(_.toLower(appPath)) === ZIP_EXT) {
+      const useSystemUnzipEnv = process.env.APPIUM_PREFER_SYSTEM_UNZIP;
+      const useSystemUnzip = _.isEmpty(useSystemUnzipEnv)
+        || !['0', 'false'].includes(_.toLower(useSystemUnzipEnv));
+      const tmpRoot = await tempDir.openDir();
+      await zip.extractAllTo(appPath, tmpRoot, {useSystemUnzip});
+
+      const globPattern = `**/*.+(${SUPPORTED_EXTENSIONS.map((ext) => ext.replace(/^\./, '')).join('|')})`;
+      const sortedBundleItems = (await fs.glob(globPattern, {
+        cwd: tmpRoot,
+        strict: false,
+      })).sort((a, b) => a.split(path.sep).length - b.split(path.sep).length);
+      const unzippedAppPath = path.resolve(tmpRoot, path.basename(_.first(sortedBundleItems)));
+      logger.info(`'${unzippedAppPath}' is the unzipped file from '${appPath}'`);
+      // The appPath is used in the following steps
+      appPath = unzippedAppPath;
+      isUnzippedAppPath = true;
+    }
+
     const isApk = _.endsWith(_.toLower(appPath), '.apk');
     // Do not cache .apk if was already present on the local file system
     const shouldResultAppPathBeCached = !isApk || (isApk && isUrl);
@@ -270,7 +294,9 @@ class EspressoDriver extends BaseDriver {
         await presignApp(appPath);
       }
     }
-    return shouldResultAppPathBeCached ? {appPath: pathInCache} : false;
+
+    return shouldResultAppPathBeCached ?
+      {appPath: pathInCache} : isUnzippedAppPath ? {appPath} : false;
   }
 
   get driverData () {
@@ -482,6 +508,7 @@ class EspressoDriver extends BaseDriver {
     if (!this.opts.skipUninstall) {
       await this.adb.uninstallApk(this.opts.appPackage);
     }
+    logger.info(`--------> this.opts.app ${this.opts.app}`);
     if (this.opts.app) {
       await helpers.installApk(this.adb, this.opts);
     }

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -305,19 +305,25 @@ class EspressoDriver extends BaseDriver {
         // .zip, .aab or downloaded .apk
         let unzippedAppPath;
         let isUnzippedAppPath = false;
+        let isUnzippedApk = false;
         if (path.extname(_.toLower(appPath)) === ZIP_EXT) {
           unzippedAppPath = await this.unzipApp(appPath);
           isUnzippedAppPath = true;
+          isUnzippedApk = hasApkExt(unzippedAppPath);
         }
 
         // unzippedAppPath or appPath has SUPPORTED_EXTENSIONS.
         pathInCache = isUnzippedAppPath
-          ? await extractUniversalApk(hasApkExt(unzippedAppPath), unzippedAppPath)
+          ? await extractUniversalApk(isUnzippedApk, unzippedAppPath)
           : await extractUniversalApk(isApk, appPath);
 
         if (!isApk && isUrl) {
           // Clean up the temporarily downloaded .aab or .zip package
           await fs.rimraf(appPath);
+        }
+        if (!isUnzippedApk) {
+          // Cleanup the local zipped .aab file
+          await fs.rimraf(unzippedAppPath);
         }
         await presignApp(pathInCache);
       } else if (isApk) {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -121,7 +121,6 @@ const CHROME_NO_PROXY = [
 ];
 
 
-const ZIP_EXT = '.zip';
 const APK_EXT = '.apk';
 const AAB_EXT = '.aab';
 const SUPPORTED_EXTENSIONS = [APK_EXT, AAB_EXT];

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -305,7 +305,7 @@ class EspressoDriver extends BaseDriver {
         // .zip, .aab or downloaded .apk
         let unzippedAppPath;
         let isUnzippedAppPath = false;
-        if (path.extname(_.toLower(appPath)) !== ZIP_EXT) {
+        if (path.extname(_.toLower(appPath)) === ZIP_EXT) {
           unzippedAppPath = await this.unzipApp(appPath);
           isUnzippedAppPath = true;
         }

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -313,7 +313,7 @@ class EspressoDriver extends BaseDriver {
           : await this.extractUniversalApk(isApk, appPath);
 
         if (!isApk && isUrl) {
-          // Clean up the temporarily downloaded one
+          // Clean up the temporarily downloaded .aab package
           await fs.rimraf(appPath);
         }
         await presignApp(pathInCache);
@@ -323,7 +323,6 @@ class EspressoDriver extends BaseDriver {
         await presignApp(appPath);
       }
     }
-
     return shouldResultAppPathBeCached ? {appPath: pathInCache} : false;
   }
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -239,17 +239,14 @@ class EspressoDriver extends BaseDriver {
   }
 
   /**
-   * Unzip the given app path if needed.
+   * Unzip the given app path and return the first package that has SUPPORTED_EXTENSIONS
+   * in the archived file.
    *
    * @param {string} appPath The path to app file.
-   * @returns {?string} Retuns the path to an unzipped app file path
-   *                    if the given path was unzipped, otherwise null.
+   * @returns {string} Retuns the path to an unzipped app file path.
+   * @throws Raise an exception if the zip did not have any SUPPORTED_EXTENSIONS packages.
    */
-  async unzipAppIfNeeded (appPath) {
-    if (path.extname(_.toLower(appPath)) !== ZIP_EXT) {
-      return null;
-    }
-
+  async unzipApp (appPath) {
     const useSystemUnzipEnv = process.env.APPIUM_PREFER_SYSTEM_UNZIP;
     const useSystemUnzip = _.isEmpty(useSystemUnzipEnv)
       || !['0', 'false'].includes(_.toLower(useSystemUnzipEnv));
@@ -263,7 +260,8 @@ class EspressoDriver extends BaseDriver {
     })).sort((a, b) => a.split(path.sep).length - b.split(path.sep).length);
     if (sortedBundleItems.length === 0) {
       // no expected packages in the zip
-      return null;
+      logger.errorAndThrow(`${this.opts.app} did not have any of '${SUPPORTED_EXTENSIONS.join(', ')}' ` +
+      `extension packages. Please make sure the zip file has a valid package.`);
     }
     const unzippedAppPath = path.join(tmpRoot, _.first(sortedBundleItems));
     logger.info(`'${unzippedAppPath}' is an unzipped file from '${appPath}'`);
@@ -282,7 +280,6 @@ class EspressoDriver extends BaseDriver {
     };
 
     const hasApkExt = (appPath) => _.endsWith(_.toLower(appPath), APK_EXT);
-    const hasZipkExt = (appPath) => _.endsWith(_.toLower(appPath), ZIP_EXT);
     const extractUniversalApk = async (shouldExtract, appPath) =>
       shouldExtract ? appPath : await this.adb.extractUniversalApk(appPath);
 
@@ -306,13 +303,11 @@ class EspressoDriver extends BaseDriver {
     if (!isResultAppPathAlreadyCached) {
       if (shouldResultAppPathBeCached) {
         // .zip, .aab or downloaded .apk
-        const unzippedAppPath = await this.unzipAppIfNeeded(appPath);
-        const isUnzippedAppPath = !!unzippedAppPath;
-
-        // Probably the appPath zip file did not have SUPPORTED_EXTENSIONS.
-        if (hasZipkExt(appPath) && !isUnzippedAppPath) {
-          logger.errorAndThrow(`${this.opts.app} did not have any of '${SUPPORTED_EXTENSIONS.join(', ')}' ` +
-            `extension packages. Please make sure the zip file has a valid package.`);
+        let unzippedAppPath;
+        let isUnzippedAppPath = false;
+        if (path.extname(_.toLower(appPath)) !== ZIP_EXT) {
+          unzippedAppPath = await this.unzipApp(appPath);
+          isUnzippedAppPath = true;
         }
 
         // unzippedAppPath or appPath has SUPPORTED_EXTENSIONS.

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -123,7 +123,8 @@ const CHROME_NO_PROXY = [
 
 const ZIP_EXT = '.zip';
 const APK_EXT = '.apk';
-const SUPPORTED_EXTENSIONS = ['.apk', '.aab'];
+const AAB_EXT = '.aab';
+const SUPPORTED_EXTENSIONS = [APK_EXT, AAB_EXT];
 
 class EspressoDriver extends BaseDriver {
   constructor (opts = {}, shouldValidateCaps = true) {
@@ -261,10 +262,10 @@ class EspressoDriver extends BaseDriver {
     if (sortedBundleItems.length === 0) {
       // no expected packages in the zip
       logger.errorAndThrow(`${this.opts.app} did not have any of '${SUPPORTED_EXTENSIONS.join(', ')}' ` +
-      `extension packages. Please make sure the zip file has a valid package.`);
+        `extension packages. Please make sure the provided .zip archive contains at least one valid application package.`);
     }
     const unzippedAppPath = path.join(tmpRoot, _.first(sortedBundleItems));
-    logger.info(`'${unzippedAppPath}' is an unzipped file from '${appPath}'`);
+    logger.debug(`'${unzippedAppPath}' is the unzipped file from '${appPath}'`);
     return unzippedAppPath;
   }
 
@@ -280,6 +281,7 @@ class EspressoDriver extends BaseDriver {
     };
 
     const hasApkExt = (appPath) => _.endsWith(_.toLower(appPath), APK_EXT);
+    const hasAabExt = (appPath) => _.endsWith(_.toLower(appPath), AAB_EXT);
     const extractUniversalApk = async (shouldExtract, appPath) =>
       shouldExtract ? appPath : await this.adb.extractUniversalApk(appPath);
 
@@ -288,15 +290,15 @@ class EspressoDriver extends BaseDriver {
     if (_.isPlainObject(cachedAppInfo)) {
       const packageHash = await fs.hash(appPath);
       if (packageHash === cachedAppInfo.packageHash && await fs.exists(cachedAppInfo.fullPath)) {
-        logger.info(`Using '${cachedAppInfo.fullPath}' that is cached from '${appPath}'`);
+        logger.info(`Using '${cachedAppInfo.fullPath}' which is cached from '${appPath}'`);
         isResultAppPathAlreadyCached = true;
         pathInCache = cachedAppInfo.fullPath;
       }
     }
 
-    // appPath can be .zip, .apk, .apks or .aab
+    // appPath can be .zip, .apk or .aab
     const isApk = hasApkExt(appPath);
-    // local .zip, .aab and downloaded .zip, .aab and .apks should be cached
+    // local .zip, .aab and downloaded .zip, .aab and .apk should be cached
     // to skip unzip and generate .apk from .aab.
     const shouldResultAppPathBeCached = !isApk || (isApk && isUrl);
 
@@ -304,24 +306,22 @@ class EspressoDriver extends BaseDriver {
       if (shouldResultAppPathBeCached) {
         // .zip, .aab or downloaded .apk
         let unzippedAppPath;
-        let isUnzippedAppPath = false;
         let isUnzippedApk = false;
         if (path.extname(_.toLower(appPath)) === ZIP_EXT) {
           unzippedAppPath = await this.unzipApp(appPath);
-          isUnzippedAppPath = true;
           isUnzippedApk = hasApkExt(unzippedAppPath);
         }
 
         // unzippedAppPath or appPath has SUPPORTED_EXTENSIONS.
-        pathInCache = isUnzippedAppPath
-          ? await extractUniversalApk(isUnzippedApk, unzippedAppPath)
-          : await extractUniversalApk(isApk, appPath);
+        pathInCache = _.isUndefined(unzippedAppPath)
+          ? await extractUniversalApk(isApk, appPath)
+          : await extractUniversalApk(isUnzippedApk, unzippedAppPath);
 
         if (!isApk && isUrl) {
           // Clean up the temporarily downloaded .aab or .zip package
           await fs.rimraf(appPath);
         }
-        if (!isUnzippedApk) {
+        if (hasAabExt(unzippedAppPath)) {
           // Cleanup the local unzipped .aab file
           await fs.rimraf(unzippedAppPath);
         }

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -508,7 +508,6 @@ class EspressoDriver extends BaseDriver {
     if (!this.opts.skipUninstall) {
       await this.adb.uninstallApk(this.opts.appPackage);
     }
-    logger.info(`--------> this.opts.app ${this.opts.app}`);
     if (this.opts.app) {
       await helpers.installApk(this.adb, this.opts);
     }

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -322,7 +322,7 @@ class EspressoDriver extends BaseDriver {
           await fs.rimraf(appPath);
         }
         if (!isUnzippedApk) {
-          // Cleanup the local zipped .aab file
+          // Cleanup the local unzipped .aab file
           await fs.rimraf(unzippedAppPath);
         }
         await presignApp(pathInCache);

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -122,6 +122,7 @@ const CHROME_NO_PROXY = [
 
 
 const ZIP_EXT = '.zip';
+const APK_EXT = '.apk';
 const SUPPORTED_EXTENSIONS = ['.apk', '.aab'];
 
 class EspressoDriver extends BaseDriver {
@@ -208,7 +209,7 @@ class EspressoDriver extends BaseDriver {
         // find and copy, or download and unzip an app url or path
         this.opts.app = await this.helpers.configureApp(this.opts.app, {
           onPostProcess: this.onPostConfigureApp.bind(this),
-          supportedExtensions: ['.apk', '.aab']
+          supportedExtensions: SUPPORTED_EXTENSIONS
         });
       } else if (this.appOnDevice) {
         // the app isn't an actual app file but rather something we want to
@@ -268,7 +269,7 @@ class EspressoDriver extends BaseDriver {
   }
 
   isApk (appPath) {
-    return _.endsWith(_.toLower(appPath), '.apk');
+    return _.endsWith(_.toLower(appPath), APK_EXT);
   }
 
   async extractUniversalApk (shouldExtract, appPath) {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -307,16 +307,16 @@ class EspressoDriver extends BaseDriver {
       if (shouldResultAppPathBeCached) {
         // .zip, .aab or downloaded .apk
         const unzippedAppPath = await this.unzipAppIfNeeded(appPath);
-        const isZipAppPath = !!unzippedAppPath;
+        const isUnzippedAppPath = !!unzippedAppPath;
 
         // Probably the appPath zip file did not have SUPPORTED_EXTENSIONS.
-        if (hasZipkExt(appPath) && !isZipAppPath) {
+        if (hasZipkExt(appPath) && !isUnzippedAppPath) {
           logger.errorAndThrow(`${this.opts.app} did not have any of '${SUPPORTED_EXTENSIONS.join(', ')}' ` +
             `extension packages. Please make sure the zip file has a valid package.`);
         }
 
         // unzippedAppPath or appPath has SUPPORTED_EXTENSIONS.
-        pathInCache = isZipAppPath
+        pathInCache = isUnzippedAppPath
           ? await extractUniversalApk(hasApkExt(unzippedAppPath), unzippedAppPath)
           : await extractUniversalApk(isApk, appPath);
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -298,24 +298,24 @@ class EspressoDriver extends BaseDriver {
 
     // appPath can be .zip, .apk or .aab
     const isApk = hasApkExt(appPath);
-    // local .zip, .aab and downloaded .zip, .aab and .apk should be cached
-    // to skip unzip and generate .apk from .aab.
+    // Only local .apk files that are available in-place should not be cached
     const shouldResultAppPathBeCached = !isApk || (isApk && isUrl);
 
     if (!isResultAppPathAlreadyCached) {
       if (shouldResultAppPathBeCached) {
         // .zip, .aab or downloaded .apk
+
         let unzippedAppPath;
         let isUnzippedApk = false;
-        if (path.extname(_.toLower(appPath)) === ZIP_EXT) {
+        if (!(hasApkExt(appPath) || hasAabExt(appPath))) {
           unzippedAppPath = await this.unzipApp(appPath);
           isUnzippedApk = hasApkExt(unzippedAppPath);
         }
 
         // unzippedAppPath or appPath has SUPPORTED_EXTENSIONS.
-        pathInCache = _.isUndefined(unzippedAppPath)
-          ? await extractUniversalApk(isApk, appPath)
-          : await extractUniversalApk(isUnzippedApk, unzippedAppPath);
+        pathInCache = unzippedAppPath
+          ? await extractUniversalApk(isUnzippedApk, unzippedAppPath)
+          : await extractUniversalApk(isApk, appPath);
 
         if (!isApk && isUrl) {
           // Clean up the temporarily downloaded .aab or .zip package


### PR DESCRIPTION
`.zip` ext local file has not been unzipped since v2.1.0.
To keep compatibility and `this.helpers.configureApp`'s behavior, it would be nice to unzip in `onPostConfigureApp` if the given local file was zipped one.
Then, `onPostConfigureApp` should return a new unzipped file as its response to give the unzipped file to set it as `this.opts.app` for the following process.