### PR TITLE
feat: Update server compatibility for appium 3

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -84,7 +84,13 @@ jobs:
         disable-animations: true
         script: echo "Generated AVD snapshot for caching."
     - run: |
-        npm install -g appium
+        appium_ver=$(node -p "require('./package.json').peerDependencies?.appium")
+        pushd "$(pwd)"
+        cd ~
+        npm install -g "appium@$appium_ver"
+        popd
+      name: Install Appium Server
+    - run: |
         npm install
         npm install --no-save mjpeg-consumer
       name: Install dev dependencies

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ The Espresso package consists of two main parts:
 - The driver part (written in Node.js) ensures the communication between the Espresso server and Appium. Also includes several handlers that directly use ADB and/or other system tools without a need to talk to the server.
 - The server part (written in Kotlin with some parts of Java), which is running on the device under test and transforms REST API calls into low-level Espresso commands.
 
-> **Note**
->
-> Since version 2.0.0 Espresso driver has dropped the support of Appium 1, and is only compatible to Appium 2. Use the `appium driver install espresso`
-> command to add it to your Appium 2 dist.
+> [!IMPORTANT]
+> Since major version *5.0.0*, this driver is only compatible with Appium 3. Use the `appium driver install espresso`
+> command to add it to your distribution.
+
 
 ## Comparison with UiAutomator2
 

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "url": "https://github.com/appium/appium-espresso-driver/issues"
   },
   "engines": {
-    "node": ">=14",
-    "npm": ">=8"
+    "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+    "npm": ">=10"
   },
   "prettier": {
     "bracketSpacing": false,
@@ -74,17 +74,17 @@
     "npm-shrinkwrap.json"
   ],
   "dependencies": {
-    "appium-adb": "^12.12.0",
-    "appium-android-driver": "^10.3.11",
+    "appium-adb": "^13.0.0",
+    "appium-android-driver": "^11.0.0",
     "asyncbox": "^3.0.0",
     "axios": "^1.7.2",
     "bluebird": "^3.5.0",
-    "io.appium.settings": "^5.14.3",
+    "io.appium.settings": "^6.0.0",
     "lodash": "^4.17.11",
     "portscanner": "^2.1.1",
     "semver": "^7.6.2",
     "source-map-support": "^0.x",
-    "teen_process": "^2.2.0"
+    "teen_process": "^3.0.0"
   },
   "scripts": {
     "build": "npm run build:node && npm run build:server",
@@ -108,12 +108,12 @@
     "e2e-test": "mocha --exit --timeout 5m \"./test/functional/**/*-specs.js\""
   },
   "peerDependencies": {
-    "appium": "^2.4.1"
+    "appium": "^3.0.0-rc.2"
   },
   "devDependencies": {
-    "@appium/eslint-config-appium-ts": "^1.0",
-    "@appium/tsconfig": "^0.x",
-    "@appium/types": "^0.x",
+    "@appium/eslint-config-appium-ts": "^2.0.0-rc.1",
+    "@appium/tsconfig": "^1.0.0-rc.1",
+    "@appium/types": "^1.0.0-rc.1",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
     "@types/bluebird": "^3.5.38",
@@ -121,10 +121,9 @@
     "@types/mocha": "^10.0.1",
     "@types/node": "^24.0.0",
     "@types/sinon": "^17.0.0",
-    "@types/teen_process": "^2.0.2",
     "@xmldom/xmldom": "^0.x",
-    "android-apidemos": "^4.1.1",
-    "appium-chromedriver": "^7.0.3",
+    "android-apidemos": "^5.0.0",
+    "appium-chromedriver": "^8.0.0",
     "async-lock": "^1.0.0",
     "chai": "^5.1.1",
     "chai-as-promised": "^8.0.0",


### PR DESCRIPTION
BREAKING CHANGE: Required Node.js version has been bumped to ^20.19.0 || ^22.12.0 || >=24.0.0
BREAKING CHANGE: Required npm version has been bumped to >=10
BREAKING CHANGE: Required Appium server version has been bumped to >=3.0.0-rc.2