### PR TITLE
docs: drop appiumpro.com references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1729,11 +1729,11 @@ mode | string | yes | One of the supported UI mode names: `night` or `car`. | ni
 
 ### mobile: startLogsBroadcast
 
-Starts Android logcat broadcast websocket on the same host and port where Appium server is running at `/ws/session/:sessionId:/appium/logcat` endpoint. The method will return immediately if the web socket is already listening. Each connected webcoket listener will receive logcat log lines as soon as they are visible to Appium. Read [Using Mobile Execution Commands to Continuously Stream Device Logs with Appium](https://appiumpro.com/editions/55-using-mobile-execution-commands-to-continuously-stream-device-logs-with-appium) for more details.
+Starts Android logcat broadcast websocket on the same host and port where Appium server is running at `/ws/session/:sessionId:/appium/logcat` endpoint. The method will return immediately if the web socket is already listening. Each connected webcoket listener will receive logcat log lines as soon as they are visible to Appium. Read [Using Mobile Execution Commands to Continuously Stream Device Logs with Appium](https://www.headspin.io/blog/using-mobile-execution-commands-to-continuously-stream-device-logs-with-appium) for more details.
 
 ### mobile: stopLogsBroadcast
 
-Stops the previously started logcat broadcasting websocket server. This method will return immediately if no server is running. Read [Using Mobile Execution Commands to Continuously Stream Device Logs with Appium](https://appiumpro.com/editions/55-using-mobile-execution-commands-to-continuously-stream-device-logs-with-appium) for more details.
+Stops the previously started logcat broadcasting websocket server. This method will return immediately if no server is running. Read [Using Mobile Execution Commands to Continuously Stream Device Logs with Appium](https://www.headspin.io/blog/using-mobile-execution-commands-to-continuously-stream-device-logs-with-appium) for more details.
 
 ### mobile: injectEmulatorCameraImage
 


### PR DESCRIPTION
## Summary
Removes `appiumpro.com` references from this repository, since the domain is no longer maintained by the Appium team (see appium/appium#22499).

Follows the same approach as appium/appium#22500 — links are removed rather than replaced, unless removal would break surrounding prose, in which case the URL is inlined as plain text.

Closes appium/appium#22499

## Checklist
- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] No documentation update needed (only stale links removed)