### PR TITLE
ci: add api-32 to functional test targets

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -8,18 +8,26 @@ jobs:
     strategy:
       matrix:
         include:
+        - chromedriverVersion: "113.0.5672.63"
+          apiLevel: 32
+          emuTag: google_apis
+          arch: x86_64
         - chromedriverVersion: "83.0.4103.39"
           apiLevel: 30
           emuTag: google_apis
+          arch: x86
         - chromedriverVersion: "74.0.3729.6"
           apiLevel: 29
           emuTag: default
+          arch: x86
         - chromedriverVersion: "2.28"
           apiLevel: 25
           emuTag: default
+          arch: x86
         - chromedriverVersion: "2.20"
           apiLevel: 23
           emuTag: default
+          arch: x86
 
     env:
       CI: true
@@ -74,6 +82,9 @@ jobs:
         api-level: ${{ matrix.apiLevel }}
         disable-spellchecker: true
         target: ${{ matrix.emuTag }}
+        arch: ${{ matrix.arch }}
+        ram-size: 4096M
+        heap-size: 1024M
     - name: Save logcat output
       if: ${{ always() }}
       uses: actions/upload-artifact@master


### PR DESCRIPTION
This PR adds API-32 to CI targets.
ref. https://github.com/appium/appium-uiautomator2-driver/pull/614#issuecomment-1572384137