### PR TITLE
chore: add changelog with @semantic-release/changelog

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -4,15 +4,17 @@
       "preset": "angular",
       "releaseRules": [
         {"type": "chore", "release": "patch"}
-        
       ]
     }],
-    "@semantic-release/npm",
     "@semantic-release/release-notes-generator",
+    ["@semantic-release/changelog", {
+      "changelogFile": "CHANGELOG.md"
+    }],
+    "@semantic-release/npm",
     ["@semantic-release/git", {
-      "assets": ["docs", "package.json"],
+      "assets": ["docs", "package.json", "CHANGELOG.md"],
       "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
     }],
-    "@semantic-release/github",
+    "@semantic-release/github"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "@babel/preset-env": "^7.18.10",
     "@babel/register": "^7.18.9",
     "@semantic-release/git": "^10.0.1",
+    "@semantic-release/changelog": "^6.0.1",
     "@xmldom/xmldom": "^0.x",
     "babel-plugin-source-map-support": "^2.2.0",
     "android-apidemos": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "espresso-server/build.gradle.kts",
     "espresso-server/settings.gradle.kts",
     "espresso-server/lint.xml",
-    "!.DS_Store"
+    "!.DS_Store",
+    "CHANGELOG.md"
   ],
   "dependencies": {
     "@babel/runtime": "^7.4.3",


### PR DESCRIPTION
appium/appium-xcuitest-driver#1452 for appium-espresso-driver.

This repo already had CHANGELOG.md