### PR TITLE
fix: rescue background app

### DIFF
--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -51,3 +51,16 @@ export async function startActivity (
   });
   await this.adb.waitForActivity(appWaitPkg, appWaitAct);
 };
+
+/**
+ * Puts the app to background and waits the given number of seconds then restores the app
+ * if necessary. The call is blocking.
+ *
+ * @this {import('../driver').EspressoDriver}
+ * @param {number} [seconds=-1] The amount of seconds to wait between putting the app to background and restoring it.
+ * Any negative value means to not restore the app after putting it to background.
+ * @returns {Promise<void>}
+ */
+export async function mobileBackgroundApp(seconds = -1) {
+  await this.background(seconds);
+}

--- a/lib/execute-method-map.ts
+++ b/lib/execute-method-map.ts
@@ -197,6 +197,13 @@ export const executeMethodMap = {
     }
   },
 
+  'mobile: backgroundApp': {
+    command: 'mobileBackgroundApp',
+    params: {
+      optional: ['seconds'],
+    }
+  },
+
   'mobile: setClipboard': {
     command: 'mobileSetClipboard',
     params: {


### PR DESCRIPTION
Maybe we accidentally removed this command:

https://github.com/appium/appium-espresso-driver?tab=readme-ov-file#mobile-backgroundapp