### PR TITLE
chore: set animation scale via settings for api level 26+

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ appium:chromeOptions | A mapping, that allows to customize chromedriver options.
 Capability Name | Description
 --- | ---
 appium:disableSuppressAccessibilityService | Being set to `true` tells the instrumentation process to not suppress accessibility services during the automated test. This might be useful if your automated test needs these services. `false` by default
-appium:disableWindowAnimation | To avoid flakiness google [recommends](https://developer.android.com/training/testing/espresso/setup#set-up-environment) to disable the window animation of the Android device under test when running espresso test. Animation state is restored automatically after the session is stopped if it was enabled before it has started. `true` by default
+appium:disableWindowAnimation | To avoid flakiness google [recommends](https://developer.android.com/training/testing/espresso/setup#set-up-environment) to disable the window animation of the Android device under test when running espresso test. Animation state is restored automatically after the session is stopped if it was enabled before it has started. The restore method may not work if the session ends unexpectedly. `true` by default
 appium:timeZone | Overrides the current device's time zone since the driver version 2.38.0. This change is preserved until the next override. The time zone identifier must be a valid name from the list of [available time zone identifiers](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), for example `Europe/Kyiv`
 
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ appium:chromeOptions | A mapping, that allows to customize chromedriver options.
 Capability Name | Description
 --- | ---
 appium:disableSuppressAccessibilityService | Being set to `true` tells the instrumentation process to not suppress accessibility services during the automated test. This might be useful if your automated test needs these services. `false` by default
-appium:disableWindowAnimation | To avoid flakiness google [recommends](https://developer.android.com/training/testing/espresso/setup#set-up-environment) to disable the window animation of the Android device under test when running espresso test. It sets x1 animtion scales after the session ends if the animation was not disabled before the session starts. `true` by default
+appium:disableWindowAnimation | To avoid flakiness google [recommends](https://developer.android.com/training/testing/espresso/setup#set-up-environment) to disable the window animation of the Android device under test when running espresso test. Animation state is restored automatically after the session is stopped if it was enabled before it has started. `true` by default
 appium:timeZone | Overrides the current device's time zone since the driver version 2.38.0. This change is preserved until the next override. The time zone identifier must be a valid name from the list of [available time zone identifiers](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), for example `Europe/Kyiv`
 
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ appium:chromeOptions | A mapping, that allows to customize chromedriver options.
 Capability Name | Description
 --- | ---
 appium:disableSuppressAccessibilityService | Being set to `true` tells the instrumentation process to not suppress accessibility services during the automated test. This might be useful if your automated test needs these services. `false` by default
-appium:disableWindowAnimation | To avoid flakiness google [recommends](https://developer.android.com/training/testing/espresso/setup#set-up-environment) to disable the window animation of the Android device under test when running espresso test. `true` by default
+appium:disableWindowAnimation | To avoid flakiness google [recommends](https://developer.android.com/training/testing/espresso/setup#set-up-environment) to disable the window animation of the Android device under test when running espresso test. It sets x1 animtion scales after the session ends if the animation was not disabled before the session starts. `true` by default
 appium:timeZone | Overrides the current device's time zone since the driver version 2.38.0. This change is preserved until the next override. The time zone identifier must be a valid name from the list of [available time zone identifiers](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), for example `Europe/Kyiv`
 
 

--- a/lib/driver.ts
+++ b/lib/driver.ts
@@ -409,9 +409,10 @@ export class EspressoDriver extends AndroidDriver implements ExternalDriver<
     }
     await this.initDevice();
 
-    // https://github.com/appium/appium-espresso-driver/issues/72
-    // default state is window animation disabled
-    await this.setWindowAnimationState(this.caps.disableWindowAnimation === false);
+    // Espresso needs to disable animation, but '--no-window-animation' instrument command does not work for lower than Android OS 6
+    if (await this.adb.getApiLevel() < 26) {
+      await this.setWindowAnimationState(this.caps.disableWindowAnimation === false);
+    }
 
     // set actual device name, udid
     this.caps.deviceName = this.adb.curDeviceId;
@@ -623,6 +624,8 @@ export class EspressoDriver extends AndroidDriver implements ExternalDriver<
           } catch (ign) {}
         })();
       }));
