### PR TITLE
fix: fix regression to allow non-Java 17 such as 21 to build th eserver

### DIFF
--- a/espresso-server/buildSrc/build.gradle.kts
+++ b/espresso-server/buildSrc/build.gradle.kts
@@ -6,8 +6,9 @@ repositories {
     mavenCentral()
 }
 
+val javaVersion = maxOf(JavaVersion.current().majorVersion.toInt(), 17)
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
+        languageVersion.set(JavaLanguageVersion.of(javaVersion))
     }
 }


### PR DESCRIPTION
Noticed that https://github.com/appium/appium-espresso-driver/pull/1151 started requiring the java version to be 17. So, for example, when my local has Java 21, the `npm run build:server` started failing as no 17 on my local.

This change allows such Java env to be 17+ - whcih is the same behavior of pre-https://github.com/appium/appium-espresso-driver/pull/1151