### PR TITLE
feat: bump default gradle wrapper to 8.7.0 and android plugin to 8.0.0

### DIFF
--- a/espresso-server/app/build.gradle.kts
+++ b/espresso-server/app/build.gradle.kts
@@ -14,7 +14,7 @@ android {
         testHandleProfiling = false
         testFunctionalTest = false
         minSdk = getIntProperty("appiumMinSdk", 21)
-        targetSdk = getIntProperty("appiumTargetSdk", 30)
+        targetSdk = getIntProperty("appiumTargetSdk", 34)
         versionCode = 1
         versionName = "1.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/espresso-server/app/build.gradle.kts
+++ b/espresso-server/app/build.gradle.kts
@@ -14,7 +14,7 @@ android {
         testHandleProfiling = false
         testFunctionalTest = false
         minSdk = getIntProperty("appiumMinSdk", 21)
-        targetSdk = getIntProperty("appiumTargetSdk", 34)
+        targetSdk = getIntProperty("appiumTargetSdk", 30)
         versionCode = 1
         versionName = "1.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/espresso-server/build.gradle.kts
+++ b/espresso-server/build.gradle.kts
@@ -5,7 +5,7 @@ buildscript {
         set("appiumKotlin", properties.getOrDefault("appiumKotlin", "1.8.10"))
         set(
             "appiumAndroidGradlePlugin",
-            properties.getOrDefault("appiumAndroidGradlePlugin", "7.4.2")
+            properties.getOrDefault("appiumAndroidGradlePlugin", "8.0.0")
         )
     }
 

--- a/espresso-server/gradle/wrapper/gradle-wrapper.properties
+++ b/espresso-server/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
I'll bump the android gradle plugin version to 8.5.0 and targetSdk version to 34 (current latest) later but let's bump the android gradle wrapper version first to v8 from v7 (major version update) as a separate version