### PR TITLE
fix: specify supported non-standard commands in newMethodMap

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -6,11 +6,12 @@ import { EspressoRunner, TEST_APK_PKG } from './espresso-runner';
 import { fs, tempDir, zip } from 'appium/support';
 import commands from './commands';
 import { DEFAULT_ADB_PORT } from 'appium-adb';
-import { androidHelpers, androidCommands, SETTINGS_HELPER_PKG_ID } from 'appium-android-driver';
+import { androidHelpers, androidCommands, SETTINGS_HELPER_PKG_ID, } from 'appium-android-driver';
 import desiredCapConstraints from './desired-caps';
 import { findAPortNotInUse } from 'portscanner';
 import { retryInterval } from 'asyncbox';
 import { qualifyActivityName, getPackageInfo } from './utils';
+import { newMethodMap } from './method-map';
 
 
 // TODO merge our own helpers onto this later
@@ -125,6 +126,9 @@ const AAB_EXT = '.aab';
 const SUPPORTED_EXTENSIONS = [APK_EXT, AAB_EXT];
 
 class EspressoDriver extends BaseDriver {
+
+  static newMethodMap = newMethodMap;
+
   constructor (opts = {}, shouldValidateCaps = true) {
     // `shell` overwrites adb.shell, so remove
     delete opts.shell;

--- a/lib/method-map.js
+++ b/lib/method-map.js
@@ -1,0 +1,11 @@
+import { AndroidDriver } from 'appium-android-driver';
+
+export const newMethodMap = /** @type {const} */ ({
+  ...AndroidDriver.newMethodMap,
+  '/session/:sessionId/appium/device/get_clipboard': {
+    POST: {
+      command: 'getClipboard',
+      payloadParams: { optional: ['contentType'] }
+    }
+  }
+});

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@babel/runtime": "^7.4.3",
     "appium-adb": "^9.10.2",
-    "appium-android-driver": "^5.6.0",
+    "appium-android-driver": "^5.8.7",
     "asyncbox": "^2.3.1",
     "bluebird": "^3.5.0",
     "lodash": "^4.17.11",


### PR DESCRIPTION
depends on https://github.com/appium/appium-android-driver/pull/782