### PR TITLE
feat: add version catalog for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
     interval: daily
     time: "11:00"
   open-pull-requests-limit: 10
+# Gradle: Dependabot updates gradle/libs.versions.toml (not arbitrary keys in gradle.properties).
 - package-ecosystem: "gradle"
   directory: "/espresso-server"
   schedule:

--- a/espresso-server/app/build.gradle.kts
+++ b/espresso-server/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
 }
 
+import io.appium.espressoserver.gradle.resolveCapabilityVersion
 import io.appium.espressoserver.jvmtarget.AppiumJvmTarget
 import org.gradle.api.GradleException
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
@@ -14,6 +15,10 @@ val appiumTargetPackage: String by project
 val appiumSourceCompatibility: String by project
 val appiumTargetCompatibility: String by project
 val appiumJvmTarget: String by project
+
+// Align androidTest dependency versions with :library when Espresso driver passes -PappiumJUnitVersion / -PappiumAndroidxTestVersion.
+val junitVersion = resolveCapabilityVersion("appiumJUnitVersion", libs.versions.junit.get())
+val androidxTestVersion = resolveCapabilityVersion("appiumAndroidxTestVersion", libs.versions.androidxTest.get())
 
 android {
     compileSdk = appiumCompileSdk.toInt()
@@ -86,9 +91,9 @@ kotlin {
 
 dependencies {
     androidTestImplementation(project(":library"))
-    androidTestImplementation("junit:junit:${libs.versions.junit.get()}")
-    androidTestImplementation("androidx.test:core:${libs.versions.androidxTest.get()}")
-    androidTestImplementation("androidx.test:runner:${libs.versions.androidxTest.get()}")
+    androidTestImplementation("junit:junit:$junitVersion")
+    androidTestImplementation("androidx.test:core:$androidxTestVersion")
+    androidTestImplementation("androidx.test:runner:$androidxTestVersion")
 
     // additionalAndroidTestDependencies placeholder (don't change or delete this line)
 }

--- a/espresso-server/app/build.gradle.kts
+++ b/espresso-server/app/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.application")
+    alias(libs.plugins.android.application)
 }
 
 import io.appium.espressoserver.jvmtarget.AppiumJvmTarget
@@ -14,17 +14,6 @@ val appiumTargetPackage: String by project
 val appiumSourceCompatibility: String by project
 val appiumTargetCompatibility: String by project
 val appiumJvmTarget: String by project
-val appiumKotlin: String by project
-val appiumAndroidxTestVersion: String by project
-val appiumAnnotationVersion: String by project
-val appiumComposeVersion: String by project
-val appiumGsonVersion: String by project
-val appiumEspressoVersion: String by project
-val appiumMockitoVersion: String by project
-val appiumNanohttpdVersion: String by project
-val appiumRobolectricVersion: String by project
-val appiumJUnitVersion: String by project
-val appiumUiAutomatorVersion: String by project
 
 android {
     compileSdk = appiumCompileSdk.toInt()
@@ -97,9 +86,9 @@ kotlin {
 
 dependencies {
     androidTestImplementation(project(":library"))
-    androidTestImplementation("junit:junit:$appiumJUnitVersion")
-    androidTestImplementation("androidx.test:core:$appiumAndroidxTestVersion")
-    androidTestImplementation("androidx.test:runner:$appiumAndroidxTestVersion")
+    androidTestImplementation("junit:junit:${libs.versions.junit.get()}")
+    androidTestImplementation("androidx.test:core:${libs.versions.androidxTest.get()}")
+    androidTestImplementation("androidx.test:runner:${libs.versions.androidxTest.get()}")
 
     // additionalAndroidTestDependencies placeholder (don't change or delete this line)
 }

--- a/espresso-server/build.gradle.kts
+++ b/espresso-server/build.gradle.kts
@@ -1,26 +1,11 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
-buildscript {
-    val appiumAndroidGradlePlugin: String by project
-
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath("com.android.tools.build:gradle:$appiumAndroidGradlePlugin")
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle.kts files
-    }
+plugins {
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.android.library) apply false
 }
 
 allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
-
     group = "io.appium.espressoserver"
 }
 

--- a/espresso-server/buildSrc/src/main/kotlin/io/appium/espressoserver/gradle/CapabilityVersion.kt
+++ b/espresso-server/buildSrc/src/main/kotlin/io/appium/espressoserver/gradle/CapabilityVersion.kt
@@ -1,0 +1,12 @@
+package io.appium.espressoserver.gradle
+
+import org.gradle.api.Project
+
+/**
+ * Resolves a dependency version from an optional Gradle property (e.g. `-PappiumKotlin=…` from the
+ * Espresso driver's `toolsVersions` / `espressoBuildConfig`) with fallback to the version catalog default.
+ */
+fun Project.resolveCapabilityVersion(propertyName: String, catalogDefaultVersion: String): String {
+    val fromCapability = findProperty(propertyName)?.toString()?.trim()
+    return if (!fromCapability.isNullOrEmpty()) fromCapability else catalogDefaultVersion
+}

--- a/espresso-server/gradle.properties
+++ b/espresso-server/gradle.properties
@@ -34,15 +34,4 @@ appiumSourceCompatibility=VERSION_1_8
 appiumTargetCompatibility=VERSION_1_8
 appiumJvmTarget=1.8
 
-appiumAndroidGradlePlugin=9.1.1
-appiumKotlin=2.3.20
-appiumAndroidxTestVersion=1.5.0
-appiumAnnotationVersion=1.6.0
-appiumComposeVersion=1.1.1
-appiumGsonVersion=2.10.1
-appiumEspressoVersion=3.5.1
-appiumMockitoVersion=5.1.1
-appiumNanohttpdVersion=2.3.1
-appiumRobolectricVersion=4.9.2
-appiumJUnitVersion=4.13.2
-appiumUiAutomatorVersion=2.2.0
+# Dependency and plugin versions for Dependabot live in gradle/libs.versions.toml

--- a/espresso-server/gradle/libs.versions.toml
+++ b/espresso-server/gradle/libs.versions.toml
@@ -1,0 +1,16 @@
+[versions]
+androidGradlePlugin = "9.1.1"
+kotlin = "2.3.20"
+androidxTest = "1.5.0"
+annotation = "1.6.0"
+composeUiTest = "1.1.1"
+gson = "2.10.1"
+espresso = "3.5.1"
+nanohttpd = "2.3.1"
+robolectric = "4.9.2"
+junit = "4.13.2"
+uiautomator = "2.2.0"
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
+android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }

