### PR TITLE
[wip] add espresso build command

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "build": "npm run build:node && npm run build:server",
     "build:node": "rimraf build && babel --out-dir=build/lib lib && babel --out-dir=build index.js",
     "build:server": "cd espresso-server && ./gradlew clean assembleAndroidTest || cd ..",
+    "build:server_js": "node ./scripts/build-espressoserver.js",
     "dev": "npm run build -- --watch",
     "lint": "eslint .",
     "lint:server": "cd espresso-server && ./gradlew lint || cd ..",

--- a/scripts/build-espressoserver.js
+++ b/scripts/build-espressoserver.js
@@ -1,0 +1,29 @@
+const path = require('path');
+const { asyncify } = require('asyncbox');
+const { logger } = require('@appium/support');
+const { ServerBuilder } = require('../build/lib/server-builder.js');
+
+const LOG = new logger.getLogger('EspressoBuild');
+
+const ROOT_DIR = path.resolve(__dirname, '..');
+const ESPRESSO_SERVER_ROOT = path.join(ROOT_DIR, 'espresso-server');
+
+async function buildEspressoServer () {
+  const opts = {
+    serverPath: ESPRESSO_SERVER_ROOT,
+    showGradleLog: true,
+  };
+
+  if (process.env.TEST_APP_PACKAGE) {
+    opts.testAppPackage = process.env.TEST_APP_PACKAGE;
+  }
+
+  const builder = new ServerBuilder(LOG, opts);
+  await builder.build();
+}
+
+if (require.main === module) {
+  asyncify(buildEspressoServer);
+}
+
+module.exports = buildEspressoServer;


### PR DESCRIPTION
This is still wip. I'd like to extract the building espresso server via npm command over appium command, eventually.
https://github.com/appium/appium-espresso-driver#espresso-build-config

This does not change the gradle file itself, but it allows users to build the server with some parameters https://github.com/appium/appium-espresso-driver/issues/851 