### PR TITLE
feat: remove isTransitive in compose for newer compose versions

### DIFF
--- a/espresso-server/app/build.gradle.kts
+++ b/espresso-server/app/build.gradle.kts
@@ -141,7 +141,6 @@ dependencies {
         because("Android Compose support")
     }
     androidTestImplementation("androidx.compose.ui:ui-test-junit4:${composeVersion}") {
-        isTransitive = false
         because("Android Compose support")
     }
 

--- a/espresso-server/app/build.gradle.kts
+++ b/espresso-server/app/build.gradle.kts
@@ -172,7 +172,7 @@ object Version {
     const val mockito = "5.1.1"
     const val robolectric = "4.9.2"
     const val junit = "4.13.2"
-    const val compose = "1.1.1"
+    const val compose = "1.4.3"
 }
 
 fun Project.getStringProperty(name: String, default: String): String =

--- a/espresso-server/app/build.gradle.kts
+++ b/espresso-server/app/build.gradle.kts
@@ -171,7 +171,7 @@ object Version {
     const val mockito = "5.1.1"
     const val robolectric = "4.9.2"
     const val junit = "4.13.2"
-    const val compose = "1.4.3"
+    const val compose = "1.1.0"
 }
 
 fun Project.getStringProperty(name: String, default: String): String =

--- a/espresso-server/app/build.gradle.kts
+++ b/espresso-server/app/build.gradle.kts
@@ -171,7 +171,7 @@ object Version {
     const val mockito = "5.1.1"
     const val robolectric = "4.9.2"
     const val junit = "4.13.2"
-    const val compose = "1.1.0"
+    const val compose = "1.1.1"
 }
 
 fun Project.getStringProperty(name: String, default: String): String =


### PR DESCRIPTION
It seems like `isTransitive = false` caused below error when the compose version was `1.4.3`

```
[debug] [EspressoDriver@633b (599df58e)] [Instrumentation] io.appium.espressoserver.EspressoServerRunnerTest:
[debug] [EspressoDriver@633b (599df58e)] [Instrumentation] Error in startEspressoServer(io.appium.espressoserver.EspressoServerRunnerTest):
[debug] [EspressoDriver@633b (599df58e)] java.lang.AbstractMethodError: abstract method "kotlin.coroutines.CoroutineContext$Key androidx.compose.ui.platform.InfiniteAnimationPolicy.getKey()"
[debug] [EspressoDriver@633b (599df58e)] 	at kotlin.coroutines.CoroutineContext$plus$1.invoke(CoroutineContext.kt:33)
[debug] [EspressoDriver@633b (599df58e)] 	at kotlin.coroutines.CoroutineContext$plus$1.invoke(CoroutineContext.kt:32)
[debug] [EspressoDriver@633b (599df58e)] 	at kotlin.coroutines.CoroutineContext$Element$DefaultImpls.fold(CoroutineContext.kt:70)
[debug] [EspressoDriver@633b (599df58e)] 	at androidx.compose.ui.platform.InfiniteAnimationPolicy$DefaultImpls.fold(InfiniteAnimationPolicy.kt:36)
[debug] [EspressoDriver@633b (599df58e)] 	at androidx.compose.ui.test.AndroidComposeUiTestEnvironment$infiniteAnimationPolicy$1.fold(ComposeUiTest.android.kt:271)
[debug] [EspressoDriver@633b (599df58e)] 	at kotlin.coroutines.CoroutineContext$DefaultImpls.plus(CoroutineContext.kt:32)
[debug] [EspressoDriver@633b (599df58e)] 	at kotlin.coroutines.CombinedContext.plus(CoroutineContextImpl.kt:111)
[debug] [EspressoDriver@633b (599df58e)] 	at androidx.compose.ui.test.AndroidComposeUiTestEnvironment.<init>(ComposeUiTest.android.kt:280)
[debug] [EspressoDriver@633b (599df58e)] 	at androidx.compose.ui.test.junit4.AndroidComposeTestRule$special$$inlined$AndroidComposeUiTestEnvironment$1.<init>(ComposeUiTest.android.kt:218)
[debug] [EspressoDriver@633b (599df58e)] 	at androidx.compose.ui.test.junit4.AndroidComposeTestRule.<init>(AndroidComposeTestRule.android.kt:352)
[debug] [EspressoDriver@633b (599df58e)] 	at androidx.compose.ui.test.junit4.AndroidComposeTestRule.<init>(AndroidComposeTestRule.android.kt:224)
[debug] [EspressoDriver@633b (599df58e)] 	at io.appium.espressoserver.EspressoServerRunnerTest.<init>(EspressoServerRunnerTest.kt:45)
[debug] [EspressoDriver@633b (599df58e)] [Instrumentation] Time: 0.047
```

Potentially this will fix https://github.com/appium/appium-espresso-driver/issues/812 as well.