### PR TITLE
feat: Add `mobile: startActivity` extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -732,7 +732,7 @@ remotePath | string | yes | The full path to the remote file or a file inside an
 
 ### mobile: startActivity
 
-Starts the given activity with intent options, activity options and locale.
+Starts the given activity with intent options, activity options and locale. Activity could only be executed in scope of the current app package.
 
 #### Arguments
 

--- a/README.md
+++ b/README.md
@@ -730,6 +730,19 @@ Name | Type | Required | Description | Example
 --- | --- | --- | --- | ---
 remotePath | string | yes | The full path to the remote file or a file inside an application bundle | `/sdcard/myfile.txt` or `@my.app.id/path/in/bundle`
 
+### mobile: startActivity
+
+Starts the given activity with intent options, activity options and locale.
+
+#### Arguments
+
+Name | Type | Required | Description | Example
+--- | --- | --- | --- | ---
+appActivity | string | yes | Applicaiton acitivity identifier to start | `com.myapp.myacitivty`
+locale | object | no | Sets the locale for the app under test. It only uses public APIs for its purpose. See https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers to get the list of available language abbreviations. | `{"language": "zh", "country": "CN", "variant": "Hans"}`
+optionalIntentArguments | object | no | The mapping of custom options for the intent that is going to be passed to the main app activity. Check [Intent Options](#intent-options) for more details. | `{ 'flags': 'ACTIVITY_NEW_TASK', 'action': '<intent_action>', 'className': '<fullyQualifiedAppActivity>', 'es': {'foo': 'bar'} }`
+optionalActivityArguments | object | no | The mapping of custom options for the main app activity that is going to be started. Check [Activity Options](#activity-options) for more details. | `{ 'launchDisplayId': 1 }`
+
 ### mobile: startService
 
 Starts the given service intent.

--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -54,6 +54,8 @@ extensions.executeMobile = async function executeMobile (mobileCommand, opts = {
 
     deleteFile: 'mobileDeleteFile',
 
+    startActivity: 'mobileStartActivity',
+
     startService: 'mobileStartService',
     stopService: 'mobileStopService',
 

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -297,9 +297,9 @@ helpers.suspendChromedriverProxy = function suspendChromedriverProxy () {
 };
 
 /**
- *  Starts the given activity with intent options, activity options and locale. 
+ *  Starts the given activity with intent options, activity options and locale.
  *  Activity could only be executed in scope of the current app package.
- *  
+ *
  *  appActivity is mandatory
  *
  *  locale, optionalIntentArguments, optionalActivityArguments are optional

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -296,6 +296,14 @@ helpers.suspendChromedriverProxy = function suspendChromedriverProxy () {
   this.jwpProxyActive = true;
 };
 
+/**
+ *  Starts the given activity with intent options, activity options and locale. 
+ *  Activity could only be executed in scope of the current app package.
+ *  
+ *  appActivity is mandatory
+ *
+ *  locale, optionalIntentArguments, optionalActivityArguments are optional
+ */
 commands.mobileStartActivity = async function mobileStartActivity (opts = {}) {
   const appPackage = this.caps.appPackage;
   const {

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -297,17 +297,24 @@ helpers.suspendChromedriverProxy = function suspendChromedriverProxy () {
 };
 
 commands.startActivity = async function startActivity (appPackage, appActivity,
-  appWaitPackage, appWaitActivity) {
-  // intentAction, intentCategory, intentFlags, optionalIntentArguments, dontStopAppOnReset
+  appWaitPackage, appWaitActivity, intentAction, intentCategory, intentFlags, optionalIntentArguments) {
+  // intentAction, intentCategory, intentFlags, dontStopAppOnReset
   // parameters are not supported by Espresso
   appPackage = appPackage || this.caps.appPackage;
   appWaitPackage = appWaitPackage || appPackage;
   appActivity = qualifyActivityName(appActivity, appPackage);
   appWaitActivity = qualifyActivityName(appWaitActivity || appActivity, appWaitPackage);
+  try {
+    optionalIntentArguments = (optionalIntentArguments) ? JSON.parse(optionalIntentArguments) : null;
+  } catch (e) {
+    this.log.error('Cannot parse the optionalIntentArguments JSON', e);
+    throw e;
+  }
   this.log.debug(`Starting activity '${appActivity}' for package '${appPackage}'`);
   await this.espresso.jwproxy.command(`/appium/device/start_activity`, 'POST', {
     appPackage,
     appActivity,
+    optionalIntentArguments,
   });
   await this.adb.waitForActivity(appWaitPackage, appWaitActivity);
 };

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -296,25 +296,35 @@ helpers.suspendChromedriverProxy = function suspendChromedriverProxy () {
   this.jwpProxyActive = true;
 };
 
+commands.mobileStartActivity = async function mobileStartActivity (opts = {}) {
+  const appPackage = this.caps.appPackage;
+  const {
+    appActivity,
+    locale,
+    optionalIntentArguments,
+    optionalActivityArguments
+  } = assertRequiredOptions(opts, ['appActivity']);
+  return await this.espresso.jwproxy.command(`/appium/device/start_activity`, 'POST', {
+    appPackage,
+    appActivity,
+    locale,
+    optionalIntentArguments,
+    optionalActivityArguments
+  });
+};
+
 commands.startActivity = async function startActivity (appPackage, appActivity,
-  appWaitPackage, appWaitActivity, intentAction, intentCategory, intentFlags, optionalIntentArguments) {
-  // intentAction, intentCategory, intentFlags, dontStopAppOnReset
+  appWaitPackage, appWaitActivity) {
+  // intentAction, intentCategory, intentFlags, optionalIntentArguments, dontStopAppOnReset
   // parameters are not supported by Espresso
   appPackage = appPackage || this.caps.appPackage;
   appWaitPackage = appWaitPackage || appPackage;
   appActivity = qualifyActivityName(appActivity, appPackage);
   appWaitActivity = qualifyActivityName(appWaitActivity || appActivity, appWaitPackage);
-  try {
-    optionalIntentArguments = (optionalIntentArguments) ? JSON.parse(optionalIntentArguments) : null;
-  } catch (e) {
-    this.log.error('Cannot parse the optionalIntentArguments JSON', e);
-    throw e;
-  }
   this.log.debug(`Starting activity '${appActivity}' for package '${appPackage}'`);
   await this.espresso.jwproxy.command(`/appium/device/start_activity`, 'POST', {
     appPackage,
     appActivity,
-    optionalIntentArguments,
   });
   await this.adb.waitForActivity(appWaitPackage, appWaitActivity);
 };


### PR DESCRIPTION
Update startActivity to support IntentOptions and passed as optionalIntentArguments. Clients might require update but this should help teams with both UiAutomator2 and Espresso scripts.