### PR TITLE
feat: Return web atom response

### DIFF
--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/WebAtoms.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/WebAtoms.kt
@@ -29,10 +29,10 @@ import io.appium.espressoserver.lib.model.EspressoElement
 import io.appium.espressoserver.lib.model.web.WebAtomsParams
 import io.appium.espressoserver.lib.viewmatcher.withView
 
-class WebAtoms : RequestHandler<WebAtomsParams, String> {
+class WebAtoms : RequestHandler<WebAtomsParams, Any> {
 
     @Throws(AppiumException::class)
-    override fun handleInternal(params: WebAtomsParams): String {
+    override fun handleInternal(params: WebAtomsParams): Any {
         var webViewInteraction: WebInteraction<*>
 
         // TODO: Add a 'waitForDocument' feature to wait for HTML DOCUMENT to be ready
@@ -69,6 +69,6 @@ class WebAtoms : RequestHandler<WebAtomsParams, String> {
             webViewInteraction = res
         }
 
-        return if (params.methodChain.size == 1) "success" else webViewInteraction.get().toString()
+        return webViewInteraction.get()
     }
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/WebAtoms.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/WebAtoms.kt
@@ -68,7 +68,7 @@ class WebAtoms : RequestHandler<WebAtomsParams, Any> {
 
             webViewInteraction = res
         }
-
-        return webViewInteraction.get()
+        // param size check is for the case when we want to check element exists but don't have any action to perform
+        return if (params.methodChain.size == 1) "success" else webViewInteraction.get()
     }
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/WebAtoms.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/WebAtoms.kt
@@ -54,21 +54,21 @@ class WebAtoms : RequestHandler<WebAtomsParams, Any?> {
         params.methodChain.forEach { method ->
             val atom = invokeStaticMethod(DriverAtoms::class.java, method.atom.name, *method.atom.args) as? Atom<*>
                 ?: throw InvalidArgumentException(
-                    "'${method.atom.name}' did not return a valid " +
-                        "'${Atom::class.qualifiedName}' object",
+                    "'${method.atom.name}' did not return a valid '${Atom::class.qualifiedName}' object",
                 )
 
             AndroidLogger.info("Calling interaction '${method.name}' with the atom '${method.atom}'")
 
             val res = invokeInstanceMethod(webViewInteraction, method.name, atom) as? WebInteraction<*>
                 ?: throw InvalidArgumentException(
-                    "'${method.name}' does not return a valid " +
-                        "'${WebInteraction::class.qualifiedName}' object",
+                    "'${method.name}' does not return a valid '${WebInteraction::class.qualifiedName}' object",
                 )
 
             webViewInteraction = res
         }
-        // param size check is for the case when we want to check element exists but don't have any action to perform
-        return if (params.methodChain.size == 1) "success" else webViewInteraction.get()
+        // if you don't pass any action to perform `webViewInteraction.get()` will throw error
+        // java.lang.IllegalStateException: Perform or Check never called on this WebInteraction!
+        // when you just want to just check element existence call with `selectActiveElement` as action
+        return webViewInteraction.get()
     }
 }

--- a/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/WebAtoms.kt
+++ b/espresso-server/app/src/androidTest/java/io/appium/espressoserver/lib/handlers/WebAtoms.kt
@@ -29,10 +29,10 @@ import io.appium.espressoserver.lib.model.EspressoElement
 import io.appium.espressoserver.lib.model.web.WebAtomsParams
 import io.appium.espressoserver.lib.viewmatcher.withView
 
-class WebAtoms : RequestHandler<WebAtomsParams, Any> {
+class WebAtoms : RequestHandler<WebAtomsParams, Any?> {
 
     @Throws(AppiumException::class)
-    override fun handleInternal(params: WebAtomsParams): Any {
+    override fun handleInternal(params: WebAtomsParams): Any? {
         var webViewInteraction: WebInteraction<*>
 
         // TODO: Add a 'waitForDocument' feature to wait for HTML DOCUMENT to be ready


### PR DESCRIPTION
Fixes: https://github.com/appium/appium-espresso-driver/issues/937

I'm not too happy with the return value.
```kotlin
return if (params.methodChain.size == 1) "success" else webViewInteraction.get().toString()
```

However, the request handler is handling all webAtom methods available in https://developer.android.com/reference/androidx/test/espresso/web/webdriver/DriverAtoms#public-methods. So not sure how to handle the different return types of all methods available.