### PR TITLE
fix: add overload to fix type issue

### DIFF
--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -51,6 +51,7 @@ export async function reset () {
 }
 
 /**
+ * @overload
  * @typedef {Object} StartActivityOptions
  * @property {string} appActivity
  * @property {string} [locale]
@@ -63,6 +64,7 @@ export async function reset () {
  * Activity could only be executed in scope of the current app package.
  *
  * @this {import('../driver').EspressoDriver}
+ * @overload
  * @param {StartActivityOptions} opts
  * @returns {Promise<string>}
  */

--- a/lib/driver.ts
+++ b/lib/driver.ts
@@ -704,7 +704,6 @@ export class EspressoDriver extends AndroidDriver implements ExternalDriver<
   reset = appManagementCmds.reset;
   mobileBackgroundApp = appManagementCmds.mobileBackgroundApp;
   startActivity = appManagementCmds.startActivity;
-  // @ts-ignore Params there are ok
   mobileStartActivity = appManagementCmds.mobileStartActivity;
 
   mobileWebAtoms = contextCmds.mobileWebAtoms;


### PR DESCRIPTION
Figured out the "overload" fixed https://github.com/appium/appium-espresso-driver/pull/975


https://austingil.com/typescript-function-overloads-with-jsdoc/


So, if CI passes (simple npm install as well), this will be ok