### PR TITLE
feat: Disable screenshots and hierarchy snapshots on failures

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/CustomFailureHandler.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/helpers/CustomFailureHandler.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2014 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.espressoserver.lib.helpers
+
+import android.content.Context
+import android.view.View
+import androidx.test.espresso.FailureHandler
+import androidx.test.espresso.base.DefaultFailureHandler
+import org.hamcrest.Matcher
+import java.util.concurrent.atomic.AtomicInteger
+
+class CustomFailureHandler(appContext: Context) : FailureHandler {
+    private val originalHandler = DefaultFailureHandler(appContext)
+
+    override fun handle(error: Throwable?, viewMatcher: Matcher<View>?) {
+        val failureCountField = DefaultFailureHandler::class.java.getDeclaredField("failureCount")
+        failureCountField.isAccessible = true
+        (failureCountField.get(originalHandler) as AtomicInteger).incrementAndGet()
+
+        val handlersField = DefaultFailureHandler::class.java.getDeclaredField("handlers")
+        handlersField.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        for (handler in (handlersField.get(originalHandler) as java.util.ArrayList<FailureHandler>)) {
+            handler.handle(error, viewMatcher)
+        }
+    }
+}

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Server.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/http/Server.kt
@@ -16,9 +16,12 @@
 
 package io.appium.espressoserver.lib.http
 
+import androidx.test.espresso.Espresso
+import androidx.test.platform.app.InstrumentationRegistry
 import com.google.gson.GsonBuilder
 import fi.iki.elonen.NanoHTTPD
 import io.appium.espressoserver.lib.helpers.AndroidLogger
+import io.appium.espressoserver.lib.helpers.CustomFailureHandler
 import io.appium.espressoserver.lib.helpers.StringHelpers
 import io.appium.espressoserver.lib.helpers.setAccessibilityServiceState
 import io.appium.espressoserver.lib.http.response.AppiumResponse
@@ -86,6 +89,7 @@ object Server : NanoHTTPD(DEFAULT_PORT) {
         }
 
         setAccessibilityServiceState()
+        setCustomFailureHandler()
 
         try {
             super.start(SOCKET_READ_TIMEOUT, false)
@@ -97,6 +101,11 @@ object Server : NanoHTTPD(DEFAULT_PORT) {
         AndroidLogger.info("\nRunning Appium Espresso Server at port $DEFAULT_PORT\n")
         router = Router()
     }
+
+    private fun setCustomFailureHandler() =
+        Espresso.setFailureHandler(
+            CustomFailureHandler(InstrumentationRegistry.getInstrumentation().targetContext)
+        )
 
     override fun stop() {
         super.stop()


### PR DESCRIPTION
Similar to https://github.com/appium/appium-espresso-driver/pull/894, but should also work for earlier Espresso versions