### PR TITLE
feat: Publish Espresso server library to JitPack

### DIFF
--- a/espresso-server/library/build.gradle.kts
+++ b/espresso-server/library/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.android.library")
     kotlin("android")
+    `maven-publish`
 }
 
 val appiumCompileSdk: String by project
@@ -50,6 +51,22 @@ android {
     testOptions {
         targetSdk = appiumTargetSdk.toInt()
         unitTests.isReturnDefaultValues = true
+    }
+
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
+        }
+    }
+}
+
+publishing {
+    publications {
+        register<MavenPublication>("release") {
+            afterEvaluate {
+                from(components["release"])
+            }
+        }
     }
 }
 

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,5 @@
+jdk:
+  - openjdk17
+install:
+  - cd espresso-server
+  - ./gradlew :library:publishToMavenLocal


### PR DESCRIPTION
This is the minimum required configuration to make the library accessible via JitPack.
JitPack sets groupId, artifactId and version automatically. The Maven coordinates of the library will be `com.github.appium:appium-espresso-driver:<tag>`.