### PR TITLE
fix: signingConfigs for test apk

### DIFF
--- a/espresso-server/app/build.gradle.kts
+++ b/espresso-server/app/build.gradle.kts
@@ -43,19 +43,19 @@ android {
     signingConfigs {
         getByName("debug") {
             findProperty("appiumKeystoreFile")?.also {
-                storeFile.apply { file(it.toString()) }
+                storeFile = file(it.toString())
             }
 
             findProperty("appiumKeystorePassword")?.also {
-                storePassword.apply { file(it.toString()) }
+                storePassword = it.toString()
             }
 
             findProperty("appiumKeyAlias")?.also {
-                keyAlias.apply { file(it.toString()) }
+                keyAlias = it.toString()
             }
 
             findProperty("appiumKeyPassword")?.also {
-                keyPassword.apply { file(it.toString()) }
+                keyPassword = it.toString()
             }
         }
     }


### PR DESCRIPTION
Fixes issue when passing `-PappiumKeystoreFile=/storeFile -PappiumKeystorePassword=passwd1 ... ` did not result in properly signed binary. It was always signed by `AndroidDebugKey`

Root cause of the issue - incorrect use of `apply` API in place, and creating File instance for passwords and alias.

How to verify:

```shell
./gradlew \
      signingReport
```

vs:

```shell
./gradlew \
      -PappiumZipAlign=true \
      -PappiumKeystoreFile="${PWD}/my_ci.keystore" \
      -PappiumKeystorePassword=my_ci_store_password \
      -PappiumKeyAlias=my_alias \
      -PappiumKeyPassword=my_ci_key_password \
      -PappiumTargetPackage=my.package \
      signingReport
```