### PR TITLE
fix: Add a workaround for wrong adb exit code on service stop

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   ],
   "dependencies": {
     "appium-adb": "^12.4.0",
-    "appium-android-driver": "^9.6.0",
+    "appium-android-driver": "^9.6.5",
     "asyncbox": "^3.0.0",
     "bluebird": "^3.5.0",
     "io.appium.settings": "^5.12.0",


### PR DESCRIPTION
as same as https://github.com/appium/appium-uiautomator2-driver/pull/794