### PR TITLE
chore: Support `checked` attribute

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/AttributesEnum.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/model/AttributesEnum.kt
@@ -59,7 +59,6 @@ class EspressoAttributes : CommonAttributes(commonAttributes + espressoAttribute
                 AttributesEnum.ADAPTERS,
                 AttributesEnum.ADAPTER_TYPE,
                 AttributesEnum.CHECKABLE,
-                AttributesEnum.CHECKED,
                 AttributesEnum.FOCUSABLE,
                 AttributesEnum.HINT,
                 AttributesEnum.INSTANCE,
@@ -81,6 +80,7 @@ abstract class CommonAttributes(var attributes: List<AttributesEnum>) {
         val commonAttributes: List<AttributesEnum> by lazy {
             listOf(
                 AttributesEnum.BOUNDS,
+                AttributesEnum.CHECKED,
                 AttributesEnum.CLASS,
                 AttributesEnum.CLICKABLE,
                 AttributesEnum.CONTENT_DESC,


### PR DESCRIPTION
**Issue:**
```
io.appium.espressoserver.lib.handlers.exceptions.NotYetImplementedException: Compose doesn't support attribute 'checked', Attribute name should be one of 'bounds', 'class', 'clickable', 'content-desc', 'enabled', 'focused', 'index', 'password', 'resource-id', 'scrollable', 'selected', 'text', 'view-tag'
        at io.appium.espressoserver.lib.model.ComposeNodeElement.getAttribute(ComposeNodeElement.kt:126)
```

**Reason:** 
**Checked** attribute not been respected for Compose Driver.