### PR TITLE
fix: Set `shell` option to true while running gradle script on Windows

### DIFF
--- a/lib/server-builder.js
+++ b/lib/server-builder.js
@@ -171,6 +171,8 @@ class ServerBuilder {
     const gradlebuild = new SubProcess(cmd, args, {
       cwd: this.serverPath,
       stdio: ['ignore', 'pipe', 'pipe'],
+      // https://github.com/nodejs/node/issues/52572
+      shell: system.isWindows(),
       windowsVerbatimArguments: true
     });
     let buildLastLines = [];


### PR DESCRIPTION
Addresses https://github.com/appium/appium-espresso-driver/issues/996