### PR TITLE
fix: proxy request to the espresso server with nativeWebScreenshot

### DIFF
--- a/lib/commands/screenshot.js
+++ b/lib/commands/screenshot.js
@@ -75,3 +75,17 @@ export async function mobileScreenshots (opts = {}) {
   }
   return infos;
 }
+
+/**
+ * Return the base 64 encoded screenshot data.
+ *
+ * @this {import('../driver').EspressoDriver}
+ * @returns {Promise<String>}
+ */
+export async function getScreenshot() {
+  return String(
+    await /** @type {import('../espresso-runner').EspressoRunner} */ (
+      this.espresso
+    ).jwproxy.command('/screenshot', 'GET')
+  );
+}

--- a/lib/commands/screenshot.js
+++ b/lib/commands/screenshot.js
@@ -78,6 +78,10 @@ export async function mobileScreenshots (opts = {}) {
 
 /**
  * Return the base 64 encoded screenshot data.
+ * This method is called only when `appium:nativeWebScreenshot` is enabled
+ * to avoid proxying requests to the chromedriver.
+ * Without `appium:nativeWebScreenshot` or disabled, espresso driver
+ * proxies screenshot endpoint requests to the espresso server directly.
  *
  * @this {import('../driver').EspressoDriver}
  * @returns {Promise<String>}

--- a/lib/driver.ts
+++ b/lib/driver.ts
@@ -735,6 +735,7 @@ export class EspressoDriver extends AndroidDriver implements ExternalDriver<
   mobileStartService = servicesCmds.mobileStartService;
   mobileStopService = servicesCmds.mobileStopService;
 
+  getScreenshot = screenshotCmds.getScreenshot;
   mobileScreenshots = screenshotCmds.mobileScreenshots;
 
   mobileRegisterIdlingResources = idlingResourcesCmds.mobileRegisterIdlingResources;


### PR DESCRIPTION
Fixes https://github.com/appium/appium-inspector/issues/1273

With `nativeWebScreenshot`, we want to proxy requests to the espresso server instead of the chromedriver. To handle it, we should add getScreenshot explicitly to prevent not implemented error.

https://github.com/appium/appium-espresso-driver/blob/619d177700084c3916b569397bac922d00d0cf19/lib/driver.ts#L686-L689

It looks like the removal of `getScreenshot` occurred in the appium-android-driver major version update as https://github.com/appium/appium-inspector/issues/1273#issuecomment-1928972593, but the implementation also raised `throw new errors.NotImplementedError('Not implemented');` so I guess somewhere overridend before.

Tested with `"appium:nativeWebScreenshot": true` and without it.


e.g.
```
[HTTP] --> GET /session/b71600c9-5df2-4b1c-8620-aebe7a42824c/screenshot
[HTTP] {}
[EspressoDriver@fdec (b71600c9)] Calling AppiumDriver.getScreenshot() with args: ["b71600c9-5df2-4b1c-8620-aebe7a42824c"]
[EspressoDriver@fdec (b71600c9)] Matched '/screenshot' to command name 'getScreenshot'
[EspressoDriver@fdec (b71600c9)] Proxying [GET /screenshot] to [GET http://127.0.0.1:8300/session/5bfd9d79-6f5b-4b81-b0bb-c6ab17687a75/screenshot] with no body
[EspressoDriver@fdec (b71600c9)] Got response with status 200: {"id":"d7d7bace-940f-4977-923e-ae7404f64b7e","sessionId":"5bfd9d79-6f5b-4b81-b0bb-c6ab17687a75","value":"iVBORw0KGgoAAAANSUhEUgAABDgAAAlgCAIAAADieBCCAAAAAXNSR0IArs4c6QAAAANzQklUCAgI2+FP4AAAIABJREFUeJzs3Xl8TPfi//EzSSQiu4QQEVuI2EI2WxCEUrVXS2kpqlRxWy1fpa22FG1vq9L91i29lP7aqqVFxR6VhZAIEkGQzZJN9k1mfn/M4zvfuedMJpOZSXLwev7Rx8yZcz7nkxnn3s/7nM+i8Pb2FgAAAABATiwauwIAAAAAIEZQAQAAACA7BBUAAAAAskNQAQAAACA7BBUAAAAAskNQAQAAACA7BBUAAAAAskNQAQAAACA7BBUAAAAAskNQAQAAACA7BBUAAAAAsmPV2BXAw83S0tLd3X3EiBGDBg3y9vZu3ry5IAj5+fmpqamnTp06ePDgnTt3qqurG7uaAAAAeMgovL29G7sOePgoFIouXbqsXbu2e/fulpaWCoVC524qlUqpVCYlJb377ruJiYkqlaqB66lHkyZN2rVrJwjCrVu3qqqqGrs6AAAA+C8EFdRZmzZtjh07JghCTflESh1RfH195fB0pVmzZp06dZo4ceKwYcMEQTh27NiuXbuuX79eWlra2FUDAACy5ujo2LVrV19fX0dHR/V/1dsLCwuTkpLU/01OTi4sLGzceor4+vomJSWZq6iVK1fq/Gjt2rXmOosaQUWOXFxcwsLCAgICRNsTExMPHz589+7dRqmVIAhNmzbdsWNHt27dLCyMGd20d+/epUuXmr1WhrO0tBw0aND06dMDAgLs7OzUf4VSqSwpKYmLi9u+fXtkZKQcopSGnZ3d5MmTPT09Ddn5/v37J0+evHr1akVFRX1XDACAx0qbNm3CwsJGjBjRt29fQ/aPiYmJiIg4fPhwZmZmfdetVpMmTZo8efL06dPNUlrf...
[EspressoDriver@fdec (b71600c9)] Responding to client with driver.getScreenshot() result: "iVBORw0KGgoAAAANSUhEUgAABDgAAAlgCAIAAADieBCCAAAAAXNSR0IArs4c6QAAAANzQklUCAgI2+FP4AAAIABJREFUeJzs3Xl8TPfi//EzSSQiu4QQEVuI2EI2WxCEUrVXS2kpqlRxWy1fpa22FG1vq9L91i29lP7aqqVFxR6VhZAIEkGQzZJN9k1mfn/M4zvfuedMJpOZSXLwev7Rx8yZcz7nkxnn3s/7nM+i8Pb2FgAAAABATiwauwIAAAAAIEZQAQAAACA7BBUAAAAAskNQAQAAACA7BBUAAAAAskNQAQAAACA7BBUAAAAAskNQAQAAACA7BBUAAAAAskNQAQAAACA7BBUAAAAAsmPV2BXAw83S0tLd3X3EiBGDBg3y9vZu3ry5IAj5+fmpqamnTp06ePDgnTt3qqurG7uaAAAAeMgovL29G7sOePgoFIouXbqsXbu2e/fulpaWCoVC524qlUqpVCYlJb377ruJiYkqlaqB66lHkyZN2rVrJwjCrVu3qqqqGrs6AAAA+C8EFdRZmzZtjh07JghCTflESh1RfH195fB0pVmzZp06dZo4ceKwYcMEQTh27NiuXbuuX79eWlra2FUDAACy5ujo2LVrV19fX0dHR/V/1dsLCwuTkpLU/01OTi4sLGzceor4+vomJSWZq6iVK1fq/Gjt2rXmOosaQUWOXFxcwsLCAgICRNsTExMPHz589+7dRqmVIAhNmzbdsWNHt27dLCyMGd20d+/epUuXmr1WhrO0tBw0aND06dMDAgLs7OzUf4VSqSwpKYmLi9u+fXtkZKQcopSGnZ3d5MmTPT09Ddn5/v37J0+evHr1akVFRX1XDACAx0qbNm3CwsJGjBjRt29fQ/aPiYmJiIg4fPhwZmZmfdetVpMmTZo8efL06dPNUlrfvn23bdum86MZM2bExMSY5SxqjFGRo+7du0+YMKFnz56i7d7e3nfu3GmsoOLp6Xno0KEmTZoYXUJYWJhCoVCpVLa2tmVlZWasm36Wlpbq...
[HTTP] <-- GET /session/b71600c9-5df2-4b1c-8620-aebe7a42824c/screenshot 200 216 ms - 93256
[HTTP]
[HTTP] --> DELETE /session/b71600c9-5df2-4b1c-8620-aebe7a42824c
```

cc @eglitise