### PR TITLE
chore: bump the base driver version in the published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "!.DS_Store"
   ],
   "dependencies": {
-    "@appium/base-driver": "^8.3.0",
+    "@appium/base-driver": "^8.5.2",
     "@appium/support": "^2.55.3",
     "@babel/runtime": "^7.4.3",
     "appium-adb": "^9.1.0",


### PR DESCRIPTION
to fix https://github.com/appium/appium-espresso-driver/issues/770