### PR TITLE
feat: add ability to customise espresso dependency version

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ minSdk | Minimum Android SDK version to compile the server for. By default the v
 targetSdk | Target Android SDK version to compile the server for. By default the version from the app [build.gradle.kts](https://github.com/appium/appium-espresso-driver/blob/master/espresso-server/app/build.gradle.kts) is used | 28
 kotlin | Kotlin version to compile the server for. By default the version from the [build.gradle.kts](https://github.com/appium/appium-espresso-driver/blob/master/espresso-server/build.gradle.kts) is used | '1.3.72'
 composeVersion | The version for the Jetpack Compose dependencies to use for Espresso server building. By default the version from the [build.gradle.kts](https://github.com/appium/appium-espresso-driver/blob/master/espresso-server/build.gradle.kts) is used | '1.1.1'
+espressoVersion | The version for the Espresso dependencies to use for Espresso server building. By default the version from the [build.gradle.kts](https://github.com/appium/appium-espresso-driver/blob/master/espresso-server/build.gradle.kts) is used | '3.5.0'
 sourceCompatibility | The minimum version of JVM the project sources are compatible with. The default value is `VERSION_1_8` | VERSION_12
 targetCompatibility | The target version of JVM the project sources are compatible with. The default value is `VERSION_1_8` | VERSION_12
 jvmTarget | Target version of the generated JVM bytecode as a string. The default value is `1_8` | `1_10`

--- a/espresso-server/app/build.gradle.kts
+++ b/espresso-server/app/build.gradle.kts
@@ -86,6 +86,7 @@ android {
 
 val kotlinVersion = rootProject.extra["appiumKotlin"]
 val composeVersion = getStringProperty("appiumComposeVersion", Version.compose)
+val espressoVersion = getStringProperty("appiumEspressoVersion", Version.espresso)
 val annotationVersion = getStringProperty("appiumAnnotationVersion", Version.annotation)
 
 dependencies {
@@ -97,9 +98,9 @@ dependencies {
     testImplementation("org.powermock:powermock-module-junit4-rule:${Version.mocklib}")
     testImplementation("org.powermock:powermock-module-junit4:${Version.mocklib}")
     testImplementation("androidx.annotation:annotation:${annotationVersion}")
-    testImplementation("androidx.test.espresso:espresso-contrib:${Version.espresso}")
-    testImplementation("androidx.test.espresso:espresso-core:${Version.espresso}")
-    testImplementation("androidx.test.espresso:espresso-web:${Version.espresso}")
+    testImplementation("androidx.test.espresso:espresso-contrib:${espressoVersion}")
+    testImplementation("androidx.test.espresso:espresso-core:${espressoVersion}")
+    testImplementation("androidx.test.espresso:espresso-web:${espressoVersion}")
     testImplementation("androidx.test.uiautomator:uiautomator:${Version.uia}")
     testImplementation("androidx.test:core:${Version.testlib}")
     testImplementation("androidx.test:runner:${Version.testlib}")
@@ -116,12 +117,12 @@ dependencies {
     testImplementation("androidx.compose.ui:ui-test-junit4:${composeVersion}")
 
     androidTestImplementation("androidx.annotation:annotation:${annotationVersion}")
-    androidTestImplementation("androidx.test.espresso:espresso-contrib:${Version.espresso}") {
+    androidTestImplementation("androidx.test.espresso:espresso-contrib:${espressoVersion}") {
         // Exclude transitive dependencies to limit conflicts with AndroidX libraries from AUT.
         // Link to PR with fix and discussion https://github.com/appium/appium-espresso-driver/pull/596
         isTransitive = false
     }
-    androidTestImplementation("androidx.test.espresso:espresso-web:${Version.espresso}") {
+    androidTestImplementation("androidx.test.espresso:espresso-web:${espressoVersion}") {
         because("Espresso Web Atoms support (mobile: webAtoms)")
     }
     androidTestImplementation("androidx.test.uiautomator:uiautomator:${Version.uia}") {

--- a/lib/server-builder.js
+++ b/lib/server-builder.js
@@ -23,6 +23,7 @@ const VERSION_KEYS = [
   'targetCompatibility',
   'jvmTarget',
   'composeVersion',
+  'espressoVersion',
   'annotationVersion'
 ];
 


### PR DESCRIPTION
- Recent espresso version bump to [3.5.1](https://github.com/appium/appium-espresso-driver/commit/2193c252cd8f975cd1e9391f594a41d70badd26b#diff-189ca601c158e86b4aeb3c6c244400608b9ed011af10276cdc10884a9a05525aR162) found to be quite flaky for us, especially tests taking twice longer(e.g findElement/s with xpath significantly slower).
- The proposed changes would give possibility to parameterise espresso version.