### PR TITLE
Revert "chore(deps-dev): bump semantic-release from 20.1.3 to 22.0.5"

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "mocha": "^10.0.0",
     "pre-commit": "^1.2.2",
     "rimraf": "^5.0.0",
-    "semantic-release": "^22.0.5",
+    "semantic-release": "^20.0.2",
     "sinon": "^16.0.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.1.6",


### PR DESCRIPTION
Reverts appium/appium-espresso-driver#916

The same issue reported after https://github.com/appium/appium-espresso-driver/pull/909 occurred in https://github.com/appium/appium-espresso-driver/issues/931

```
kazu@laptop espresso-server % ls
app                 build.gradle.kts    gradle.properties   gradlew             gradlew.bat         lint.xml            settings.gradle.kts
kazu@laptop espresso-server % ./gradlew
Error: Could not find or load main class org.gradle.wrapper.GradleWrapperMain
Caused by: java.lang.ClassNotFoundException: org.gradle.wrapper.GradleWrapperMain
```

I haven't dug into the root cause, but it seems like gradlew is broken right now