### PR TITLE
fix: modify the format of listApps to follow xcuitest format

### DIFF
--- a/README.md
+++ b/README.md
@@ -941,7 +941,8 @@ user | number or string | no | The user ID for which the package is installed. T
 
 #### Returned Result
 
-List of installed package names.
+A map where keys are packageName and values are maps of platform-specific app properties since Espresso driver v7.0.0.
+Espresso driver v6.4.0 was a list of installed package names.
 
 ### mobile: queryAppState
 

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   ],
   "dependencies": {
     "appium-adb": "^14.0.0",
-    "appium-android-driver": "^12.7.0",
+    "appium-android-driver": "^13.0.0",
     "asyncbox": "^6.1.0",
     "axios": "^1.12.2",
     "bluebird": "^3.5.0",


### PR DESCRIPTION
BREAKING CHANGE: modify the mobile:listApps style to follow XCUITest driver format


The same as https://github.com/appium/appium-uiautomator2-driver/pull/986