### PR TITLE
fix: use specific android driver for now to fix the build (for now)

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   ],
   "dependencies": {
     "appium-adb": "^12.0.0",
-    "appium-android-driver": "^8.1.6",
+    "appium-android-driver": "8.1.7",
     "asyncbox": "^3.0.0",
     "bluebird": "^3.5.0",
     "io.appium.settings": "^5.7.2",


### PR DESCRIPTION
it looks like android driver 8.1.8+ start causing below build error:

```
lib/commands/app-management.js:30:16 - error TS2684: The 'this' context of type 'EspressoDriver' is not assignable to method's 'this' of type 'AndroidDriver'.
  Types of property 'suspendChromedriverProxy' are incompatible.
    Type 'typeof import("/Users/kazu/GitHub/appium-espresso-driver/lib/commands/context").suspendChromedriverProxy' is not assignable to type 'typeof import("/Users/kazu/GitHub/appium-espresso-driver/node_modules/appium-android-driver/build/lib/commands/context/exports").suspendChromedriverProxy'.

30   return await this.background(seconds);
                  ~~~~

lib/driver.ts:219:25 - error TS2684: The 'this' context of type 'this' is not assignable to method's 'this' of type 'AndroidDriver'.
  Type 'EspressoDriver' is not assignable to type 'AndroidDriver'.
    Types of property 'suspendChromedriverProxy' are incompatible.
      Type 'typeof import("/Users/kazu/GitHub/appium-espresso-driver/lib/commands/context").suspendChromedriverProxy' is not assignable to type 'typeof import("/Users/kazu/GitHub/appium-espresso-driver/node_modules/appium-android-driver/build/lib/commands/context/exports").suspendChromedriverProxy'.

219       this.curContext = this.defaultContextName();
                            ~~~~

lib/driver.ts:244:36 - error TS2684: The 'this' context of type 'this' is not assignable to method's 'this' of type 'AndroidDriver'.

244       const {udid, emPort} = await this.getDeviceInfoFromCaps();
                                       ~~~~

lib/driver.ts:250:24 - error TS2684: The 'this' context of type 'this' is not assignable to method's 'this' of type 'AndroidDriver'.

250       this.adb = await this.createADB();
                           ~~~~

lib/driver.ts:397:25 - error TS2684: The 'this' context of type 'this' is not assignable to method's 'this' of type 'AndroidDriver'.

397     let appInfo = await this.getLaunchInfo();
                            ~~~~

lib/driver.ts:409:11 - error TS2684: The 'this' context of type 'this' is not assignable to method's 'this' of type 'AndroidDriver'.

409     await this.initDevice();
              ~~~~

lib/driver.ts:500:22 - error TS2684: The 'this' context of type 'this' is not assignable to method's 'this' of type 'AndroidDriver'.

500     const viewName = this.defaultWebviewName();
                         ~~~~

lib/driver.ts:556:13 - error TS2684: The 'this' context of type 'this' is not assignable to method's 'this' of type 'AndroidDriver'.

556       await this.uninstallOtherPackages(
                ~~~~

lib/driver.ts:568:15 - error TS2684: The 'this' context of type 'this' is not assignable to method's 'this' of type 'AndroidDriver'.

568         await this.resetAUT();
                  ~~~~

lib/driver.ts:576:13 - error TS2684: The 'this' context of type 'this' is not assignable to method's 'this' of type 'AndroidDriver'.

576       await this.installAUT();
                ~~~~

lib/driver.ts:596:15 - error TS2684: The 'this' context of type 'this' is not assignable to method's 'this' of type 'AndroidDriver'.

596         await this.stopRecordingScreen();
                  ~~~~

lib/driver.ts:599:17 - error TS2684: The 'this' context of type 'this' is not assignable to method's 'this' of type 'AndroidDriver'.

599       if (await this.mobileIsMediaProjectionRecordingRunning()) {
                    ~~~~

lib/driver.ts:600:15 - error TS2684: The 'this' context of type 'this' is not assignable to method's 'this' of type 'AndroidDriver'.

600         await this.mobileStopMediaProjectionRecording();
                  ~~~~

lib/driver.ts:604:15 - error TS2684: The 'this' context of type 'this' is not assignable to method's 'this' of type 'AndroidDriver'.

604         await this.mobileStopScreenStreaming();
                  ~~~~

lib/driver.ts:700:12 - error TS2416: Property 'executeMobile' in type 'EspressoDriver' is not assignable to the same property in base type 'AndroidDriver'.
  Type '(this: EspressoDriver, mobileCommand: string, opts?: Record<string, any> | undefined) => Promise<any>' is not assignable to type '(this: AndroidDriver, mobileCommand: string, opts?: StringRecord<any> | undefined) => Promise<any>'.
    The 'this' types of each signature are incompatible.
      Type 'AndroidDriver' is missing the following properties from type 'EspressoDriver': _originalIme, espresso, unzipApp, onPostConfigureApp, and 34 more.

700   override executeMobile = executeCmds.executeMobile;
               ~~~~~~~~~~~~~

lib/driver.ts:711:3 - error TS2416: Property 'suspendChromedriverProxy' in type 'EspressoDriver' is not assignable to the same property in base type 'AndroidDriver'.
  Type 'typeof import("/Users/kazu/GitHub/appium-espresso-driver/lib/commands/context").suspendChromedriverProxy' is not assignable to type 'typeof import("/Users/kazu/GitHub/appium-espresso-driver/node_modules/appium-android-driver/build/lib/commands/context/exports").suspendChromedriverProxy'.
    The 'this' types of each signature are incompatible.
      Type 'AndroidDriver' is not assignable to type 'EspressoDriver'.

711   suspendChromedriverProxy = contextCmds.suspendChromedriverProxy;
      ~~~~~~~~~~~~~~~~~~~~~~~~

lib/driver.ts:713:3 - error TS2416: Property 'mobilePerformEditorAction' in type 'EspressoDriver' is not assignable to the same property in base type 'AndroidDriver'.
  Type '(this: EspressoDriver, opts: PerformEditorActionOpts) => Promise<void>' is not assignable to type '(this: AndroidDriver, opts: PerformEditorActionOpts) => Promise<void>'.
    The 'this' types of each signature are incompatible.
      Type 'AndroidDriver' is not assignable to type 'EspressoDriver'.

713   mobilePerformEditorAction = elementCmds.mobilePerformEditorAction;
      ~~~~~~~~~~~~~~~~~~~~~~~~~

lib/driver.ts:729:3 - error TS2416: Property 'getDisplayDensity' in type 'EspressoDriver' is not assignable to the same property in base type 'AndroidDriver'.
  Type '(this: EspressoDriver) => Promise<number>' is not assignable to type '(this: AndroidDriver) => Promise<number>'.
    The 'this' types of each signature are incompatible.
      Type 'AndroidDriver' is not assignable to type 'EspressoDriver'.

729   getDisplayDensity = miscCmds.getDisplayDensity;
      ~~~~~~~~~~~~~~~~~

lib/driver.ts:736:3 - error TS2416: Property 'mobileStartService' in type 'EspressoDriver' is not assignable to the same property in base type 'AndroidDriver'.
  Type '(this: EspressoDriver, opts: StartServiceOptions) => Promise<string>' is not assignable to type '(this: AndroidDriver, opts?: StartServiceOpts | undefined) => Promise<string>'.
    The 'this' types of each signature are incompatible.
      Type 'AndroidDriver' is not assignable to type 'EspressoDriver'.

736   mobileStartService = servicesCmds.mobileStartService;
      ~~~~~~~~~~~~~~~~~~

lib/driver.ts:737:3 - error TS2416: Property 'mobileStopService' in type 'EspressoDriver' is not assignable to the same property in base type 'AndroidDriver'.
  Type '(this: EspressoDriver, opts: StopServiceOptions) => Promise<string>' is not assignable to type '(this: AndroidDriver, opts?: IntentOpts | undefined) => Promise<string>'.
    The 'this' types of each signature are incompatible.
      Type 'AndroidDriver' is not assignable to type 'EspressoDriver'.

737   mobileStopService = servicesCmds.mobileStopService;
      ~~~~~~~~~~~~~~~~~


Found 20 errors.

npm ERR! code 1
npm ERR! path /Users/kazu/GitHub/appium-espresso-driver
npm ERR! command failed
npm ERR! command sh -c npm run rebuild

npm ERR! A complete log of this run can be found in:
```

lets use `8.1.7` right now, and see how can i fix them..