### PR TITLE
refactor: use an object spread instead of Object.assign

### DIFF
--- a/lib/commands/actions.js
+++ b/lib/commands/actions.js
@@ -6,13 +6,10 @@
 export async function performActions(actions) {
   this.log.debug(`Received the following W3C actions: ${JSON.stringify(actions, null, '  ')}`);
   // This is needed because Selenium API uses MOUSE as the default pointer type
-  const preprocessedActions = actions.map((action) =>
-    Object.assign(
-      {},
-      action,
-      action.type === 'pointer' ? {parameters: {pointerType: 'touch'}} : {}
-    )
-  );
+  const preprocessedActions = actions.map((action) => ({
+    ...action,
+    ...(action.type === 'pointer' ? {parameters: {pointerType: 'touch'}} : {})
+  }));
   this.log.debug(`Preprocessed actions: ${JSON.stringify(preprocessedActions, null, '  ')}`);
   await this.espresso.jwproxy.command('/actions', 'POST', {actions: preprocessedActions});
 }

--- a/test/functional/commands/contexts-e2e-specs.js
+++ b/test/functional/commands/contexts-e2e-specs.js
@@ -15,9 +15,10 @@ describe('context', function () {
     chai.should();
     chai.use(chaiAsPromised.default);
 
-    let caps = Object.assign({
+    let caps = {
       appActivity: 'io.appium.android.apis.view.WebView1',
-    }, APIDEMO_CAPS);
+      ...APIDEMO_CAPS
+    };
     driver = await initSession(caps);
   });
   after(async function () {

--- a/test/functional/commands/element-values-e2e-specs.js
+++ b/test/functional/commands/element-values-e2e-specs.js
@@ -15,9 +15,10 @@ describe('ElementValue', function () {
     chai.should();
     chai.use(chaiAsPromised.default);
 
-    let caps = Object.assign({
+    let caps = {
       appActivity: 'io.appium.android.apis.app.CustomTitle',
-    }, APIDEMO_CAPS);
+      ...APIDEMO_CAPS
+    };
     driver = await initSession(caps);
   });
   after(async function () {

--- a/test/functional/commands/keyboard-e2e-specs.js
+++ b/test/functional/commands/keyboard-e2e-specs.js
@@ -37,10 +37,11 @@ describe('keyboard', function () {
     chai.should();
     chai.use(chaiAsPromised.default);
 
-    let caps = Object.assign({
+    let caps = {
       appActivity: 'io.appium.android.apis.view.AutoComplete4',
       autoGrantPermissions: true,
-    }, APIDEMO_CAPS);
+      ...APIDEMO_CAPS
+    };
     driver = await initSession(caps);
   });
   after(async function () {

--- a/test/functional/commands/mobile-e2e-specs.js
+++ b/test/functional/commands/mobile-e2e-specs.js
@@ -15,7 +15,8 @@ describe('mobile', function () {
     chai.should();
     chai.use(chaiAsPromised.default);
 
-    driver = await initSession({...APIDEMO_CAPS,
+    driver = await initSession({
+      ...APIDEMO_CAPS,
       espressoBuildConfig: JSON.stringify({
         additionalAndroidTestDependencies: ['com.google.android.material:material:1.2.1']
       })

--- a/test/functional/commands/mobile-e2e-specs.js
+++ b/test/functional/commands/mobile-e2e-specs.js
@@ -15,11 +15,11 @@ describe('mobile', function () {
     chai.should();
     chai.use(chaiAsPromised.default);
 
-    driver = await initSession(Object.assign({}, APIDEMO_CAPS, {
+    driver = await initSession({...APIDEMO_CAPS,
       espressoBuildConfig: JSON.stringify({
         additionalAndroidTestDependencies: ['com.google.android.material:material:1.2.1']
       })
-    }));
+    });
   });
   after(async function () {
     await deleteSession();


### PR DESCRIPTION
use an object spread instead of Object.assign to make it more concise and readable