### PR TITLE
fix: error message of espresso attribute

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetAttribute.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/GetAttribute.kt
@@ -101,7 +101,7 @@ class GetAttribute : RequestHandler<AppiumParams, String?> {
             // If it's a TEXT attribute, return the view's raw text
             AttributesEnum.TEXT -> return ViewTextGetter()[viewInteractionGetter()].rawText
             else -> throw NotYetImplementedException(
-                "Espresso doesn't support attribute '$attributeName', Attribute name should be one of ${composeAttributes.supportedAttributes()}\"")
+                "Espresso doesn't support attribute '$attributeName', Attribute name should be one of ${espressoAttributes.supportedAttributes()}\"")
         }
     }
 }


### PR DESCRIPTION
These lines handle `espressoAttributes` stuff, so the error message also should be `espressoAttributes` instead of composeAttributes 