### PR TITLE
chore: downgrade conventional-changelog-conventionalcommits to v9

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "async-lock": "^1.0.0",
     "chai": "^6.0.0",
     "chai-as-promised": "^8.0.0",
-    "conventional-changelog-conventionalcommits": "^10.2.0",
+    "conventional-changelog-conventionalcommits": "^9.3.1",
     "prettier": "^3.0.0",
     "semantic-release": "^25.0.2",
     "semver": "^7.3.7",


### PR DESCRIPTION
https://github.com/appium/appium-safari-driver/pull/177