### PR TITLE
chore: bump kotlin and compose deps versions

### DIFF
--- a/espresso-server/app/build.gradle.kts
+++ b/espresso-server/app/build.gradle.kts
@@ -171,7 +171,7 @@ object Version {
     const val mockito = "5.1.1"
     const val robolectric = "4.9.2"
     const val junit = "4.13.2"
-    const val compose = "1.1.1"
+    const val compose = "1.5.4"
 }
 
 fun Project.getStringProperty(name: String, default: String): String =

--- a/espresso-server/build.gradle.kts
+++ b/espresso-server/build.gradle.kts
@@ -2,7 +2,7 @@
 
 buildscript {
     extra.apply {
-        set("appiumKotlin", properties.getOrDefault("appiumKotlin", "1.8.10"))
+        set("appiumKotlin", properties.getOrDefault("appiumKotlin", "1.9.10"))
         set(
             "appiumAndroidGradlePlugin",
             properties.getOrDefault("appiumAndroidGradlePlugin", "7.4.2")

--- a/test/functional/desired.js
+++ b/test/functional/desired.js
@@ -29,11 +29,7 @@ const APIDEMO_CAPS = amendCapabilities(GENERIC_CAPS, {
 });
 
 const COMPOSE_CAPS = amendCapabilities(GENERIC_CAPS, {
-  'appium:app': path.resolve('test', 'assets', 'compose_playground.apk'),
-  'appium:espressoBuildConfig': '{"additionalAndroidTestDependencies": ' +
-    '["androidx.lifecycle:lifecycle-extensions:2.2.0", ' +
-    '"androidx.activity:activity:1.3.1", ' +
-    '"androidx.fragment:fragment:1.3.4"]}'
+  'appium:app': path.resolve('test', 'assets', 'compose_playground.apk')
 });
 
 // http://www.impressive-artworx.de/tutorials/android/gps_tutorial_1.zip


### PR DESCRIPTION
Small default version bump.

These can be configured via `espressoBuildConfig` so users can specify old ones with it. These had no issue in our testing app