### PR TITLE
feat: Add compose support more for element

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ to mix Espresso and Compose elements.
 In order to change between subdrivers use the [driver](#settings-api) setting. Setting its value to `compose` modifies driver behavior in the way it interacts with Compose elements rather that with classic Android views. It is possible to switch between `espresso` and `compose` modes at any point of time. When `compose` mode is active the the following webdriver commands behave differently (as of driver version *1.50.0*):
 - findElement(s): Element finding commands only support Compose-based locators. Read [Compose Elements Location](#compose-elements-location) for more details.
 - getPageSource: The returned page source is retrieved from Compose and all elements there contain [Compose-specific](#compose-element-attributes) attributes.
-- click, isDisplayed, isEnabled, clear, getText, sendKeys, getElementRect, getValue: These commands should properly support compose elements.
+- click, isDisplayed, isEnabled, clear, getText, sendKeys, getElementRect, getValue, isSelected: These commands should properly support compose elements.
 - getAttribute: Accepts and returns Compose-specific element attributes. See [Compose Element Attributes](#compose-element-attributes) for the full list of supported Compose element attributes.
 
 Calling other driver element-specific APIs not listed above would most likely throw an exception as Compose and Espresso elements are being stored in completely separated internal caches and must not be mixed.

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetEnabled.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetEnabled.kt
@@ -16,15 +16,17 @@
 
 package io.appium.espressoserver.lib.handlers
 
-import io.appium.espressoserver.lib.handlers.exceptions.AppiumException
+import io.appium.espressoserver.lib.helpers.getSemanticsNode
 import io.appium.espressoserver.lib.model.AppiumParams
-import io.appium.espressoserver.lib.model.EspressoElement
-
 import io.appium.espressoserver.lib.model.ViewElement
+import io.appium.espressoserver.lib.model.EspressoElement
+import io.appium.espressoserver.lib.model.ComposeNodeElement
 
 class GetEnabled : RequestHandler<AppiumParams, Boolean> {
 
-    @Throws(AppiumException::class)
-    override fun handleInternal(params: AppiumParams): Boolean =
-            ViewElement(EspressoElement.getViewById(params.elementId)).isEnabled
+    override fun handleEspresso(params: AppiumParams): Boolean =
+        ViewElement(EspressoElement.getViewById(params.elementId)).isEnabled
+
+    override fun handleCompose(params: AppiumParams): Boolean =
+        ComposeNodeElement(getSemanticsNode(params.elementId!!)).isEnabled
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetLocation.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetLocation.kt
@@ -16,17 +16,22 @@
 
 package io.appium.espressoserver.lib.handlers
 
-import io.appium.espressoserver.lib.handlers.exceptions.AppiumException
+import io.appium.espressoserver.lib.helpers.getSemanticsNode
 import io.appium.espressoserver.lib.model.AppiumParams
-import io.appium.espressoserver.lib.model.EspressoElement
 import io.appium.espressoserver.lib.model.Location
 import io.appium.espressoserver.lib.model.ViewElement
+import io.appium.espressoserver.lib.model.EspressoElement
+import io.appium.espressoserver.lib.model.ComposeNodeElement
 
 class GetLocation : RequestHandler<AppiumParams, Location> {
 
-    @Throws(AppiumException::class)
-    override fun handleInternal(params: AppiumParams): Location {
+    override fun handleEspresso(params: AppiumParams): Location {
         val viewElement = ViewElement(EspressoElement.getViewById(params.elementId))
         return Location(viewElement.bounds.left, viewElement.bounds.top)
+    }
+
+    override fun handleCompose(params: AppiumParams): Location {
+        val composeNodeElement = ComposeNodeElement(getSemanticsNode(params.elementId!!))
+        return Location(composeNodeElement.bounds.left, composeNodeElement.bounds.top)
     }
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetLocationInView.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetLocationInView.kt
@@ -16,18 +16,15 @@
 
 package io.appium.espressoserver.lib.handlers
 
-import io.appium.espressoserver.lib.handlers.exceptions.AppiumException
 import io.appium.espressoserver.lib.model.AppiumParams
-import io.appium.espressoserver.lib.model.EspressoElement
 import io.appium.espressoserver.lib.model.Location
+import io.appium.espressoserver.lib.model.EspressoElement
 import io.appium.espressoserver.lib.model.ViewElement
 
 class GetLocationInView : RequestHandler<AppiumParams, Location> {
 
-    @Throws(AppiumException::class)
-    override fun handleInternal(params: AppiumParams): Location {
-        val view = EspressoElement.getViewById(params.elementId)
-        val viewElement = ViewElement(view)
+    override fun handleEspresso(params: AppiumParams): Location {
+        val viewElement = ViewElement(EspressoElement.getViewById(params.elementId))
         return Location(viewElement.relativeLeft, viewElement.relativeTop)
     }
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetName.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetName.kt
@@ -16,16 +16,21 @@
 
 package io.appium.espressoserver.lib.handlers
 
-import io.appium.espressoserver.lib.handlers.exceptions.AppiumException
+import io.appium.espressoserver.lib.helpers.getSemanticsNode
 import io.appium.espressoserver.lib.model.AppiumParams
-import io.appium.espressoserver.lib.model.EspressoElement
 import io.appium.espressoserver.lib.model.ViewElement
+import io.appium.espressoserver.lib.model.EspressoElement
+import io.appium.espressoserver.lib.model.ComposeNodeElement
 
 class GetName : RequestHandler<AppiumParams, String?> {
 
-    @Throws(AppiumException::class)
-    override fun handleInternal(params: AppiumParams): String? {
+    override fun handleEspresso(params: AppiumParams): String? {
         val view = EspressoElement.getViewById(params.elementId)
         return ViewElement(view).contentDescription?.toString()
+    }
+
+    override fun handleCompose(params: AppiumParams): String? {
+        val composeNodeElement = ComposeNodeElement(getSemanticsNode(params.elementId!!))
+        return composeNodeElement.contentDescription?.toString()
     }
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetSelected.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetSelected.kt
@@ -16,15 +16,18 @@
 
 package io.appium.espressoserver.lib.handlers
 
-import io.appium.espressoserver.lib.handlers.exceptions.AppiumException
+import io.appium.espressoserver.lib.helpers.getSemanticsNode
 import io.appium.espressoserver.lib.model.AppiumParams
+import io.appium.espressoserver.lib.model.ComposeNodeElement
 import io.appium.espressoserver.lib.model.EspressoElement
 
 import io.appium.espressoserver.lib.model.ViewElement
 
 class GetSelected : RequestHandler<AppiumParams, Boolean> {
 
-    @Throws(AppiumException::class)
-    override fun handleInternal(params: AppiumParams): Boolean =
+    override fun handleEspresso(params: AppiumParams): Boolean =
             ViewElement(EspressoElement.getViewById(params.elementId)).isSelected
+
+    override fun handleCompose(params: AppiumParams): Boolean =
+            ComposeNodeElement(getSemanticsNode(params.elementId!!)).isSelected
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetSize.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetSize.kt
@@ -16,17 +16,22 @@
 
 package io.appium.espressoserver.lib.handlers
 
-import io.appium.espressoserver.lib.handlers.exceptions.AppiumException
+import io.appium.espressoserver.lib.helpers.getSemanticsNode
 import io.appium.espressoserver.lib.model.AppiumParams
-import io.appium.espressoserver.lib.model.EspressoElement
 import io.appium.espressoserver.lib.model.Size
 import io.appium.espressoserver.lib.model.ViewElement
+import io.appium.espressoserver.lib.model.EspressoElement
+import io.appium.espressoserver.lib.model.ComposeNodeElement
 
 class GetSize : RequestHandler<AppiumParams, Size> {
 
-    @Throws(AppiumException::class)
-    override fun handleInternal(params: AppiumParams): Size {
+    override fun handleEspresso(params: AppiumParams): Size {
         val bounds = ViewElement(EspressoElement.getViewById(params.elementId)).bounds
+        return Size(bounds.width(), bounds.height())
+    }
+
+    override fun handleCompose(params: AppiumParams): Size {
+        val bounds = ComposeNodeElement(getSemanticsNode(params.elementId!!)).bounds
         return Size(bounds.width(), bounds.height())
     }
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/Text.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/Text.kt
@@ -16,7 +16,6 @@
 
 package io.appium.espressoserver.lib.handlers
 
-import io.appium.espressoserver.lib.handlers.exceptions.InvalidElementStateException
 import io.appium.espressoserver.lib.helpers.getSemanticsNode
 import io.appium.espressoserver.lib.model.AppiumParams
 import io.appium.espressoserver.lib.model.ComposeNodeElement


### PR DESCRIPTION
https://github.com/appium/appium/discussions/17001#discussioncomment-2842792

GetXXXX via elements like displayed has compose handler while some of them had only espresso ones.
This PR adds other GetXXXX for compose.

```
class GetDisplayed : RequestHandler<AppiumParams, Boolean> {

    override fun handleEspresso(params: AppiumParams): Boolean =
        ViewElement(EspressoElement.getViewById(params.elementId, false)).isVisible

    override fun handleCompose(params: AppiumParams): Boolean =
        try {
            getNodeInteractionById(params.elementId).assertIsDisplayed()
            true
        } catch (e: AssertionError) {
            false
        }
}
```

These implementation basically follows existing `class Text : RequestHandler<AppiumParams, String>`'s implementation.