### PR TITLE
fix: calls this.settings in settings handling

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -322,11 +322,14 @@ commands.mobileClickAction = async function mobileClickAction (opts = {}) {
 };
 
 commands.updateSettings = async function updateSettings (settings) {
-  return await this.espresso.jwproxy.command(`/appium/settings`, 'POST', { settings });
+  await this.settings.update(settings);
+  await this.espresso.jwproxy.command(`/appium/settings`, 'POST', { settings });
 };
 
 commands.getSettings = async function getSettings () {
-  return await this.espresso.jwproxy.command(`/appium/settings`, 'GET');
+  const driverSettings = this.settings.getSettings();
+  const serverSettings = await this.espresso.jwproxy.command(`/appium/settings`, 'GET');
+  return {...driverSettings, ...serverSettings};
 };
 
 // Stop proxying to any Chromedriver and redirect to Espresso


### PR DESCRIPTION
As same as UIA2, maybe should this driver also call `this.settings` stuff to call plugins?
Fixes https://github.com/appium/appium-espresso-driver/issues/900