### PR TITLE
chore: Update to hamcrest 2.2

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/ViewFinder.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/ViewFinder.kt
@@ -53,9 +53,9 @@ import io.appium.espressoserver.lib.handlers.exceptions.InvalidElementStateExcep
 import io.appium.espressoserver.lib.model.toJsonMatcher
 import io.appium.espressoserver.lib.viewmatcher.withView
 import io.appium.espressoserver.lib.viewmatcher.withXPath
-import org.hamcrest.CoreMatchers.allOf
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.Matchers.allOf
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.`is`
 import org.hamcrest.Matchers.endsWith
 import org.hamcrest.Matchers.hasEntry
 import org.hamcrest.Matchers.instanceOf

--- a/espresso-server/app/src/test/java/io/appium/espressoserver/test/model/HamcrestMatcherTest.kt
+++ b/espresso-server/app/src/test/java/io/appium/espressoserver/test/model/HamcrestMatcherTest.kt
@@ -109,4 +109,13 @@ class HamcrestMatcherTest {
             {"args": "Hello World!"}
         """.trimIndent(), HamcrestMatcher::class.java)
     }
+
+    @Test
+    fun `should parse Hamcrest matcher that have regex as an arg` () {
+        val matcher = g.fromJson("""
+            {"name": "matchesRegex", "args": "[A-Za-z ]*"}
+        """.trimIndent(), HamcrestMatcher::class.java)
+        assertTrue(matcher.invoke().matches("Hello World"))
+        assertFalse(matcher.invoke().matches("Hello World!"))
+    }
 }


### PR DESCRIPTION
Hi!
The project uses old version of the hamcrest library v1.3 because it uses internal API http://hamcrest.org/JavaHamcrest/distributables.html#upgrading-from-hamcrest-1x.
I fixed it and added a test to check.