### PR TITLE
fix: do not reply error message in updateSettings to follow other drivers

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -323,7 +323,11 @@ commands.mobileClickAction = async function mobileClickAction (opts = {}) {
 
 commands.updateSettings = async function updateSettings (settings) {
   await this.settings.update(settings);
-  await this.espresso.jwproxy.command(`/appium/settings`, 'POST', { settings });
+  try {
+    await this.espresso.jwproxy.command(`/appium/settings`, 'POST', { settings });  
+  } catch (err) {
+    this.log.warn(`The espresso driver returned an error. ${err.message}`);
+  };
 };
 
 commands.getSettings = async function getSettings () {

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -321,12 +321,23 @@ commands.mobileClickAction = async function mobileClickAction (opts = {}) {
   });
 };
 
+/**
+ * @typedef {Object} SettingsOptions
+ * @property {!string|number|boolean} Object Settings parameters that is available in
+ * https://github.com/appium/appium-espresso-driver#settings-api or enabled plugins.
+ */
+
+/**
+ * Apply the given settings to the espresso driver and the espresso server.
+ * Errors by the espresso server will be printed as log, but it does not return an error message.
+ * @param {SettingsOptions} settings
+ */
 commands.updateSettings = async function updateSettings (settings) {
   await this.settings.update(settings);
   try {
-    await this.espresso.jwproxy.command(`/appium/settings`, 'POST', { settings });  
+    await this.espresso.jwproxy.command(`/appium/settings`, 'POST', { settings });
   } catch (err) {
-    this.log.warn(`The espresso driver returned an error. ${err.message}`);
+    this.log.warn(`The espresso driver responded an error. Original error: ${err.message}`);
   };
 };
 


### PR DESCRIPTION
As same as other drivers, espresso driver also does not return an error to the client. Instead, the error response by the espresso server will be the appium log.



example:
```
[HTTP] --> POST /session/37f7067e-2470-4984-a4bc-237f8dc60b6b/appium/settings
[HTTP] {"settings":{"animationCoolOffTimeout":0,"waitForIdleTimeout":1}}
[debug] [EspressoDriver@e161 (37f7067e)] Calling AppiumDriver.updateSettings() with args: [{"animationCoolOffTimeout":0,"waitForIdleTimeout":1},"37f7067e-2470-4984-a4bc-237f8dc60b6b"]
[debug] [EspressoDriver@e161 (37f7067e)] Matched '/appium/settings' to command name 'updateSettings'
[debug] [EspressoDriver@e161 (37f7067e)] Proxying [POST /appium/settings] to [POST http://127.0.0.1:8300/session/15112ec3-ba21-48f1-927d-761a0df577a0/appium/settings] with body: {"settings":{"animationCoolOffTimeout":0,"waitForIdleTimeout":1}}
[EspressoDriver@e161 (37f7067e)] Got response with status 400: {"id":"c5171a9e-0332-480d-ab04-bb0efbc0eb2b","sessionId":"15112ec3-ba21-48f1-927d-761a0df577a0","value":{"error":"invalid argument","message":"Could not find matching setting. Known setting names are: [driver]","stacktrace":"io.appium.espressoserver.lib.handlers.exceptions.InvalidArgumentException: Could not find matching setting. Known setting names are: [driver]\n\tat io.appium.espressoserver.lib.handlers.UpdateSettings.getSetting(UpdateSettings.kt:30)\n\tat io.appium.espressoserver.lib.handlers.UpdateSettings.handleInternal(UpdateSettings.kt:26)\n\tat io.appium.espressoserver.lib.handlers.UpdateSettings.handleInternal(UpdateSettings.kt:24)\n\tat io.appium.espressoserver.lib.handlers.RequestHandler$DefaultImpls.handle(RequestHandler.kt:57)\n\tat io.appium.espressoserver.lib.handlers.UpdateSettings.handle(UpdateSettings.kt:24)\n\tat io.appium.espressoserver.lib.handlers.UpdateSettings.handle(UpdateSettings.kt:24)\n\tat io.appium.espressoserver.lib.http.Router.route(Router.kt:231)\n\tat io.appium.espressos...
[debug] [W3C] Matched W3C error code 'invalid argument' to InvalidArgumentError
[EspressoDriver@e161 (37f7067e)] The espresso driver returned an error. Original error: Could not find matching setting. Known setting names are: [driver]
[debug] [EspressoDriver@e161 (37f7067e)] Responding to client with driver.updateSettings() result: null
[HTTP] <-- POST /session/37f7067e-2470-4984-a4bc-237f8dc60b6b/appium/settings 200 31 ms - 14
```

closes https://github.com/appium/appium-espresso-driver/issues/900