### PR TITLE
chore: drop rimraf deps from dev deps as no references

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,6 @@
     "chai-as-promised": "^8.0.0",
     "conventional-changelog-conventionalcommits": "^9.0.0",
     "mocha": "^11.1.0",
-    "rimraf": "^5.0.0",
     "semantic-release": "^24.0.0",
     "sinon": "^21.0.0",
     "semver": "^7.3.7",


### PR DESCRIPTION
```
kazu $ git grep 'rimraf'
CHANGELOG.md:* **deps-dev:** bump rimraf from 4.4.1 to 5.0.0 ([#868](https://github.com/appium/appium-espresso-driver/issues/868)) ([67cfe30](https://github.com/appium/appium-espresso-driver/commit/67cfe30e1345cbb6ede1d975213179f074aa8151))
CHANGELOG.md:* **deps-dev:** bump rimraf from 3.0.2 to 4.0.4 ([#848](https://github.com/appium/appium-espresso-driver/issues/848)) ([cf06466](https://github.com/appium/appium-espresso-driver/commit/cf064663eea2b3ffd7a02e2ba5dec3bffb4f9e53))
lib/driver.ts:          await fs.rimraf(appPath);
lib/driver.ts:          await fs.rimraf(/** @type {string} */ (unzippedAppPath));
lib/espresso-runner.js:    await fs.rimraf(serverPath);
package.json:    "rimraf": "^5.0.0",
test/functional/utils-e2e-specs.js:    await fs.rimraf(baseSrcDir);
    "axios": "^1.7.2",
test/functional/utils-e2e-specs.js:    await fs.rimraf(baseDestDir);
```

instead of https://github.com/appium/appium-espresso-driver/pull/1045