### PR TITLE
chore: use latest io.appium.settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "appium-android-driver": "^9.6.0",
     "asyncbox": "^3.0.0",
     "bluebird": "^3.5.0",
-    "io.appium.settings": "^5.10.0",
+    "io.appium.settings": "^5.12.0",
     "lodash": "^4.17.11",
     "portscanner": "^2.1.1",
     "source-map-support": "^0.x",


### PR DESCRIPTION
To use api level 32 built settings apk