### PR TITLE
fix: typecheck

### DIFF
--- a/lib/driver.ts
+++ b/lib/driver.ts
@@ -6,7 +6,8 @@ import type {
   InitialOpts,
   StringRecord,
   SingularSessionData,
-  RouteMatcher
+  RouteMatcher,
+  SessionCapabilities
 } from '@appium/types';
 import type { EspressoConstraints } from './constraints';
 import _ from 'lodash';
@@ -190,6 +191,11 @@ export class EspressoDriver extends AndroidDriver implements ExternalDriver<
 
   override async getSession(): Promise<SingularSessionData<EspressoConstraints>> {
     return await BaseDriver.prototype.getSession.call(this);
+  }
+
+  // needed to make the typechecker happy
+  async getAppiumSessionCapabilities(): Promise<SessionCapabilities<EspressoConstraints>> {
+    return (await super.getAppiumSessionCapabilities()) as SessionCapabilities<EspressoConstraints>;
   }
 
   async createSession (


### PR DESCRIPTION
To fix:

```
lib/driver.ts:156:14 - error TS2420: Class 'EspressoDriver' incorrectly implements interface 'ExternalDriver<{ readonly platformName: { readonly isString: true; readonly inclusionCaseInsensitive: readonly ["Android"]; readonly presence: true; }; readonly deviceName: { readonly isString: true; }; readonly appActivity: { ...; }; ... 95 more ...; readonly appLocale: { ...; }; }, ... 5 more ..., StringRecord>'.
  The types returned by 'getAppiumSessionCapabilities()' are incompatible between these types.
    Type 'Promise<SessionCapabilities<{ readonly platformName: { readonly isString: true; readonly inclusionCaseInsensitive: readonly ["Android"]; readonly presence: true; }; readonly deviceName: { readonly isString: true; }; ... 85 more ...; readonly injectedImageProperties: { ...; }; }>>' is not assignable to type 'Promise<SessionCapabilities<{ readonly platformName: { readonly isString: true; readonly inclusionCaseInsensitive: readonly ["Android"]; readonly presence: true; }; readonly deviceName: { readonly isString: true; }; ... 96 more ...; readonly appLocale: { ...; }; }, StringRecord>>'.
      Type 'SessionCapabilities<{ readonly platformName: { readonly isString: true; readonly inclusionCaseInsensitive: readonly ["Android"]; readonly presence: true; }; readonly deviceName: { readonly isString: true; }; readonly appActivity: { ...; }; ... 84 more ...; readonly injectedImageProperties: { ...; }; }>' is not assignable to type 'SessionCapabilities<{ readonly platformName: { readonly isString: true; readonly inclusionCaseInsensitive: readonly ["Android"]; readonly presence: true; }; readonly deviceName: { readonly isString: true; }; readonly appActivity: { ...; }; ... 95 more ...; readonly appLocale: { ...; }; }, StringRecord>'.
        Type 'SessionCapabilities<{ readonly platformName: { readonly isString: true; readonly inclusionCaseInsensitive: readonly ["Android"]; readonly presence: true; }; readonly deviceName: { readonly isString: true; }; readonly appActivity: { ...; }; ... 84 more ...; readonly injectedImageProperties: { ...; }; }>' is not assignable to type '{ capabilities: DriverCaps<{ readonly platformName: { readonly isString: true; readonly inclusionCaseInsensitive: readonly ["Android"]; readonly presence: true; }; readonly deviceName: { readonly isString: true; }; ... 96 more ...; readonly appLocale: { ...; }; }>; }'.
          Types of property 'capabilities' are incompatible.
            Type 'DriverCaps<{ readonly platformName: { readonly isString: true; readonly inclusionCaseInsensitive: readonly ["Android"]; readonly presence: true; }; readonly deviceName: { readonly isString: true; }; readonly appActivity: { ...; }; ... 84 more ...; readonly injectedImageProperties: { ...; }; }>' is not assignable to type 'DriverCaps<{ readonly platformName: { readonly isString: true; readonly inclusionCaseInsensitive: readonly ["Android"]; readonly presence: true; }; readonly deviceName: { readonly isString: true; }; readonly appActivity: { ...; }; ... 95 more ...; readonly appLocale: { ...; }; }>'.
              Type 'DriverCaps<{ readonly platformName: { readonly isString: true; readonly inclusionCaseInsensitive: readonly ["Android"]; readonly presence: true; }; readonly deviceName: { readonly isString: true; }; readonly appActivity: { ...; }; ... 84 more ...; readonly injectedImageProperties: { ...; }; }>' is not assignable to type 'ConstraintsToCaps<{ readonly platformName: { readonly isString: true; readonly inclusionCaseInsensitive: readonly ["Android"]; readonly presence: true; }; readonly deviceName: { readonly isString: true; }; readonly appActivity: { ...; }; ... 95 more ...; readonly appLocale: { ...; }; }>'.
                Type 'DriverCaps<{ readonly platformName: { readonly isString: true; readonly inclusionCaseInsensitive: readonly ["Android"]; readonly presence: true; }; readonly deviceName: { readonly isString: true; }; readonly appActivity: { ...; }; ... 84 more ...; readonly injectedImageProperties: { ...; }; }>' is missing the following properties from type 'ConstraintsToCaps<{ readonly platformName: { readonly isString: true; readonly inclusionCaseInsensitive: readonly ["Android"]; readonly presence: true; }; readonly deviceName: { readonly isString: true; }; readonly appActivity: { ...; }; ... 95 more ...; readonly appLocale: { ...; }; }>': systemPort, launchTimeout, forceEspressoRebuild, espressoServerLaunchTimeout, and 7 more.

156 export class EspressoDriver extends AndroidDriver implements ExternalDriver<
                 ~~~~~~~~~~~~~~
```