--- a/espresso-server/library/build.gradle.kts
+++ b/espresso-server/library/build.gradle.kts
@@ -1,8 +1,9 @@
 plugins {
-    id("com.android.library")
+    alias(libs.plugins.android.library)
     `maven-publish`
 }
 
+import io.appium.espressoserver.gradle.resolveCapabilityVersion
 import io.appium.espressoserver.jvmtarget.AppiumJvmTarget
 import org.gradle.api.GradleException
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
@@ -14,16 +15,19 @@ val appiumBuildTools: String by project
 val appiumSourceCompatibility: String by project
 val appiumTargetCompatibility: String by project
 val appiumJvmTarget: String by project
-val appiumKotlin: String by project
-val appiumAndroidxTestVersion: String by project
-val appiumAnnotationVersion: String by project
-val appiumComposeVersion: String by project
-val appiumGsonVersion: String by project
-val appiumEspressoVersion: String by project
-val appiumNanohttpdVersion: String by project
-val appiumRobolectricVersion: String by project
-val appiumJUnitVersion: String by project
-val appiumUiAutomatorVersion: String by project
+
+// Versions: defaults from gradle/libs.versions.toml; -Pappium* overrides from Espresso driver (toolsVersions / capabilities).
+val kotlinVersion = resolveCapabilityVersion("appiumKotlin", libs.versions.kotlin.get())
+val annotationVersion = resolveCapabilityVersion("appiumAnnotationVersion", libs.versions.annotation.get())
+val composeUiTestVersion =
+    resolveCapabilityVersion("appiumComposeVersion", libs.versions.composeUiTest.get())
+val gsonVersion = resolveCapabilityVersion("appiumGsonVersion", libs.versions.gson.get())
+val espressoVersion = resolveCapabilityVersion("appiumEspressoVersion", libs.versions.espresso.get())
+val nanohttpdVersion = resolveCapabilityVersion("appiumNanohttpdVersion", libs.versions.nanohttpd.get())
+val androidxTestVersion = resolveCapabilityVersion("appiumAndroidxTestVersion", libs.versions.androidxTest.get())
+val robolectricVersion = resolveCapabilityVersion("appiumRobolectricVersion", libs.versions.robolectric.get())
+val junitVersion = resolveCapabilityVersion("appiumJUnitVersion", libs.versions.junit.get())
+val uiautomatorVersion = resolveCapabilityVersion("appiumUiAutomatorVersion", libs.versions.uiautomator.get())
 
 android {
     compileSdk = appiumCompileSdk.toInt()
@@ -85,39 +89,39 @@ publishing {
 dependencies {
     // additionalAppDependencies placeholder (don't change or delete this line)
 
-    api("androidx.annotation:annotation:$appiumAnnotationVersion")
-    api("androidx.test.espresso:espresso-contrib:$appiumEspressoVersion") {
+    api("androidx.annotation:annotation:$annotationVersion")
+    api("androidx.test.espresso:espresso-contrib:$espressoVersion") {
         // Exclude transitive dependencies to limit conflicts with AndroidX libraries from AUT.
         // Link to PR with fix and discussion https://github.com/appium/appium-espresso-driver/pull/596
         isTransitive = false
     }
-    api("androidx.test.espresso:espresso-web:$appiumEspressoVersion") {
+    api("androidx.test.espresso:espresso-web:$espressoVersion") {
         because("Espresso Web Atoms support (mobile: webAtoms)")
     }
-    api("androidx.test.uiautomator:uiautomator:$appiumUiAutomatorVersion") {
+    api("androidx.test.uiautomator:uiautomator:$uiautomatorVersion") {
         because("UiAutomator support (mobile: uiautomator)")
     }
-    api("androidx.test:core:$appiumAndroidxTestVersion")
-    api("androidx.test:runner:$appiumAndroidxTestVersion")
-    api("androidx.test:rules:$appiumAndroidxTestVersion")
-    api("com.google.code.gson:gson:$appiumGsonVersion")
-    api("org.nanohttpd:nanohttpd-webserver:$appiumNanohttpdVersion")
-    api("org.jetbrains.kotlin:kotlin-stdlib:$appiumKotlin")
-    api("org.jetbrains.kotlin:kotlin-reflect:$appiumKotlin")
-    api("androidx.compose.ui:ui-test:$appiumComposeVersion") {
+    api("androidx.test:core:$androidxTestVersion")
+    api("androidx.test:runner:$androidxTestVersion")
+    api("androidx.test:rules:$androidxTestVersion")
+    api("com.google.code.gson:gson:$gsonVersion")
+    api("org.nanohttpd:nanohttpd-webserver:$nanohttpdVersion")
+    api("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
+    api("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
+    api("androidx.compose.ui:ui-test:$composeUiTestVersion") {
         because("Android Compose support")
     }
-    api("androidx.compose.ui:ui-test-junit4:$appiumComposeVersion") {
+    api("androidx.compose.ui:ui-test-junit4:$composeUiTestVersion") {
         because("Android Compose support")
     }
 
-    testImplementation("androidx.test.espresso:espresso-contrib:$appiumEspressoVersion")
-    testImplementation("junit:junit:$appiumJUnitVersion")
-    testImplementation("org.robolectric:robolectric:$appiumRobolectricVersion")
-    testImplementation("org.jetbrains.kotlin:kotlin-test:$appiumKotlin")
-    testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$appiumKotlin")
+    testImplementation("androidx.test.espresso:espresso-contrib:$espressoVersion")
+    testImplementation("junit:junit:$junitVersion")
+    testImplementation("org.robolectric:robolectric:$robolectricVersion")
+    testImplementation("org.jetbrains.kotlin:kotlin-test:$kotlinVersion")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion")
 
     constraints {
-        api("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$appiumKotlin")
+        api("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion")
     }
 }

--- a/espresso-server/settings.gradle.kts
+++ b/espresso-server/settings.gradle.kts
@@ -1,2 +1,39 @@
+import java.io.File
+
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+
+    // Match [versions] androidGradlePlugin in gradle/libs.versions.toml (same key Dependabot updates).
+    // Espresso driver passes -PappiumAndroidGradlePlugin when espressoBuildConfig.toolsVersions.androidGradlePlugin is set.
+    val agpDefault =
+        Regex("""(?m)^androidGradlePlugin\s*=\s*"([^"]+)"""")
+            .find(File(rootDir, "gradle/libs.versions.toml").readText())
+            ?.groupValues
+            ?.get(1)
+            ?: error("androidGradlePlugin not found in gradle/libs.versions.toml")
+
+    resolutionStrategy {
+        eachPlugin {
+            if (requested.id.id == "com.android.application" || requested.id.id == "com.android.library") {
+                val fromCapability =
+                    providers.gradleProperty("appiumAndroidGradlePlugin").orNull?.trim()?.takeIf { it.isNotEmpty() }
+                useVersion(fromCapability ?: agpDefault)
+            }
+        }
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
 include(":app")
 include(":library")

--- a/espresso-server/settings.gradle.kts
+++ b/espresso-server/settings.gradle.kts
@@ -1,5 +1,3 @@
-import java.io.File
-
 pluginManagement {
     repositories {
         google()
@@ -7,21 +5,16 @@ pluginManagement {
         gradlePluginPortal()
     }
 
-    // Match [versions] androidGradlePlugin in gradle/libs.versions.toml (same key Dependabot updates).
-    // Espresso driver passes -PappiumAndroidGradlePlugin when espressoBuildConfig.toolsVersions.androidGradlePlugin is set.
-    val agpDefault =
-        Regex("""(?m)^androidGradlePlugin\s*=\s*"([^"]+)"""")
-            .find(File(rootDir, "gradle/libs.versions.toml").readText())
-            ?.groupValues
-            ?.get(1)
-            ?: error("androidGradlePlugin not found in gradle/libs.versions.toml")
-
+    // When Espresso driver passes -PappiumAndroidGradlePlugin, override the AGP version from the
+    // version catalog. Otherwise keep Gradle's catalog-resolved requested version (no regex/TOML parse).
     resolutionStrategy {
         eachPlugin {
             if (requested.id.id == "com.android.application" || requested.id.id == "com.android.library") {
                 val fromCapability =
                     providers.gradleProperty("appiumAndroidGradlePlugin").orNull?.trim()?.takeIf { it.isNotEmpty() }
-                useVersion(fromCapability ?: agpDefault)
+                if (fromCapability != null) {
+                    useVersion(fromCapability)
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

This change moves pinned dependency and AGP versions from `espresso-server/gradle.properties` into `espresso-server/gradle/libs.versions.toml` so Dependabot’s Gradle integration can bump them reliably. The Espresso driver’s existing behavior is preserved: `ServerBuilder` still passes `-Pappium…` flags from `espressoBuildConfig.toolsVersions`, and those values again override catalog defaults where they matter.

## Motivation

Dependabot does not maintain arbitrary version keys in `gradle.properties` ([dependabot/dependabot-core#1618](https://github.com/dependabot/dependabot-core/issues/1618)). A Gradle version catalog (`gradle/libs.versions.toml`) is the supported surface for automated updates while keeping a single declared default for each coordinate.

## What changed

- **Version catalog** – Added `espresso-server/gradle/libs.versions.toml` with `[versions]` and `[plugins]`; removed the duplicated version lines from `espresso-server/gradle.properties` (left a short pointer comment).
- **Build wiring** – Root and modules use the catalog for plugin IDs; `settings.gradle.kts` uses `dependencyResolutionManagement` for repositories and `pluginManagement.resolutionStrategy.eachPlugin` so `-PappiumAndroidGradlePlugin` still selects the AGP version (default read from the same TOML key Dependabot updates).
- **Capability overrides** – Added `resolveCapabilityVersion` in `buildSrc` and used it in `library/build.gradle.kts` for all coordinates that previously relied on `gradle.properties`, so `-PappiumKotlin`, `-PappiumEspressoVersion`, etc. continue to override catalog defaults.
- **Plugins** – AGP 9: no separate `org.jetbrains.kotlin.android` plugin (built-in Kotlin support).
- **Cleanup** – Dropped unused `appiumMockitoVersion` from the old properties set.
- **Dependabot** – Comment in `.github/dependabot.yml` noting that Gradle bumps target the version catalog, not custom `gradle.properties` version keys.