+
+      // can be true if the target device's api version is lower than 26.
       if (this.wasAnimationEnabled) {
         try {
           await this.settingsApp.setAnimationState(true);

--- a/lib/driver.ts
+++ b/lib/driver.ts
@@ -494,13 +494,13 @@ export class EspressoDriver extends AndroidDriver implements ExternalDriver<
       this.log.debug('Disabling window animation as "disableWindowAnimation" capability is set to true/fallback to default value "true"');
       await this.adb.getApiLevel() < 26
         ? await this.settingsApp.setAnimationState(false)
-        : await this.adb.setAnimation(0);
+        : await this.adb.setAnimationScale(0);
       this.wasAnimationEnabled = true;
     } else if (shouldEnableAnimation) {
       this.log.debug('Enabling window animation as "disableWindowAnimation" capability is set to false');
       await this.adb.getApiLevel() < 26
         ? await this.settingsApp.setAnimationState(true)
-        : await this.adb.setAnimation(1);
+        : await this.adb.setAnimationScale(1);
       this.wasAnimationEnabled = false;
     } else {
       this.log.debug(`Window animation is already ${isEnabled ? 'enabled' : 'disabled'}`);
@@ -638,7 +638,7 @@ export class EspressoDriver extends AndroidDriver implements ExternalDriver<
         try {
           await this.adb.getApiLevel() < 26
             ? await this.settingsApp.setAnimationState(true)
-            : await this.adb.setAnimation(1);
+            : await this.adb.setAnimationScale(1);
         } catch (err) {
           this.log.warn(`Unable to reset animation: ${err.message}`);
         }

--- a/lib/driver.ts
+++ b/lib/driver.ts
@@ -481,8 +481,8 @@ export class EspressoDriver extends AndroidDriver implements ExternalDriver<
   /**
    * Turn on or off animation scale.
    * '--no-window-animation' instrument argument for espresso disables window animation,
-   * but it did not bring back to animation on in espresso unlike uia2 driver.
-   * We should manage the animation status outside instrumentation process as possible.
+   * but it does not bring the animation scale back to pre-instrument process start state in espresso
+   * unlike uia2 driver. We should disable/enable the animation scale only in an appium session as possible.
    * @param isEnabled
    */
   async setWindowAnimationState(isEnabled: boolean): Promise<void> {

--- a/lib/driver.ts
+++ b/lib/driver.ts
@@ -409,7 +409,7 @@ export class EspressoDriver extends AndroidDriver implements ExternalDriver<
     }
     await this.initDevice();
 
-    // '--no-window-animation' instrument command can set always but it does not work for lower than Android OS 6.
+    // Default state is window animation disabled.
     await this.setWindowAnimationState(this.caps.disableWindowAnimation === false);
 
     // set actual device name, udid
@@ -480,9 +480,9 @@ export class EspressoDriver extends AndroidDriver implements ExternalDriver<
 
   /**
    * Turn on or off animation scale.
-   * '--no-window-animation' instrument argument for espresso disables window animation,
-   * but it does not bring the animation scale back to pre-instrument process start state in espresso
-   * unlike uia2 driver. We should disable/enable the animation scale only in an appium session as possible.
+   * '--no-window-animation' instrument argument for Espresso disables window animations,
+   * but it does not bring the animation scale back to the pre-instrument process start state in Espresso
+   * unlike Appium UIA2 driver case. We want to disable/enable the animation scale only in an appium espresso session as possible.
    * @param isEnabled
    */
   async setWindowAnimationState(isEnabled: boolean): Promise<void> {
@@ -633,7 +633,6 @@ export class EspressoDriver extends AndroidDriver implements ExternalDriver<
           } catch (ign) {}
         })();
       }));
-
       if (this.wasAnimationEnabled) {
         try {
           await this.adb.getApiLevel() < 26

--- a/lib/driver.ts
+++ b/lib/driver.ts
@@ -492,15 +492,11 @@ export class EspressoDriver extends AndroidDriver implements ExternalDriver<
 
     if (shouldDisableAnimation) {
       this.log.debug('Disabling window animation as "disableWindowAnimation" capability is set to true/fallback to default value "true"');
-      await this.adb.getApiLevel() < 26
-        ? await this.settingsApp.setAnimationState(false)
-        : await this.adb.setAnimationScale(0);
+      await this.settingsApp.setAnimationState(false);
       this.wasAnimationEnabled = true;
     } else if (shouldEnableAnimation) {
       this.log.debug('Enabling window animation as "disableWindowAnimation" capability is set to false');
-      await this.adb.getApiLevel() < 26
-        ? await this.settingsApp.setAnimationState(true)
-        : await this.adb.setAnimationScale(1);
+      await this.settingsApp.setAnimationState(true);
       this.wasAnimationEnabled = false;
     } else {
       this.log.debug(`Window animation is already ${isEnabled ? 'enabled' : 'disabled'}`);
@@ -635,9 +631,7 @@ export class EspressoDriver extends AndroidDriver implements ExternalDriver<
       }));
       if (this.wasAnimationEnabled) {
         try {
-          await this.adb.getApiLevel() < 26
-            ? await this.settingsApp.setAnimationState(true)
-            : await this.adb.setAnimationScale(1);
+          await this.settingsApp.setAnimationState(true);
         } catch (err) {
           this.log.warn(`Unable to reset animation: ${err.message}`);
         }

--- a/lib/driver.ts
+++ b/lib/driver.ts
@@ -409,7 +409,7 @@ export class EspressoDriver extends AndroidDriver implements ExternalDriver<
     }
     await this.initDevice();
 
