### PR TITLE
chore: add because in the gradle file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1061,7 +1061,7 @@ Allows to retrieve accessibility elements hierarchy tree with [UiAutomator](http
 
 The UI accessibility hierarchy represented as XML document.
 
-### mobile: mobileWebAtoms
+### mobile: webAtoms
 
 Allows to run a chain of [Espresso web atoms](https://developer.android.com/training/testing/espresso/web) on a web view element.
 

--- a/espresso-server/app/build.gradle.kts
+++ b/espresso-server/app/build.gradle.kts
@@ -112,8 +112,12 @@ dependencies {
     testImplementation("org.jetbrains.kotlin:kotlin-test:${kotlinVersion}")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion")
     testImplementation("org.jetbrains.kotlin:kotlin-reflect:${kotlinVersion}")
-    testImplementation("androidx.compose.ui:ui-test:${composeVersion}")
-    testImplementation("androidx.compose.ui:ui-test-junit4:${composeVersion}")
+    testImplementation("androidx.compose.ui:ui-test:${composeVersion}") {
+        because("Android Compose Support")
+    }
+    testImplementation("androidx.compose.ui:ui-test-junit4:${composeVersion}") {
+        because("Android Compose Support")
+    }
 
     androidTestImplementation("androidx.annotation:annotation:${annotationVersion}")
     androidTestImplementation("androidx.test.espresso:espresso-contrib:${Version.espresso}") {
@@ -130,9 +134,12 @@ dependencies {
     androidTestImplementation("org.nanohttpd:nanohttpd-webserver:${Version.nanohttpd}")
     androidTestImplementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlinVersion}")
     androidTestImplementation("org.jetbrains.kotlin:kotlin-reflect:${kotlinVersion}")
-    androidTestImplementation("androidx.compose.ui:ui-test:${composeVersion}")
-    androidTestImplementation("androidx.compose.ui:ui-test-junit4:${composeVersion}"){
-        isTransitive = false
+    androidTestImplementation("androidx.compose.ui:ui-test:${composeVersion}") {
+        because("Android Compose Support")
+    }
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4:${composeVersion}") {
+        isTransitive = false,
+        because("Android Compose Support")
     }
 
     // additionalAndroidTestDependencies placeholder (don't change or delete this line)

--- a/espresso-server/app/build.gradle.kts
+++ b/espresso-server/app/build.gradle.kts
@@ -138,7 +138,7 @@ dependencies {
         because("Android Compose support")
     }
     androidTestImplementation("androidx.compose.ui:ui-test-junit4:${composeVersion}") {
-        isTransitive = false,
+        isTransitive = false
         because("Android Compose support")
     }
 

--- a/espresso-server/app/build.gradle.kts
+++ b/espresso-server/app/build.gradle.kts
@@ -112,12 +112,8 @@ dependencies {
     testImplementation("org.jetbrains.kotlin:kotlin-test:${kotlinVersion}")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion")
     testImplementation("org.jetbrains.kotlin:kotlin-reflect:${kotlinVersion}")
-    testImplementation("androidx.compose.ui:ui-test:${composeVersion}") {
-        because("Android Compose Support")
-    }
-    testImplementation("androidx.compose.ui:ui-test-junit4:${composeVersion}") {
-        because("Android Compose Support")
-    }
+    testImplementation("androidx.compose.ui:ui-test:${composeVersion}")
+    testImplementation("androidx.compose.ui:ui-test-junit4:${composeVersion}")
 
     androidTestImplementation("androidx.annotation:annotation:${annotationVersion}")
     androidTestImplementation("androidx.test.espresso:espresso-contrib:${Version.espresso}") {
@@ -125,8 +121,12 @@ dependencies {
         // Link to PR with fix and discussion https://github.com/appium/appium-espresso-driver/pull/596
         isTransitive = false
     }
-    androidTestImplementation("androidx.test.espresso:espresso-web:${Version.espresso}")
-    androidTestImplementation("androidx.test.uiautomator:uiautomator:${Version.uia}")
+    androidTestImplementation("androidx.test.espresso:espresso-web:${Version.espresso}") {
+        because("Espresso Web Atoms support (mobile: webAtoms)")
+    }
+    androidTestImplementation("androidx.test.uiautomator:uiautomator:${Version.uia}") {
+        because("UiAutomator support (mobile: uiautomator)")
+    }
     androidTestImplementation("androidx.test:core:${Version.testlib}")
     androidTestImplementation("androidx.test:runner:${Version.testlib}")
     androidTestImplementation("androidx.test:rules:${Version.testlib}")
@@ -135,11 +135,11 @@ dependencies {
     androidTestImplementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlinVersion}")
     androidTestImplementation("org.jetbrains.kotlin:kotlin-reflect:${kotlinVersion}")
     androidTestImplementation("androidx.compose.ui:ui-test:${composeVersion}") {
-        because("Android Compose Support")
+        because("Android Compose support")
     }
     androidTestImplementation("androidx.compose.ui:ui-test-junit4:${composeVersion}") {
         isTransitive = false,
-        because("Android Compose Support")
+        because("Android Compose support")
     }
 
     // additionalAndroidTestDependencies placeholder (don't change or delete this line)


### PR DESCRIPTION
We could set _because_ in the dependency to add the description. They may help our future maintenance. Code comment and this `because` might have no difference to leaving comments on the gradle file, but maybe the error message will change(?). No strong opinion for this option vs code comment though