### PR TITLE
feat: add appium:adbListenAllNetwork with espresso:adb_listen_all_network flag to add -a option for adb

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ appium:mockLocationApp | Sets the package identifier of the app, which is used a
 appium:logcatFormat | The log print format, where `format` is one of: `brief` `process` `tag` `thread` `raw` `time` `threadtime` `long`. `threadtime` is the default value.
 appium:logcatFilterSpecs | Series of `tag[:priority]` where `tag` is a log component tag (or * for all) and priority is: `V    Verbose`, `D    Debug`, `I    Info`, `W    Warn`, `E    Error`, `F    Fatal`, `S    Silent (suppress all output)`. '*' means '*:d' and `tag` by itself means `tag:v`. If not specified on the commandline, filterspec is set from ANDROID_LOG_TAGS. If no filterspec is found, filter defaults to '*:I'.
 appium:allowDelayAdb | Being set to `false` prevents emulator to use `-delay-adb` feature to detect its startup. See https://github.com/appium/appium/issues/14773 for more details.
+appium:adbListenAllNetwork | Being set to `true` adds `-a` ADB command line global option. Requires `uiautomator2:adb_listen_all_network` [security feature](https://github.com/appium/appium/blob/master/packages/appium/docs/en/guides/security.md) to be enabled. Unset by default. Available since the driver version 6.2.0.
 
 ### Emulator (Android Virtual Device)
 
@@ -465,7 +466,7 @@ object result = driver.ExecuteScript("mobile: <methodName>", new Dictionary<stri
 
 ### mobile: shell
 
-Executes the given shell command on the device under test via ADB connection. This extension exposes a potential security risk and thus is only enabled when explicitly activated by the `adb_shell` server command line feature specifier
+Executes the given shell command on the device under test via ADB connection. This extension exposes a potential security risk and thus is only enabled when explicitly activated by the `espresso:adb_shell` server command line feature specifier
 
 #### Arguments
 

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   ],
   "dependencies": {
     "appium-adb": "^14.0.0",
-    "appium-android-driver": "^12.3.0",
+    "appium-android-driver": "^12.4.0",
     "asyncbox": "^3.0.0",
     "axios": "^1.12.2",
     "bluebird": "^3.5.0",


### PR DESCRIPTION
https://github.com/appium/appium-uiautomator2-driver/pull/955 for espresso