### PR TITLE
fix: build app with Gradle 8.x

### DIFF
--- a/espresso-server/app/build.gradle.kts
+++ b/espresso-server/app/build.gradle.kts
@@ -82,6 +82,8 @@ android {
     packagingOptions {
         resources.excludes.add("META-INF/**")
     }
+
+    namespace = "io.appium.espressoserver"
 }
 
 val kotlinVersion = rootProject.extra["appiumKotlin"]

--- a/espresso-server/app/src/main/AndroidManifest.xml
+++ b/espresso-server/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.appium.espressoserver">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />


### PR DESCRIPTION
Fixes: #871

On gradle 8.0 and up, the package name needs to be moved from the manifest file to the build.gradle file