### PR TITLE
fix: Cache children in serializeComposeNode

### DIFF
--- a/espresso-server/library/src/main/java/io/appium/espressoserver/lib/model/SourceDocument.kt
+++ b/espresso-server/library/src/main/java/io/appium/espressoserver/lib/model/SourceDocument.kt
@@ -240,8 +240,9 @@ class SourceDocument constructor(
 
         if (depth < MAX_TRAVERSAL_DEPTH) {
             // Visit the children and build them too
-            for (index in 0 until semanticsNode.children.count()) {
-                serializeComposeNode(semanticsNode.children[index], depth + 1)
+            val children = semanticsNode.children
+            for (index in 0 until children.count()) {
+                serializeComposeNode(children[index], depth + 1)
             }
         } else {
             AndroidLogger.warn(


### PR DESCRIPTION
We can have modifications in the nodes when traversing through them in `serializeComposeNode`, so it's important to cache children before printing them. Similar approach is [used](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/ui/ui-test/src/commonMain/kotlin/androidx/compose/ui/test/Output.kt;l=206?q=compose%2Fui%2Ftest%2FOutput.kt) in compose-ui-test when printing compose nodes.
 
<details>
<summary>This is to prevent stack traces like that one</summary>

```Responding to server with error: {error=unknown error, message=java.lang.IndexOutOfBoundsException: Index 5 out of bounds for length 5, stacktrace=java.lang.IndexOutOfBoundsException: Index 5 out of bounds for length 5
        at jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)
        at jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70)
        at jdk.internal.util.Preconditions.checkIndex(Preconditions.java:266)
        at java.util.Objects.checkIndex(Objects.java:359)
        at java.util.ArrayList.get(ArrayList.java:434)
        at io.appium.espressoserver.lib.model.SourceDocument.serializeComposeNode(SourceDocument.java:244)
        at io.appium.espressoserver.lib.model.SourceDocument.toStream(SourceDocument.java:288)
        at io.appium.espressoserver.lib.model.SourceDocument.access$toStream(SourceDocument.java:87)
        at io.appium.espressoserver.lib.model.SourceDocument$findMatchingNodeIds$1.invoke(SourceDocument.java:376)
        at io.appium.espressoserver.lib.model.SourceDocument$findMatchingNodeIds$1.invoke(SourceDocument.java:375)
        at io.appium.espressoserver.lib.helpers.extensions.SemaphoreKt.withPermit(SemaphoreKt.java:17)
        at io.appium.espressoserver.lib.model.SourceDocument.findMatchingNodeIds(SourceDocument.java:375)
        at io.appium.espressoserver.lib.helpers.ComposeNodeFinderKt.hasXpath(ComposeNodeFinderKt.java:72)
        at io.appium.espressoserver.lib.helpers.ComposeNodeFinderKt.semanticsMatcherForLocator(ComposeNodeFinderKt.java:58)
        at io.appium.espressoserver.lib.helpers.ComposeNodeFinderKt.toNodeInteractionsCollection(ComposeNodeFinderKt.java:45)
        at io.appium.espressoserver.lib.handlers.FindElements.handleCompose(FindElements.java:44)
        at io.appium.espressoserver.lib.handlers.FindElements.handleCompose(FindElements.java:28)
        at io.appium.espressoserver.lib.handlers.RequestHandler$DefaultImpls.invokeStrategy(RequestHandler.java:34)
        at io.appium.espressoserver.lib.handlers.FindElements.invokeStrategy(FindElements.java:28)
        at io.appium.espressoserver.lib.handlers.FindElements.invokeStrategy(FindElements.java:28)
        at io.appium.espressoserver.lib.handlers.RequestHandler$DefaultImpls.handleInternal(RequestHandler.java:29)
        at io.appium.espressoserver.lib.handlers.FindElements.handleInternal(FindElements.java:28)
        at io.appium.espressoserver.lib.handlers.FindElements.handleInternal(FindElements.java:28)
        at io.appium.espressoserver.lib.handlers.RequestHandler$DefaultImpls.handle(RequestHandler.java:57)
        at io.appium.espressoserver.lib.handlers.FindElements.handle(FindElements.java:28)
        at io.appium.espressoserver.lib.handlers.FindElements.handle(FindElements.java:28)
        at io.appium.espressoserver.lib.http.Router.route(Router.java:232)
        at io.appium.espressoserver.lib.http.Server.serve(Server.java:78)
```
</details>

<details>
<summary>Some decompiled code to show the difference</summary>

**Old code** 
Size is calculated once, but we calculate a new collection each time when getting a new child so if the collection has fewer elements there will be `IndexOutOfBoundsException`
```
for(int var15 = ((Collection)semanticsNode.getChildren()).size(); index < var15; ++index) {
   this.serializeComposeNode((SemanticsNode)semanticsNode.getChildren().get(index), depth + 1);
}
```

**New code**
we calculate children collection only once
```
List children = semanticsNode.getChildren();
int index = 0;
for(int var17 = ((Collection)children).size(); index < var17; ++index) {
   this.serializeComposeNode((SemanticsNode)children.get(index), depth + 1);
}
```

</details>

