### PR TITLE
fix: naming of webviewEl in mobile: webAtoms

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -111,7 +111,7 @@ jobs:
     - uses: reactivecircus/android-emulator-runner@v2
       name: e2e_api${{ matrix.apiLevel }}
       with:
-        script: npx mocha --timeout 10m ./test/functional/driver-e2e-specs.js ./test/functional/commands/jetpack-compose-attributes-e2e-specs.js ./test/functional/webview/webatoms-e2e-specs.js -g @skip-ci -i --exit
+        script: npx mocha --timeout 10m ./test/functional/driver-e2e-specs.js ./test/functional/commands/jetpack-compose-attributes-e2e-specs.js -g @skip-ci -i --exit
         avd-name: ${{ env.ANDROID_AVD }}
         force-avd-creation: false
         api-level: ${{ matrix.apiLevel }}

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -111,7 +111,7 @@ jobs:
     - uses: reactivecircus/android-emulator-runner@v2
       name: e2e_api${{ matrix.apiLevel }}
       with:
-        script: npx mocha --timeout 10m ./test/functional/driver-e2e-specs.js ./test/functional/commands/jetpack-compose-attributes-e2e-specs.js -g @skip-ci -i --exit
+        script: npx mocha --timeout 10m ./test/functional/driver-e2e-specs.js ./test/functional/commands/jetpack-compose-attributes-e2e-specs.js ./test/functional/webview/webatoms-e2e-specs.js -g @skip-ci -i --exit
         avd-name: ${{ env.ANDROID_AVD }}
         force-avd-creation: false
         api-level: ${{ matrix.apiLevel }}

