### PR TITLE
chore(deps-dev): revert “bump semantic-release from 20.1.3 to 21.1.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "mocha": "^10.0.0",
     "pre-commit": "^1.2.2",
     "rimraf": "^5.0.0",
-    "semantic-release": "^21.1.0",
+    "semantic-release": "^20.0.2",
     "sinon": "^15.0.0",
     "webdriverio": "^8.0.2",
     "xpath": "^0.x"


### PR DESCRIPTION
Reverts appium/appium-espresso-driver#904

https://github.com/appium/appium-espresso-driver/issues/905
saw the same one in the ruby_lib_core tests as well. I’ll take a look later further what happened