### PR TITLE
fix: fix typo in mobile clipboard commands

### DIFF
--- a/lib/driver.ts
+++ b/lib/driver.ts
@@ -749,8 +749,8 @@ export class EspressoDriver extends AndroidDriver implements ExternalDriver<
   getSettings = miscCmds.getSettings;
 
   getClipboard = clipboardCmds.getClipboard;
-  mobileGetClipbard = clipboardCmds.getClipboard;
-  mobileSetClipbard = clipboardCmds.mobileSetClipboard;
+  mobileGetClipboard = clipboardCmds.getClipboard;
+  mobileSetClipboard = clipboardCmds.mobileSetClipboard;
 
   // @ts-ignore It's expected
   mobileStartService = servicesCmds.mobileStartService;

--- a/lib/execute-method-map.ts
+++ b/lib/execute-method-map.ts
@@ -208,7 +208,7 @@ export const executeMethodMap = {
     }
   },
   'mobile: getClipboard': {
-    command: 'getClipboard',
+    command: 'mobileGetClipboard',
   },
 
   'mobile: startService': {


### PR DESCRIPTION
The main typo fix is set's one. The type caused:

```
[HTTP] --> POST /session/be6b7c51-e619-4631-9e2e-0eb116629592/execute/sync
[HTTP] {"script":"mobile:setClipboard","args":[{"contentType":"plaintext","content":"aGFwcHkgdGVzdGluZw==","label":"Note"}]}
[EspressoDriver@9cd6 (be6b7c51)] Calling AppiumDriver.execute() with args: ["mobile:setClipboard",[{"contentType":"plaintext","content":"aGFwcHkgdGVzdGluZw==","label":"Note"}],"be6b7c51-e619-4631-9e2e-0eb116629592"]
[EspressoDriver@9cd6 (be6b7c51)] Encountered internal error running command: TypeError: Cannot read properties of undefined (reading 'call')
[EspressoDriver@9cd6 (be6b7c51)]     at EspressoDriver.executeMethod (/Users/kazu/.nvm/versions/node/v18.20.2/lib/node_modules/appium/node_modules/@appium/base-driver/lib/basedriver/commands/execute.ts:36:26)
[EspressoDriver@9cd6 (be6b7c51)]     at EspressoDriver.execute (/Users/kazu/.appium/node_modules/appium-espresso-driver/node_modules/appium-android-driver/lib/commands/execute.js:17:23)
[EspressoDriver@9cd6 (be6b7c51)]     at commandExecutor (/Users/kazu/.nvm/versions/node/v18.20.2/lib/node_modules/appium/node_modules/@appium/base-driver/lib/basedriver/driver.ts:106:18)
[EspressoDriver@9cd6 (be6b7c51)]     at /Users/kazu/.nvm/versions/node/v18.20.2/lib/node_modules/appium/node_modules/async-lock/lib/index.js:171:12
[EspressoDriver@9cd6 (be6b7c51)]     at AsyncLock._promiseTry (/Users/kazu/.nvm/versions/node/v18.20.2/lib/node_modules/appium/node_modules/async-lock/lib/index.js:306:31)
[EspressoDriver@9cd6 (be6b7c51)]     at exec (/Users/kazu/.nvm/versions/node/v18.20.2/lib/node_modules/appium/node_modules/async-lock/lib/index.js:170:9)
[EspressoDriver@9cd6 (be6b7c51)]     at AsyncLock.acquire (/Users/kazu/.nvm/versions/node/v18.20.2/lib/node_modules/appium/node_modules/async-lock/lib/index.js:189:3)
[EspressoDriver@9cd6 (be6b7c51)]     at EspressoDriver.executeCommand (/Users/kazu/.nvm/versions/node/v18.20.2/lib/node_modules/appium/node_modules/@appium/base-driver/lib/basedriver/driver.ts:122:39)
[EspressoDriver@9cd6 (be6b7c51)]     at processTicksAndRejections (node:internal/process/task_queues:95:5)
[EspressoDriver@9cd6 (be6b7c51)]     at defaultBehavior (/Users/kazu/.nvm/versions/node/v18.20.2/lib/node_modules/appium/lib/appium.js:1109:14)
[EspressoDriver@9cd6 (be6b7c51)]     at AppiumDriver.executeWrappedCommand (/Users/kazu/.nvm/versions/node/v18.20.2/lib/node_modules/appium/lib/appium.js:1215:16)
[EspressoDriver@9cd6 (be6b7c51)]     at AppiumDriver.executeCommand (/Users/kazu/.nvm/versions/node/v18.20.2/lib/node_modules/appium/lib/appium.js:1121:17)
[EspressoDriver@9cd6 (be6b7c51)]     at asyncHandler (/Users/kazu/.nvm/versions/node/v18.20.2/lib/node_modules/appium/node_modules/@appium/base-driver/lib/protocol/protocol.js:393:19)
[HTTP] <-- POST /session/be6b7c51-e619-4631-9e2e-0eb116629592/execute/sync 500 1 ms - 662
```