--- a/espresso-server/library/src/main/java/io/appium/espressoserver/lib/handlers/WebAtoms.kt
+++ b/espresso-server/library/src/main/java/io/appium/espressoserver/lib/handlers/WebAtoms.kt
@@ -38,9 +38,9 @@ class WebAtoms : RequestHandler<WebAtomsParams, Any?> {
         // TODO: Add a 'waitForDocument' feature to wait for HTML DOCUMENT to be ready
 
         // Initialize onWebView with web view matcher (if webviewEl provided)
-        params.webviewElement.let { webviewElement ->
-            AndroidLogger.info("Initializing webView interaction on webview with el: '$webviewElement'")
-            val viewState = EspressoElement.getCachedViewStateById(webviewElement)
+        params.webviewEl.let { webviewEl ->
+            AndroidLogger.info("Initializing webView interaction on webview with el: '$webviewEl'")
+            val viewState = EspressoElement.getCachedViewStateById(webviewEl)
             val matcher = withView(viewState.view)
             webViewInteraction = onWebView(matcher)
         }

--- a/espresso-server/library/src/main/java/io/appium/espressoserver/lib/handlers/WebAtoms.kt
+++ b/espresso-server/library/src/main/java/io/appium/espressoserver/lib/handlers/WebAtoms.kt
@@ -39,7 +39,7 @@ class WebAtoms : RequestHandler<WebAtomsParams, Any?> {
 
         // Initialize onWebView with web view matcher (if webviewEl provided)
         params.webviewEl.let { webviewEl ->
-            AndroidLogger.info("Initializing webView interaction on webview with el: '$webviewEl'")
+            AndroidLogger.info("Initializing webView interaction on webview with the element")
             val viewState = EspressoElement.getCachedViewStateById(webviewEl)
             val matcher = withView(viewState.view)
             webViewInteraction = onWebView(matcher)

--- a/espresso-server/library/src/main/java/io/appium/espressoserver/lib/model/web/WebAtomsParams.kt
+++ b/espresso-server/library/src/main/java/io/appium/espressoserver/lib/model/web/WebAtomsParams.kt
@@ -3,7 +3,7 @@ package io.appium.espressoserver.lib.model.web
 import io.appium.espressoserver.lib.model.AppiumParams
 
 data class WebAtomsParams(
-        val webviewElement: String,
+        val webviewEl: String,
         val forceJavascriptEnabled: Boolean,
         val methodChain: List<WebAtomsMethod> = emptyList()
 ) : AppiumParams()

--- a/espresso-server/library/src/test/java/io/appium/espressoserver/test/model/web/WebAtomsTest.kt
+++ b/espresso-server/library/src/test/java/io/appium/espressoserver/test/model/web/WebAtomsTest.kt
@@ -44,7 +44,7 @@ class WebAtomsTest {
     @Test
     fun `should parse web atoms object`() {
         val json = """{
-           "webviewElement":"abc",
+           "webviewEl":"abc",
            "forceJavascriptEnabled":true,
            "methodChain":[
               {
@@ -71,7 +71,7 @@ class WebAtomsTest {
            ]
         }"""
         val webAtoms = g.fromJson(json, WebAtomsParams::class.java)
-        assertEquals(webAtoms.webviewElement, "abc")
+        assertEquals(webAtoms.webviewEl, "abc")
         assertEquals(webAtoms.forceJavascriptEnabled, true)
 
         webAtoms.methodChain[0].let {

--- a/test/functional/webview/webatoms-e2e-specs.js
+++ b/test/functional/webview/webatoms-e2e-specs.js
@@ -29,7 +29,7 @@ describe('mobile web atoms', function () {
     const webviewEl = await driver.elementById('wv1');
     await B.delay(10000); // Wait for WebView to load
     await driver.execute(`mobile: webAtoms`, {
-      webviewElement: webviewEl.value,
+      webviewEl: webviewEl.value,
       forceJavascriptEnabled: true,
       methodChain: [
         {name: 'withElement', atom: {name: 'findElement', locator: {using: 'ID', value: 'i_am_a_textbox'}}},

--- a/test/functional/webview/webatoms-e2e-specs.js
+++ b/test/functional/webview/webatoms-e2e-specs.js
@@ -16,9 +16,11 @@ describe('mobile web atoms', function () {
     chai.use(chaiAsPromised.default);
 
     driver = await initSession({
-      ...APIDEMO_CAPS,
-      appPackage: 'io.appium.android.apis',
-      appActivity: 'io.appium.android.apis.view.WebView1',
+      capabilities: {
+        ...APIDEMO_CAPS,
+        'appium:appPackage': 'io.appium.android.apis',
+        'appium:appActivity': 'io.appium.android.apis.view.WebView1',
+      }
     });
   });
   after(async function () {

--- a/test/functional/webview/webatoms-e2e-specs.js
+++ b/test/functional/webview/webatoms-e2e-specs.js
@@ -16,11 +16,9 @@ describe('mobile web atoms', function () {
     chai.use(chaiAsPromised.default);
 
     driver = await initSession({
-      capabilities: {
-        ...APIDEMO_CAPS,
-        'appium:appPackage': 'io.appium.android.apis',
-        'appium:appActivity': 'io.appium.android.apis.view.WebView1',
-      }
+      ...APIDEMO_CAPS,
+      appPackage: 'io.appium.android.apis',
+      appActivity: 'io.appium.android.apis.view.WebView1',
     });
   });
   after(async function () {


### PR DESCRIPTION
The original issue was the README addressed `webviewEl` while our actual implementation referred to `webviewElement`. So after correcting it in https://github.com/appium/appium-espresso-driver/pull/1042 to follow README, it started failing.

https://github.com/appium/appium-espresso-driver/issues/1074

This is a fix to follow the `webviewEl` by following `lib/execute-method-map.ts` and README documentation.

I also had the same error in https://github.com/appium/ruby_lib_core/actions/runs/16225328137/job/45864088476

```
I0713 01:36:25.645430    5442 VkDecoderGlobalState.cpp:9181] Destroyed VkInstance:0x55b99ec3f800 for application: engine:.
ERROR AppiumLibCoreTest::Android::MobileCommandsTest#test_webatom (303.94s)
Minitest::UnexpectedError:         Selenium::WebDriver::Error::InvalidArgumentError: Cannot find 'null' element
            /opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/selenium-webdriver-4.34.0/lib/selenium/webdriver/remote/response.rb:63:in `add_cause'
            /opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/selenium-webdriver-4.34.0/lib/selenium/webdriver/remote/response.rb:41:in `error'
            /opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/selenium-webdriver-4.34.0/lib/selenium/webdriver/remote/response.rb:52:in `assert_ok'
            /opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/selenium-webdriver-4.34.0/lib/selenium/webdriver/remote/response.rb:34:in `initialize'
            /opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/selenium-webdriver-4.34.0/lib/selenium/webdriver/remote/http/common.rb:103:in `new'
            /opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/selenium-webdriver-4.34.0/lib/selenium/webdriver/remote/http/common.rb:103:in `create_response'
            /opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/selenium-webdriver-4.34.0/lib/selenium/webdriver/remote/http/default.rb:103:in `request'
            /opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/selenium-webdriver-4.34.0/lib/selenium/webdriver/remote/http/common.rb:68:in `call'
            /opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/selenium-webdriver-4.34.0/lib/selenium/webdriver/remote/bridge.rb:625:in `execute'
            /opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/selenium-webdriver-4.34.0/lib/selenium/webdriver/remote/bridge.rb:304:in `execute_script'
            /opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/selenium-webdriver-4.34.0/lib/selenium/webdriver/common/driver.rb:229:in `execute_script'
            test/functional/android/android/mobile_commands_test.rb:213:in `test_webatom'
```

https://github.com/appium/appium-espresso-driver/issues/1074