-    // Espresso needs to disable animation, but '--no-window-animation' instrument command does not work for lower than Android OS 6
+    // '--no-window-animation' instrument command can set always but it does not work for lower than Android OS 6.
     if (await this.adb.getApiLevel() < 26) {
       await this.setWindowAnimationState(this.caps.disableWindowAnimation === false);
     }

--- a/lib/espresso-runner.js
+++ b/lib/espresso-runner.js
@@ -263,7 +263,7 @@ class EspressoRunner {
       '-e', 'disableAnalytics', 'true', // To avoid unexpected error by google analytics
     ];
 
-    if ((await this.adb.getApiLevel() >= 26) && this.caps.disableWindowAnimation) {
+    if (!!caps.disableWindowAnimation) {
       cmd.push('--no-window-animation');
     }
 

--- a/lib/espresso-runner.js
+++ b/lib/espresso-runner.js
@@ -263,7 +263,7 @@ class EspressoRunner {
       '-e', 'disableAnalytics', 'true', // To avoid unexpected error by google analytics
     ];
 
-    if (!!caps.disableWindowAnimation) {
+    if (caps.disableWindowAnimation) {
       cmd.push('--no-window-animation');
     }
 

--- a/lib/espresso-runner.js
+++ b/lib/espresso-runner.js
@@ -263,6 +263,10 @@ class EspressoRunner {
       '-e', 'disableAnalytics', 'true', // To avoid unexpected error by google analytics
     ];
 
+    if ((await this.adb.getApiLevel() >= 26) && this.caps.disableWindowAnimation) {
+      cmd.push('--no-window-animation');
+    }
+
     if (_.isBoolean(this.disableSuppressAccessibilityService)) {
       cmd.push('-e', 'DISABLE_SUPPRESS_ACCESSIBILITY_SERVICES', String(this.disableSuppressAccessibilityService));
     }

--- a/lib/espresso-runner.js
+++ b/lib/espresso-runner.js
@@ -263,10 +263,6 @@ class EspressoRunner {
       '-e', 'disableAnalytics', 'true', // To avoid unexpected error by google analytics
     ];
 
-    if (caps.disableWindowAnimation !== false) {
-      cmd.push('--no-window-animation');
-    }
-
     if (_.isBoolean(this.disableSuppressAccessibilityService)) {
       cmd.push('-e', 'DISABLE_SUPPRESS_ACCESSIBILITY_SERVICES', String(this.disableSuppressAccessibilityService));
     }

--- a/lib/espresso-runner.js
+++ b/lib/espresso-runner.js
@@ -263,7 +263,7 @@ class EspressoRunner {
       '-e', 'disableAnalytics', 'true', // To avoid unexpected error by google analytics
     ];
 
-    if (caps.disableWindowAnimation) {
+    if (caps.disableWindowAnimation !== false) {
       cmd.push('--no-window-animation');
     }
 

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "appium-android-driver": "^9.6.0",
     "asyncbox": "^3.0.0",
     "bluebird": "^3.5.0",
-    "io.appium.settings": "^5.7.2",
+    "io.appium.settings": "^5.10.0",
     "lodash": "^4.17.11",
     "portscanner": "^2.1.1",
     "source-map-support": "^0.x",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "npm-shrinkwrap.json"
   ],
   "dependencies": {
-    "appium-adb": "^12.2.0",
+    "appium-adb": "^12.4.0",
     "appium-android-driver": "^9.6.0",
     "asyncbox": "^3.0.0",
     "bluebird": "^3.5.0",


### PR DESCRIPTION
https://github.com/appium/appium-adb/pull/745 method instead of `--no-window-animation` for espresso since the flag in espresso instrumentation process did not bring the animation scale back after the process kill.


0/1 for animation scale is to make the behavior as same as `this.settingsApp.setAnimationState` 