### PR TITLE
chore: add print espresso path as a command

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ On top of standard Appium requirements Espresso driver also expects the followin
 
 ## Scripts
 
-- `appium driver run log-espresso-path` prints the path to the Appium Espresso server root. You can modify the gradle file directly if [Espresso Build Config](#espresso-build-config) was not sufficient.
+- `appium driver run print-espresso-path` prints the path to the Appium Espresso server root. You can modify the gradle file directly if [Espresso Build Config](#espresso-build-config) was not sufficient.
 
 ## Capabilities
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ On top of standard Appium requirements Espresso driver also expects the followin
 - The package under test must not have mangled class names (e.g. [Proguard](https://developer.android.com/studio/build/shrink-code) must not be enabled for it)
 
 
+## Scripts
+
+- `appium driver run log-espresso-path` prints the path to the Appium Espresso server root. You can modify the gradle file directly if [Espresso Build Config](#espresso-build-config) was not sufficient.
+
 ## Capabilities
 
 ### General
@@ -206,7 +210,7 @@ In order to change between subdrivers use the [driver](#settings-api) setting. S
 - click, isDisplayed, isEnabled, clear, getText, sendKeys, getElementRect, getValue, isSelected: These commands should properly support compose elements.
 - getAttribute: Accepts and returns Compose-specific element attributes. See [Compose Element Attributes](#compose-element-attributes) for the full list of supported Compose element attributes.
 - getElementScreenshot: Fetches a screenshot of the given Compose element. Available since driver version *2.14.0*
-- `mobile: swipe`: Performs swipe gesture on the given element in the given direction. 
+- `mobile: swipe`: Performs swipe gesture on the given element in the given direction.
 The `swiper` argument is not supported in Compose mode. Available since driver version *2.15.0*
 
 Calling other driver element-specific APIs not listed above would most likely throw an exception as Compose and Espresso elements are being stored in completely separated internal caches and must not be mixed.

--- a/package.json
+++ b/package.json
@@ -37,7 +37,10 @@
     "platformNames": [
       "Android"
     ],
-    "mainClass": "EspressoDriver"
+    "mainClass": "EspressoDriver",
+    "scripts": {
+      "log-espresso-path": "./scripts/log-espresso-path.js"
+    }
   },
   "main": "./build/index.js",
   "bin": {},
@@ -66,6 +69,7 @@
     "appium-android-driver": "^5.8.7",
     "asyncbox": "^2.3.1",
     "bluebird": "^3.5.0",
+    "fancy-log": "^2.0.0",
     "lodash": "^4.17.11",
     "portscanner": "^2.1.1",
     "source-map-support": "^0.x",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     ],
     "mainClass": "EspressoDriver",
     "scripts": {
-      "log-espresso-path": "./scripts/log-espresso-path.js"
+      "print-espresso-path": "./scripts/print-espresso-path.js"
     }
   },
   "main": "./build/index.js",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "appium-android-driver": "^5.8.7",
     "asyncbox": "^2.3.1",
     "bluebird": "^3.5.0",
-    "fancy-log": "^2.0.0",
     "lodash": "^4.17.11",
     "portscanner": "^2.1.1",
     "source-map-support": "^0.x",

--- a/scripts/log-espresso-path.js
+++ b/scripts/log-espresso-path.js
@@ -1,9 +1,8 @@
 const path = require('path');
-const log = require('fancy-log');
 
 function logEspressoServerPath () {
   const dstPath = path.resolve(__dirname, '..', 'espresso-server');
-  log.info(`Appium Espresso server exists in '${dstPath}'`);
+  console.log(dstPath); // eslint-disable-line no-console
 }
 
 logEspressoServerPath();

--- a/scripts/log-espresso-path.js
+++ b/scripts/log-espresso-path.js
@@ -1,0 +1,9 @@
+const path = require('path');
+const log = require('fancy-log');
+
+function logEspressoServerPath () {
+  const dstPath = path.resolve(__dirname, '..', 'espresso-server');
+  log.info(`Appium Espresso server exists in '${dstPath}'`);
+}
+
+logEspressoServerPath();

--- a/scripts/print-espresso-path.js
+++ b/scripts/print-espresso-path.js
@@ -1,8 +1,8 @@
 const path = require('path');
 
-function logEspressoServerPath () {
+function printEspressoServerPath () {
   const dstPath = path.resolve(__dirname, '..', 'espresso-server');
   console.log(dstPath); // eslint-disable-line no-console
 }
 
-logEspressoServerPath();
+printEspressoServerPath();


### PR DESCRIPTION
similar to opening wda fir, I'd like to show where the espresso server is. This could be on Win as well, so this command shows where it is. This will help when a user wants to modify the gradle file directly in their debug for example. I had questions about where the espresso server was in past, so this command may help in such cases as well.

Example (local installed espresso driver dir)
```
kazu$ appium driver run --json espresso print-espresso-path
{
    "output": [
        "[STDOUT] /Users/kazu/GitHub/appium-espresso-driver/espresso-server"
    ]
}
kazu$ appium driver run espresso print-espresso-path
[STDOUT] /Users/kazu/GitHub/appium-espresso-driver/espresso-server
✔ log-espresso-path successfully ran
```